### PR TITLE
perf: use merge_all to avoid deeply nested runfiles depsets

### DIFF
--- a/js/private/nodejs_binary.bzl
+++ b/js/private/nodejs_binary.bzl
@@ -189,8 +189,10 @@ def _nodejs_binary_impl(ctx):
         files = all_files,
         transitive_files = depset(all_files),
     )
-    for dep in ctx.attr.data:
-        runfiles = runfiles.merge(dep[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge_all([
+        dep[DefaultInfo].default_runfiles
+        for dep in ctx.attr.data
+    ])
     return DefaultInfo(
         executable = launcher,
         runfiles = runfiles,


### PR DESCRIPTION
Prefer to use `merge_all` when merging runfiles in a loop to avoid creating deeply nested depset.

See the docs for more info: https://bazel.build/rules/lib/runfiles#merge_all