### PR TITLE
Update github archive URLs to have stable SHAs

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -19,7 +19,7 @@ http_archive(
     name = "aspect_rules_js",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/aspect-build/rules_js/archive/${TAG}.tar.gz",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/${TAG}.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -49,7 +49,7 @@ def rules_js_internal_deps():
         strip_prefix = "bazel-skylib-1.1.1",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.1.1.tar.gz",
         ],
     )
 

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -37,5 +37,5 @@ def rules_js_dependencies():
         name = "aspect_bazel_lib",
         sha256 = "e834c368f36cb336b5b42cd1dd9cd4b6bafa0ad3ed7f92f54a47e5ab436e4f59",
         strip_prefix = "bazel-lib-0.3.0",
-        url = "https://github.com/aspect-build/bazel-lib/archive/v0.3.0.tar.gz",
+        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v0.3.0.tar.gz",
     )


### PR DESCRIPTION
Required per https://github.com/bazel-contrib/SIG-rules-authors/issues/11