### PR TITLE
Demonstrate the need for a dynamic linker

### DIFF
--- a/example/ts_lib/BUILD.bazel
+++ b/example/ts_lib/BUILD.bazel
@@ -4,4 +4,5 @@ ts_project(
     name = "ts",
     srcs = ["foo.ts"],
     declaration = True,
+    deps = ["@npm_deps//@types/node"],
 )

--- a/example/ts_lib/foo.ts
+++ b/example/ts_lib/foo.ts
@@ -1,1 +1,2 @@
 const a: string = 'a'
+require('assert').equals(a, 'a')

--- a/js/private/nodejs_package.bzl
+++ b/js/private/nodejs_package.bzl
@@ -1,7 +1,7 @@
 "nodejs_package rule"
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@rules_nodejs//nodejs:providers.bzl", "LinkablePackageInfo")
+load("@rules_nodejs//nodejs:providers.bzl", "LinkablePackageInfo", "declaration_info")
 
 _DOC = """Defines a library that executes in a node.js runtime.
     
@@ -152,6 +152,10 @@ def _nodejs_package_impl(ctx):
     return [
         DefaultInfo(files = files, runfiles = runfiles),
         LinkablePackageInfo(package_name = ctx.attr.package_name, files = [output]),
+        # Assume every npm package publishes typings, rather than make this conditional
+        # on an action that inspects the package.json for a typings field and looks for
+        # .d.ts files in the package.
+        declaration_info(declarations = depset([output]), deps = ctx.attr.deps),
     ]
 
 nodejs_package_lib = struct(


### PR DESCRIPTION
Fails with
example/ts_lib/foo.ts(2,1): error TS2580: Cannot find name 'require'. Do you need to install type definitions for node? Try 'npm i --save-dev @types/node'.