### PR TITLE
refactor: allow more reuse of nodejs_binary starlark lib

### DIFF
--- a/docs/nodejs_binary.md
+++ b/docs/nodejs_binary.md
@@ -52,8 +52,27 @@ with a `deps` attribute at the callsite.
 | <a id="nodejs_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="nodejs_binary-data"></a>data |  Runtime dependencies of the program.<br><br>        The transitive closure of the <code>data</code> dependencies will be available in         the .runfiles folder for this binary/test.<br><br>        You can use the <code>@bazel/runfiles</code> npm library to access these files         at runtime.<br><br>        npm packages are also linked into the <code>.runfiles/node_modules</code> folder         so they may be resolved directly from runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="nodejs_binary-enable_runfiles"></a>enable_runfiles |  Whether runfiles are enabled in the current build configuration.<br><br>        Typical usage of this rule is via a macro which automatically sets this         attribute based on a <code>config_setting</code> rule.   | Boolean | required |  |
-| <a id="nodejs_binary-entry_point"></a>entry_point |  The main script which is evaluated by node.js<br><br>        This is the module referenced by the <code>require.main</code> property in the runtime.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="nodejs_binary-entry_point"></a>entry_point |  The main script which is evaluated by node.js<br><br>        This is the module referenced by the <code>require.main</code> property in the runtime.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="nodejs_binary-is_windows"></a>is_windows |  Whether the build is being performed on a Windows host platform.<br><br>        Typical usage of this rule is via a macro which automatically sets this         attribute based on a <code>select()</code> on <code>@bazel_tools//src/conditions:host_windows</code>.   | Boolean | required |  |
+
+
+<a id="#nodejs_binary_lib.create_launcher"></a>
+
+## nodejs_binary_lib.create_launcher
+
+<pre>
+nodejs_binary_lib.create_launcher(<a href="#nodejs_binary_lib.create_launcher-ctx">ctx</a>, <a href="#nodejs_binary_lib.create_launcher-args">args</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="nodejs_binary_lib.create_launcher-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
+| <a id="nodejs_binary_lib.create_launcher-args"></a>args |  <p align="center"> - </p>   |  none |
 
 
 <a id="#nodejs_binary_lib.nodejs_binary_impl"></a>

--- a/js/nodejs_binary.bzl
+++ b/js/nodejs_binary.bzl
@@ -1,13 +1,16 @@
 "wrapper macro for nodejs_binary rule"
 
-load("//js/private:nodejs_binary.bzl", lib = "nodejs_binary_lib")
+load("//js/private:nodejs_binary.bzl", _lib = "nodejs_binary_lib")
 
 _nodejs_binary = rule(
-    implementation = lib.nodejs_binary_impl,
-    attrs = lib.attrs,
+    implementation = _lib.nodejs_binary_impl,
+    attrs = _lib.attrs,
     executable = True,
-    toolchains = lib.toolchains,
+    toolchains = _lib.toolchains,
 )
+
+# export the starlark library as a public API
+lib = _lib
 
 def nodejs_binary(**kwargs):
     _nodejs_binary(


### PR DESCRIPTION
I'm using this for a new jest_test rule which wants to return a similar launcher binary but control the args