### PR TITLE
rename js_dependencies back to rules_js_dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,9 +10,9 @@ load(":internal_deps.bzl", "js_internal_deps")
 js_internal_deps()
 
 # Install our "runtime" dependencies which users install as well
-load("//js:repositories.bzl", "js_dependencies")
+load("//js:repositories.bzl", "rules_js_dependencies")
 
-js_dependencies()
+rules_js_dependencies()
 
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -21,7 +21,7 @@ versions = struct(
 # ours took precedence. Such breakages are challenging for users, so any
 # changes in this function should be marked as BREAKING in the commit message
 # and released only in semver majors.
-def js_dependencies():
+def rules_js_dependencies():
     "Dependencies for users of aspect_rules_js"
 
     # The minimal version of bazel_skylib we require


### PR DESCRIPTION
This is what is in the template https://github.com/bazel-contrib/rules-template/blob/main/mylang/repositories.bzl#L18
so that's what all our other rulesets use, and much of the community, since it comes from the style guide

> Create a file named [LANG]/repositories.bzl and provide a single entry point macro named rules_[LANG]_dependencies.

from https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies