### PR TITLE
fix: set 755 folder permissions on extract npm packages

### DIFF
--- a/js/private/npm_import.bzl
+++ b/js/private/npm_import.bzl
@@ -226,6 +226,16 @@ def _impl(rctx):
         msg = "tar %s failed: \nSTDOUT:\n%s\nSTDERR:\n%s" % (_EXTRACT_TO_DIRNAME, result.stdout, result.stderr)
         fail(msg)
 
+    if not repo_utils.is_windows(rctx):
+        # Some packages have directory permissions missing executable which
+        # make the directories not listable. Fix these cases in order to be able
+        # to execute the copy action. https://stackoverflow.com/a/14634721
+        chmod_args = ["chmod", "-R", "a+X", _EXTRACT_TO_DIRNAME]
+        result = rctx.execute(chmod_args)
+        if result.return_code:
+            msg = "chmod %s failed: \nSTDOUT:\n%s\nSTDERR:\n%s" % (_EXTRACT_TO_DIRNAME, result.stdout, result.stderr)
+            fail(msg)
+
     pkg_json_path = paths.join(_EXTRACT_TO_DIRNAME, "package.json")
 
     pkg_json = json.decode(rctx.read(pkg_json_path))


### PR DESCRIPTION
Some npm package tarballs such as https://registry.npmjs.org/usng.js/-/usng.js-0.4.5.tgz have folder permissions set to 644 (not executable) when extracted which means that the contents can be listed or copied (since they can't be listed). This resolved that by always setting folder permissions to 755 on macOS and linux.

2nd commit fixes a logic bug in lifecycle ref deps handlings