### PR TITLE
chore: misc cleanup

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,1 @@
-e2e/link_js_package
-e2e/link_js_package/rules_foo
+e2e/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bazel-*
 node_modules/
+.pnpm-*

--- a/e2e/link_js_package/.bazelversion
+++ b/e2e/link_js_package/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/js/private/link_js_package_internal.bzl
+++ b/js/private/link_js_package_internal.bzl
@@ -27,8 +27,6 @@ _INTERNAL_ATTRS = dicts.add(_link_js_package_lib.attrs, {
     ),
 })
 
-print(_INTERNAL_ATTRS)
-
 _link_js_package_internal = rule(
     implementation = _link_js_package_lib.implementation,
     attrs = _INTERNAL_ATTRS,


### PR DESCRIPTION
Misc cleanups,

- .bazelignore everything under /e2e
- .gitignore .pnpm-* files
- make a .bazelversion symlink in e2e folders so we are testing on consistent bazel versions
- remove print statement in bzl that was for debugging