### PR TITLE
fix: fix expected_exit_code attribute on js_binary/js_test

### DIFF
--- a/docs/js_binary.md
+++ b/docs/js_binary.md
@@ -15,7 +15,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_test")
 
 <pre>
 js_binary(<a href="#js_binary-name">name</a>, <a href="#js_binary-chdir">chdir</a>, <a href="#js_binary-data">data</a>, <a href="#js_binary-enable_runfiles">enable_runfiles</a>, <a href="#js_binary-entry_point">entry_point</a>, <a href="#js_binary-env">env</a>, <a href="#js_binary-expected_exit_code">expected_exit_code</a>, <a href="#js_binary-is_windows">is_windows</a>,
-          <a href="#js_binary-node_options">node_options</a>)
+          <a href="#js_binary-node_options">node_options</a>, <a href="#js_binary-verbose">verbose</a>)
 </pre>
 
 Execute a program in the node.js runtime.
@@ -54,6 +54,7 @@ This rules requires that Bazel was run with
 | <a id="js_binary-expected_exit_code"></a>expected_exit_code |  The expected exit code.<br><br>        Can be used to write tests that are expected to fail.   | Integer | optional | 0 |
 | <a id="js_binary-is_windows"></a>is_windows |  Whether the build is being performed on a Windows host platform.<br><br>        Typical usage of this rule is via a macro which automatically sets this         attribute based on a <code>select()</code> on <code>@bazel_tools//src/conditions:host_windows</code>.   | Boolean | required |  |
 | <a id="js_binary-node_options"></a>node_options |  Options to pass to the node.<br><br>        https://nodejs.org/api/cli.html   | List of strings | optional | [] |
+| <a id="js_binary-verbose"></a>verbose |  Produce verbose output.   | Boolean | optional | False |
 
 
 <a id="#js_test"></a>
@@ -62,7 +63,7 @@ This rules requires that Bazel was run with
 
 <pre>
 js_test(<a href="#js_test-name">name</a>, <a href="#js_test-chdir">chdir</a>, <a href="#js_test-data">data</a>, <a href="#js_test-enable_runfiles">enable_runfiles</a>, <a href="#js_test-entry_point">entry_point</a>, <a href="#js_test-env">env</a>, <a href="#js_test-expected_exit_code">expected_exit_code</a>, <a href="#js_test-is_windows">is_windows</a>,
-        <a href="#js_test-node_options">node_options</a>)
+        <a href="#js_test-node_options">node_options</a>, <a href="#js_test-verbose">verbose</a>)
 </pre>
 
 Identical to js_binary, but usable under `bazel test`.
@@ -81,6 +82,7 @@ Identical to js_binary, but usable under `bazel test`.
 | <a id="js_test-expected_exit_code"></a>expected_exit_code |  The expected exit code.<br><br>        Can be used to write tests that are expected to fail.   | Integer | optional | 0 |
 | <a id="js_test-is_windows"></a>is_windows |  Whether the build is being performed on a Windows host platform.<br><br>        Typical usage of this rule is via a macro which automatically sets this         attribute based on a <code>select()</code> on <code>@bazel_tools//src/conditions:host_windows</code>.   | Boolean | required |  |
 | <a id="js_test-node_options"></a>node_options |  Options to pass to the node.<br><br>        https://nodejs.org/api/cli.html   | List of strings | optional | [] |
+| <a id="js_test-verbose"></a>verbose |  Produce verbose output.   | Boolean | optional | False |
 
 
 <a id="#js_binary_lib.js_binary_impl"></a>

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -374,9 +374,21 @@ js_test(
     entry_point = "case10.js",
     env = {
         "FOO": "BAR",
-        "JS_BINARY__EXPECTED_EXIT_CODE": "42",
-        "JS_BINARY__VERBOSE": "1",
     },
+    expected_exit_code = 42,
+    verbose = True,
+)
+
+# bazel run //example:test10_binary
+js_binary(
+    name = "test10_binary",
+    args = ["dummy"],
+    entry_point = "case10.js",
+    env = {
+        "FOO": "BAR",
+    },
+    expected_exit_code = 42,
+    verbose = True,
 )
 
 run_js_binary(

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -2,14 +2,19 @@
 
 # shellcheck disable=SC1090
 {
-{rlocation_function}
+{{rlocation_function}}
 }
 
 set -o pipefail -o errexit -o nounset
 
-{env}
+{{envs}}
 
-LOG_PREFIX="aspect_rules_js[js_binary]"
+# https://docs.bazel.build/versions/main/test-encyclopedia.html#initial-conditions
+if [ "${TEST_TARGET:-}" ]; then
+    LOG_PREFIX="aspect_rules_js[js_test]"
+else
+    LOG_PREFIX="aspect_rules_js[js_binary]"
+fi
 
 # ==============================================================================
 # Initialize RUNFILES environment variable
@@ -118,13 +123,13 @@ export RUNFILES
 
 if [[ "$PWD" == *"/bazel-out/"* ]]; then
     # We in runfiles
-    node="$PWD/{node}"
-    entry_point="$PWD/{entry_point_path}"
+    node="$PWD/{{node}}"
+    entry_point="$PWD/{{entry_point_path}}"
 else
     # We are in execroot or in some other context all together such as a nodejs_image or a manually
     # run js_binary.
-    node="$RUNFILES/{workspace_name}/{node}"
-    entry_point="$RUNFILES/{workspace_name}/{entry_point_path}"
+    node="$RUNFILES/{{workspace_name}}/{{node}}"
+    entry_point="$RUNFILES/{{workspace_name}}/{{entry_point_path}}"
     if [ -z "${BAZEL_BINDIR:-}" ]; then
         printf "\nERROR: %s: BAZEL_BINDIR must be set in environment when not running out of runfiles so js_binary can run out of the output tree on build actions\n" "$LOG_PREFIX" >&2
         exit 1
@@ -196,7 +201,7 @@ _exit() {
 }
 
 NODE_OPTIONS=()
-{node_options}
+{{node_options}}
 
 ARGS=()
 ALL_ARGS=("$@")

--- a/js/private/test/shellcheck_launcher.sh
+++ b/js/private/test/shellcheck_launcher.sh
@@ -19,7 +19,12 @@ set -o pipefail -o errexit -o nounset
 
 
 
-LOG_PREFIX="aspect_rules_js[js_binary]"
+# https://docs.bazel.build/versions/main/test-encyclopedia.html#initial-conditions
+if [ "${TEST_TARGET:-}" ]; then
+    LOG_PREFIX="aspect_rules_js[js_test]"
+else
+    LOG_PREFIX="aspect_rules_js[js_binary]"
+fi
 
 # ==============================================================================
 # Initialize RUNFILES environment variable


### PR DESCRIPTION
- also add `verbose` attribute which sets the `JS_BINARY__VERBOSE` env var
- fix-up template params to use double `{{` braces instead of single so as not to accidentally collide with variable expansions
- remove unused template params
- fix verbose log prefix to differentiate between js_binary and js_test