### PR TITLE
chore: update to copy_directory

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,9 @@
 # Take care to document any settings that you expect users to apply.
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
+# Recommended when using copy_directory, see
+# https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md
+--host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,26 +1,23 @@
 load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
 
 stardoc_with_diff_test(
+    name = "nodejs_binary",
     bzl_library_target = "//js/private:nodejs_binary",
-    out_label = "//docs:nodejs_binary.md",
 )
 
 stardoc_with_diff_test(
+    name = "nodejs_test",
     bzl_library_target = "//js:nodejs_test",
-    out_label = "//docs:nodejs_test.md",
 )
 
 stardoc_with_diff_test(
+    name = "nodejs_package",
     bzl_library_target = "//js/private:nodejs_package",
-    out_label = "//docs:nodejs_package.md",
 )
 
 stardoc_with_diff_test(
+    name = "npm_import",
     bzl_library_target = "//js:npm_import",
-    out_label = "//docs:npm_import.md",
 )
 
-update_docs(
-    name = "update",
-    docs_folder = "docs",
-)
+update_docs(name = "update")

--- a/js/npm_import.bzl
+++ b/js/npm_import.bzl
@@ -27,18 +27,16 @@ def _npm_import_impl(repository_ctx):
         fail("failed to inspect content of npm download: \nSTDOUT:\n%s\nSTDERR:\n%s" % (result.stdout, result.stderr))
 
     repository_ctx.file("BUILD.bazel", """
+load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory")
 load("@aspect_rules_js//js:nodejs_package.bzl", "nodejs_package")
-load("@rules_nodejs//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
 
 # Turn a source directory into a TreeArtifact for RBE-compat
-copy_file(
+copy_directory(
     # The default target in this repository
     name = "_{name}",
     src = "extract_tmp/{nested_folder}",
-    # This attribute comes from rules_nodejs patch of
-    # https://github.com/bazelbuild/bazel-skylib/pull/323
-    is_directory = True,
-    # We must give this as the directory in order for it to appear on NODE_PATH
+    # The directory name must match the package in order for node to find it under
+    # NODE_PATH=runfiles/[out]
     out = "{package_name}",
 )
 

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -7,6 +7,10 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
+versions = struct(
+    bazel_lib = "a23d1b03f7c96dfbd660b4946436a7df3515d647",
+)
+
 # WARNING: any changes in this function may be BREAKING CHANGES for users
 # because we'll fetch a dependency which may be different from one that
 # they were previously fetching later in their WORKSPACE setup, and now
@@ -35,7 +39,8 @@ def rules_js_dependencies():
     maybe(
         http_archive,
         name = "aspect_bazel_lib",
-        sha256 = "e834c368f36cb336b5b42cd1dd9cd4b6bafa0ad3ed7f92f54a47e5ab436e4f59",
-        strip_prefix = "bazel-lib-0.3.0",
-        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v0.3.0.tar.gz",
+        sha256 = "9306cb42e19221ea8ec76c05481fd508aefb5b37b3e35123f542977dabaa8d4b",
+        strip_prefix = "bazel-lib-" + versions.bazel_lib,
+        #url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v{}.tar.gz".format(versions.bazel_lib),
+        url = "https://github.com/aspect-build/bazel-lib/archive/{}.tar.gz".format(versions.bazel_lib),
     )


### PR DESCRIPTION
We no longer use a fork of bazel-skylib under rules_nodejs.

This might be removable in the future if we upstream it to bazel-skylib, but no real need since we depend on aspect_bazel_lib either way.