### PR TITLE
chore: replace is_windows select pattern with target_platform_has_constraint pattern

### DIFF
--- a/docs/js_binary.md
+++ b/docs/js_binary.md
@@ -14,8 +14,8 @@ load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_test")
 ## js_binary
 
 <pre>
-js_binary(<a href="#js_binary-name">name</a>, <a href="#js_binary-chdir">chdir</a>, <a href="#js_binary-data">data</a>, <a href="#js_binary-enable_runfiles">enable_runfiles</a>, <a href="#js_binary-entry_point">entry_point</a>, <a href="#js_binary-env">env</a>, <a href="#js_binary-expected_exit_code">expected_exit_code</a>, <a href="#js_binary-is_windows">is_windows</a>,
-          <a href="#js_binary-node_options">node_options</a>, <a href="#js_binary-verbose">verbose</a>)
+js_binary(<a href="#js_binary-name">name</a>, <a href="#js_binary-chdir">chdir</a>, <a href="#js_binary-data">data</a>, <a href="#js_binary-enable_runfiles">enable_runfiles</a>, <a href="#js_binary-entry_point">entry_point</a>, <a href="#js_binary-env">env</a>, <a href="#js_binary-expected_exit_code">expected_exit_code</a>, <a href="#js_binary-node_options">node_options</a>,
+          <a href="#js_binary-verbose">verbose</a>)
 </pre>
 
 Execute a program in the node.js runtime.
@@ -52,7 +52,6 @@ This rules requires that Bazel was run with
 | <a id="js_binary-entry_point"></a>entry_point |  The main script which is evaluated by node.js.<br><br>        This is the module referenced by the <code>require.main</code> property in the runtime.<br><br>        This must be a target that provides a single file or a <code>DirectoryPathInfo</code>         from <code>@aspect_bazel_lib//lib::directory_path.bzl</code>.<br><br>        See https://github.com/aspect-build/bazel-lib/blob/main/docs/directory_path.md         for more info on creating a target that provides a <code>DirectoryPathInfo</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="js_binary-env"></a>env |  Environment variables of the action.<br><br>        Subject to <code>$(location)</code> and make variable expansion.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="js_binary-expected_exit_code"></a>expected_exit_code |  The expected exit code.<br><br>        Can be used to write tests that are expected to fail.   | Integer | optional | 0 |
-| <a id="js_binary-is_windows"></a>is_windows |  Whether the build is being performed on a Windows host platform.<br><br>        Typical usage of this rule is via a macro which automatically sets this         attribute based on a <code>select()</code> on <code>@bazel_tools//src/conditions:host_windows</code>.   | Boolean | required |  |
 | <a id="js_binary-node_options"></a>node_options |  Options to pass to the node.<br><br>        https://nodejs.org/api/cli.html   | List of strings | optional | [] |
 | <a id="js_binary-verbose"></a>verbose |  Produce verbose output.   | Boolean | optional | False |
 
@@ -62,8 +61,8 @@ This rules requires that Bazel was run with
 ## js_test
 
 <pre>
-js_test(<a href="#js_test-name">name</a>, <a href="#js_test-chdir">chdir</a>, <a href="#js_test-data">data</a>, <a href="#js_test-enable_runfiles">enable_runfiles</a>, <a href="#js_test-entry_point">entry_point</a>, <a href="#js_test-env">env</a>, <a href="#js_test-expected_exit_code">expected_exit_code</a>, <a href="#js_test-is_windows">is_windows</a>,
-        <a href="#js_test-node_options">node_options</a>, <a href="#js_test-verbose">verbose</a>)
+js_test(<a href="#js_test-name">name</a>, <a href="#js_test-chdir">chdir</a>, <a href="#js_test-data">data</a>, <a href="#js_test-enable_runfiles">enable_runfiles</a>, <a href="#js_test-entry_point">entry_point</a>, <a href="#js_test-env">env</a>, <a href="#js_test-expected_exit_code">expected_exit_code</a>, <a href="#js_test-node_options">node_options</a>,
+        <a href="#js_test-verbose">verbose</a>)
 </pre>
 
 Identical to js_binary, but usable under `bazel test`.
@@ -80,7 +79,6 @@ Identical to js_binary, but usable under `bazel test`.
 | <a id="js_test-entry_point"></a>entry_point |  The main script which is evaluated by node.js.<br><br>        This is the module referenced by the <code>require.main</code> property in the runtime.<br><br>        This must be a target that provides a single file or a <code>DirectoryPathInfo</code>         from <code>@aspect_bazel_lib//lib::directory_path.bzl</code>.<br><br>        See https://github.com/aspect-build/bazel-lib/blob/main/docs/directory_path.md         for more info on creating a target that provides a <code>DirectoryPathInfo</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="js_test-env"></a>env |  Environment variables of the action.<br><br>        Subject to <code>$(location)</code> and make variable expansion.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="js_test-expected_exit_code"></a>expected_exit_code |  The expected exit code.<br><br>        Can be used to write tests that are expected to fail.   | Integer | optional | 0 |
-| <a id="js_test-is_windows"></a>is_windows |  Whether the build is being performed on a Windows host platform.<br><br>        Typical usage of this rule is via a macro which automatically sets this         attribute based on a <code>select()</code> on <code>@bazel_tools//src/conditions:host_windows</code>.   | Boolean | required |  |
 | <a id="js_test-node_options"></a>node_options |  Options to pass to the node.<br><br>        https://nodejs.org/api/cli.html   | List of strings | optional | [] |
 | <a id="js_test-verbose"></a>verbose |  Produce verbose output.   | Boolean | optional | False |
 

--- a/docs/node_package.md
+++ b/docs/node_package.md
@@ -7,8 +7,7 @@ node_package rule
 ## node_package
 
 <pre>
-node_package(<a href="#node_package-name">name</a>, <a href="#node_package-always_output_bins">always_output_bins</a>, <a href="#node_package-bins">bins</a>, <a href="#node_package-deps">deps</a>, <a href="#node_package-indirect">indirect</a>, <a href="#node_package-is_windows">is_windows</a>, <a href="#node_package-package">package</a>, <a href="#node_package-root_dir">root_dir</a>, <a href="#node_package-src">src</a>,
-             <a href="#node_package-version">version</a>)
+node_package(<a href="#node_package-name">name</a>, <a href="#node_package-always_output_bins">always_output_bins</a>, <a href="#node_package-bins">bins</a>, <a href="#node_package-deps">deps</a>, <a href="#node_package-indirect">indirect</a>, <a href="#node_package-package">package</a>, <a href="#node_package-root_dir">root_dir</a>, <a href="#node_package-src">src</a>, <a href="#node_package-version">version</a>)
 </pre>
 
 
@@ -23,7 +22,6 @@ node_package(<a href="#node_package-name">name</a>, <a href="#node_package-alway
 | <a id="node_package-bins"></a>bins |  A dict of bin entry point names to entry point paths for this package.<br><br>        This should mirror what is in the <code>bin</code> field of the package.json of the package.         See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#bin.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="node_package-deps"></a>deps |  Other node packages this one depends on.<br><br>        This should include *all* modules the program may need at runtime.<br><br>        &gt; In typical usage, a node.js program sometimes requires modules which were         &gt; never declared as dependencies.         &gt; This pattern is typically used when the program has conditional behavior         &gt; that is enabled when the module is found (like a plugin) but the program         &gt; also runs without the dependency.         &gt;          &gt; This is possible because node.js doesn't enforce the dependencies are sound.         &gt; All files under <code>node_modules</code> are available to any program.         &gt; In contrast, Bazel makes it possible to make builds hermetic, which means that         &gt; all dependencies of a program must be declared when running in Bazel's sandbox.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="node_package-indirect"></a>indirect |  If True, this is an indirect node_package which will not linked at the top-level of node_modules   | Boolean | optional | False |
-| <a id="node_package-is_windows"></a>is_windows |  -   | Boolean | required |  |
 | <a id="node_package-package"></a>package |  Must match the <code>name</code> field in the <code>package.json</code> file for this package.   | String | required |  |
 | <a id="node_package-root_dir"></a>root_dir |  For internal use only   | String | optional | "node_modules" |
 | <a id="node_package-src"></a>src |  A source directory or TreeArtifact containing the package files.<br><br>Can be left unspecified to allow for circular deps between <code>node_package</code>s.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -12,10 +12,6 @@ js_binary_lib = _js_binary_lib
 
 def js_binary(**kwargs):
     _js_binary(
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
         enable_runfiles = select({
             "@aspect_rules_js//js/private:enable_runfiles": True,
             "//conditions:default": False,
@@ -30,10 +26,6 @@ def js_test(**kwargs):
       **kwargs: see js_binary attributes
     """
     _js_test(
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
         enable_runfiles = select({
             "@aspect_rules_js//js/private:enable_runfiles": True,
             "//conditions:default": False,

--- a/js/node_package.bzl
+++ b/js/node_package.bzl
@@ -30,10 +30,6 @@ def node_package(name, **kwargs):
     """
     _node_package(
         name = name,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
         **kwargs
     )
 

--- a/js/private/node_package.bzl
+++ b/js/private/node_package.bzl
@@ -72,7 +72,7 @@ Can be left unspecified to allow for circular deps between `node_package`s.
         doc = "For internal use only",
         default = "node_modules",
     ),
-    "is_windows": attr.bool(mandatory = True),
+    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 
 _BIN_SH_TEMPLATE = """#!/usr/bin/env bash
@@ -86,6 +86,8 @@ def _normalize_bin_path(bin_path):
     return result
 
 def _impl(ctx):
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+
     if ctx.file.src and not ctx.file.src.is_source and not ctx.file.src.is_directory:
         fail("src must a source directory or TreeArtifact if set")
     if not ctx.attr.package:
@@ -143,7 +145,7 @@ def _impl(ctx):
             # "{root_dir}/{virtual_store_root}/{virtual_store_name}/node_modules/{package}"
             paths.join(ctx.attr.root_dir, pnpm_utils.virtual_store_root, virtual_store_name, "node_modules", ctx.attr.package),
         )
-        copy_directory_action(ctx, ctx.file.src, virtual_store_out, ctx.attr.is_windows)
+        copy_directory_action(ctx, ctx.file.src, virtual_store_out, is_windows = is_windows)
         direct_files.append(virtual_store_out)
 
         if not ctx.attr.indirect:


### PR DESCRIPTION
Based on https://github.com/bazelbuild/proposals/blob/main/designs/2019-11-11-target-platform-constraints.md#proposal-a-check-method-that-takes-a-constraint-value-label
Flag added in bazel 2.1.0 https://docs.bazel.build/versions/main/skylark/lib/ctx.html#target_platform_has_constraint