### PR TITLE
fix: translate_package_lock handles semver ranges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v2
-            - uses: bazelbuild/setup-bazelisk@v1
             - name: Mount bazel action cache
               uses: actions/cache@v2
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,11 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-            - uses: bazelbuild/setup-bazelisk@v1
             - name: bazel test //...
               env:
                   # Bazelisk will download bazel to here
                   XDG_CACHE_HOME: ~/.cache/bazel-repo
-              run:
-                  bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+              run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
             - name: Release
               uses: softprops/action-gh-release@v1
               with:

--- a/docs/npm_import.md
+++ b/docs/npm_import.md
@@ -70,7 +70,7 @@ nodejs_test(
 ## npm_import
 
 <pre>
-npm_import(<a href="#npm_import-integrity">integrity</a>, <a href="#npm_import-package">package</a>, <a href="#npm_import-version">version</a>, <a href="#npm_import-deps">deps</a>, <a href="#npm_import-name">name</a>)
+npm_import(<a href="#npm_import-integrity">integrity</a>, <a href="#npm_import-package">package</a>, <a href="#npm_import-version">version</a>, <a href="#npm_import-deps">deps</a>, <a href="#npm_import-name">name</a>, <a href="#npm_import-patches">patches</a>)
 </pre>
 
 Import a single npm package into Bazel.
@@ -130,5 +130,6 @@ To change the proxy URL we use to fetch, configure the Bazel downloader:
 | <a id="npm_import-version"></a>version |  version of the npm package, such as <code>8.4.0</code>   |  none |
 | <a id="npm_import-deps"></a>deps |  other npm packages this one depends on.   |  <code>[]</code> |
 | <a id="npm_import-name"></a>name |  the external repository generated to contain the package content. This argument may be omitted to get the default name documented above.   |  <code>None</code> |
+| <a id="npm_import-patches"></a>patches |  patch files to apply onto the downloaded npm package. Paths in the patch file must start with <code>extract_tmp/package</code> where <code>package</code> is the top-level folder in the archive on npm.   |  <code>[]</code> |
 
 

--- a/js/npm_import.bzl
+++ b/js/npm_import.bzl
@@ -14,6 +14,9 @@ def _npm_import_impl(repository_ctx):
         integrity = repository_ctx.attr.integrity,
     )
 
+    for patch in repository_ctx.attr.patches:
+        repository_ctx.patch(patch)
+
     # npm packages are always published with one top-level directory inside the tarball, but the name is not predictable
     # so we have to run an external program to inspect the downloaded folder.
     if repository_ctx.os.name == "Windows":
@@ -60,10 +63,11 @@ _npm_import = repository_rule(
         "integrity": attr.string(),
         "package": attr.string(mandatory = True),
         "version": attr.string(mandatory = True),
+        "patches": attr.label_list(),
     },
 )
 
-def npm_import(integrity, package, version, deps = [], name = None):
+def npm_import(integrity, package, version, deps = [], name = None, patches = []):
     """Import a single npm package into Bazel.
 
     Normally you'd want to use `translate_package_lock` to import all your packages at once.
@@ -124,6 +128,9 @@ def npm_import(integrity, package, version, deps = [], name = None):
             It is optional to make development easier but should be set before shipping.
         package: npm package name, such as `acorn` or `@types/node`
         version: version of the npm package, such as `8.4.0`
+        patches: patch files to apply onto the downloaded npm package.
+            Paths in the patch file must start with `extract_tmp/package`
+            where `package` is the top-level folder in the archive on npm.
     """
 
     _npm_import(
@@ -131,6 +138,7 @@ def npm_import(integrity, package, version, deps = [], name = None):
         deps = deps,
         integrity = integrity,
         package = package,
+        patches = patches,
         version = version,
     )
 

--- a/js/private/translate_package_lock.bzl
+++ b/js/private/translate_package_lock.bzl
@@ -87,8 +87,8 @@ def npm_repositories():
             continue
         deps = []
         if "requires" in dep.keys():
-            for (n, d) in dep["requires"].items():
-                deps.append("@" + _repo_name(n, d))
+            for n in dep["requires"].keys():
+                deps.append("@" + _repo_name(n, [d["version"] for (p, d) in lockfile["dependencies"].items() if p == n][0]))
         bzl_out.extend([_NPM_IMPORT_TMPL.format(
             name = _repo_name(name, dep["version"]),
             package = name,

--- a/js/test/translate_package_lock_tests.bzl
+++ b/js/test/translate_package_lock_tests.bzl
@@ -31,7 +31,7 @@ _lockfile = json.decode("""
             "integrity": "sha512-b==",
             "dev": true,
             "requires": {
-                "@gregmagolan/test-a": "0.0.1"
+                "@gregmagolan/test-a": "~0.0.1"
             }
         }
     }


### PR DESCRIPTION
We have to do a second lookup through the file to get the actual version
of the package that satisfied the dependency.

Also add the ability to patch npm packages as we fetch them,
since there's no way to use the patch-package package in this setup
where npm packages are installed individually.

These fixes needed for rules_swc