### PR TITLE
feat: support pnpm lockfile 5.4 which was introduced in pnpm 7.0.0

### DIFF
--- a/e2e/link_js_package/pnpm-lock.yaml
+++ b/e2e/link_js_package/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
     '@aspect-test/a': 5.0.0


### PR DESCRIPTION
pnpm 7.0.0 was released five days ago;

also support `importers` top-level field as a pre-factor for supporting pnpm workspaces