### PR TITLE
fix: don't double copy 3rd party packages when linking with no lifecycle hook

### DIFF
--- a/js/private/js_package.bzl
+++ b/js/private/js_package.bzl
@@ -58,9 +58,13 @@ def _impl(ctx):
 
     if ctx.attr.src:
         if ctx.file.src.is_source:
-            # copy the source directory to a TreeArtifact
-            directory = ctx.actions.declare_directory(ctx.attr.name)
-            copy_directory_action(ctx, ctx.file.src, directory, is_windows = is_windows)
+            if getattr(ctx.attr, "provide_source_directory", False):
+                # pass the source directory through; for rules_js internal use only
+                directory = ctx.file.src
+            else:
+                # copy the source directory to a TreeArtifact
+                directory = ctx.actions.declare_directory(ctx.attr.name)
+                copy_directory_action(ctx, ctx.file.src, directory, is_windows = is_windows)
         elif ctx.file.src.is_directory:
             # pass-through since src is already a TreeArtifact
             directory = ctx.file.src

--- a/js/private/js_package_internal.bzl
+++ b/js/private/js_package_internal.bzl
@@ -1,0 +1,18 @@
+"js_package_internal rule"
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load(":js_package.bzl", _js_package_lib = "js_package_lib")
+
+_INTERNAL_ATTRS = dicts.add(_js_package_lib.attrs, {
+    "provide_source_directory": attr.bool(
+        doc = """If true, source directories are provided and not copied to the output tree.
+
+        For internal rules_js use only.""",
+    ),
+})
+
+js_package_internal = rule(
+    implementation = _js_package_lib.implementation,
+    attrs = _INTERNAL_ATTRS,
+    provides = _js_package_lib.provides,
+)


### PR DESCRIPTION
This speeds up linking time on after a bazel clean by approx 35%