### PR TITLE
chore: don't run prettier on pnpm-lock.yaml files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 docs/
 min/
+**/pnpm-lock.yaml

--- a/e2e/link_js_package/pnpm-lock.yaml
+++ b/e2e/link_js_package/pnpm-lock.yaml
@@ -1,76 +1,59 @@
 lockfileVersion: 5.4
 
 specifiers:
-    '@aspect-test/a': 5.0.0
-    '@aspect-test/b': 5.0.0
-    '@aspect-test/c': 2.0.0
+  '@aspect-test/a': 5.0.0
+  '@aspect-test/b': 5.0.0
+  '@aspect-test/c': 2.0.0
 
 dependencies:
-    '@aspect-test/a': 5.0.0
+  '@aspect-test/a': 5.0.0
 
 optionalDependencies:
-    '@aspect-test/c': 2.0.0
+  '@aspect-test/c': 2.0.0
 
 devDependencies:
-    '@aspect-test/b': 5.0.0
+  '@aspect-test/b': 5.0.0
 
 packages:
-    /@aspect-test/a/5.0.0:
-        resolution:
-            {
-                integrity: sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==,
-            }
-        hasBin: true
-        dependencies:
-            '@aspect-test/b': 5.0.0
-            '@aspect-test/c': 1.0.0
-            '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
 
-    /@aspect-test/b/5.0.0:
-        resolution:
-            {
-                integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==,
-            }
-        hasBin: true
-        dependencies:
-            '@aspect-test/a': 5.0.0
-            '@aspect-test/c': 2.0.0
-            '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
+  /@aspect-test/a/5.0.0:
+    resolution: {integrity: sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/b': 5.0.0
+      '@aspect-test/c': 1.0.0
+      '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
 
-    /@aspect-test/c/1.0.0:
-        resolution:
-            {
-                integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==,
-            }
-        hasBin: true
-        requiresBuild: true
+  /@aspect-test/b/5.0.0:
+    resolution: {integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/c': 2.0.0
+      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
 
-    /@aspect-test/c/2.0.0:
-        resolution:
-            {
-                integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==,
-            }
-        hasBin: true
-        requiresBuild: true
+  /@aspect-test/c/1.0.0:
+    resolution: {integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==}
+    hasBin: true
+    requiresBuild: true
 
-    /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
-        resolution:
-            {
-                integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@aspect-test/c': x.x.x
-        dependencies:
-            '@aspect-test/c': 1.0.0
+  /@aspect-test/c/2.0.0:
+    resolution: {integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==}
+    hasBin: true
+    requiresBuild: true
 
-    /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
-        resolution:
-            {
-                integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@aspect-test/c': x.x.x
-        dependencies:
-            '@aspect-test/c': 2.0.0
+  /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 1.0.0
+
+  /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 2.0.0

--- a/e2e/pnpm_workspace/pnpm-lock.yaml
+++ b/e2e/pnpm_workspace/pnpm-lock.yaml
@@ -1,139 +1,111 @@
 lockfileVersion: 5.4
 
 importers:
-    .:
-        specifiers:
-            '@aspect-test/a': 5.0.0
-            '@aspect-test/b': 5.0.0
-            '@aspect-test/c': 2.0.0
-        dependencies:
-            '@aspect-test/a': 5.0.0
-        optionalDependencies:
-            '@aspect-test/c': 2.0.0
-        devDependencies:
-            '@aspect-test/b': 5.0.0
 
-    app/a:
-        specifiers:
-            '@aspect-test/g': 1.0.0
-            '@lib/a': workspace:*
-        dependencies:
-            '@aspect-test/g': 1.0.0
-            '@lib/a': link:../../lib/a
+  .:
+    specifiers:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/b': 5.0.0
+      '@aspect-test/c': 2.0.0
+    dependencies:
+      '@aspect-test/a': 5.0.0
+    optionalDependencies:
+      '@aspect-test/c': 2.0.0
+    devDependencies:
+      '@aspect-test/b': 5.0.0
 
-    app/b:
-        specifiers:
-            '@aspect-test/h': 1.0.0
-            '@lib/b': workspace:*
-            '@lib/b_alias': workspace:@lib/b@*
-        dependencies:
-            '@aspect-test/h': 1.0.0
-            '@lib/b': link:../../lib/b
-            '@lib/b_alias': link:../../lib/b
+  app/a:
+    specifiers:
+      '@aspect-test/g': 1.0.0
+      '@lib/a': workspace:*
+    dependencies:
+      '@aspect-test/g': 1.0.0
+      '@lib/a': link:../../lib/a
 
-    lib/a:
-        specifiers:
-            '@aspect-test/e': 1.0.0
-            '@lib/b': workspace:*
-        dependencies:
-            '@aspect-test/e': 1.0.0
-            '@lib/b': link:../b
+  app/b:
+    specifiers:
+      '@aspect-test/h': 1.0.0
+      '@lib/b': workspace:*
+      '@lib/b_alias': workspace:@lib/b@*
+    dependencies:
+      '@aspect-test/h': 1.0.0
+      '@lib/b': link:../../lib/b
+      '@lib/b_alias': link:../../lib/b
 
-    lib/b:
-        specifiers:
-            '@aspect-test/f': 1.0.0
-        dependencies:
-            '@aspect-test/f': 1.0.0
+  lib/a:
+    specifiers:
+      '@aspect-test/e': 1.0.0
+      '@lib/b': workspace:*
+    dependencies:
+      '@aspect-test/e': 1.0.0
+      '@lib/b': link:../b
+
+  lib/b:
+    specifiers:
+      '@aspect-test/f': 1.0.0
+    dependencies:
+      '@aspect-test/f': 1.0.0
 
 packages:
-    /@aspect-test/a/5.0.0:
-        resolution:
-            {
-                integrity: sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==,
-            }
-        hasBin: true
-        dependencies:
-            '@aspect-test/b': 5.0.0
-            '@aspect-test/c': 1.0.0
-            '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
 
-    /@aspect-test/b/5.0.0:
-        resolution:
-            {
-                integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==,
-            }
-        hasBin: true
-        dependencies:
-            '@aspect-test/a': 5.0.0
-            '@aspect-test/c': 2.0.0
-            '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
+  /@aspect-test/a/5.0.0:
+    resolution: {integrity: sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/b': 5.0.0
+      '@aspect-test/c': 1.0.0
+      '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
 
-    /@aspect-test/c/1.0.0:
-        resolution:
-            {
-                integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==,
-            }
-        hasBin: true
-        requiresBuild: true
+  /@aspect-test/b/5.0.0:
+    resolution: {integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/c': 2.0.0
+      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
 
-    /@aspect-test/c/2.0.0:
-        resolution:
-            {
-                integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==,
-            }
-        hasBin: true
-        requiresBuild: true
+  /@aspect-test/c/1.0.0:
+    resolution: {integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==}
+    hasBin: true
+    requiresBuild: true
 
-    /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
-        resolution:
-            {
-                integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@aspect-test/c': x.x.x
-        dependencies:
-            '@aspect-test/c': 1.0.0
+  /@aspect-test/c/2.0.0:
+    resolution: {integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==}
+    hasBin: true
+    requiresBuild: true
 
-    /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
-        resolution:
-            {
-                integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@aspect-test/c': x.x.x
-        dependencies:
-            '@aspect-test/c': 2.0.0
+  /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 1.0.0
 
-    /@aspect-test/e/1.0.0:
-        resolution:
-            {
-                integrity: sha512-GyAxHYKN650db+xnimHnL2LPz65ilmQsVhCasWA7drDNQn/rfmPiEVMzjRiS7m46scXIERaBmiJMzYDf0bIUbA==,
-            }
-        hasBin: true
-        dev: false
+  /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 2.0.0
 
-    /@aspect-test/f/1.0.0:
-        resolution:
-            {
-                integrity: sha512-VjuHu/TXdK0dfMeArZoOFaBY0Z/wAjWuCNtEWDTVJftbDcBtcH3IrhLrOy0NdJu+/CjE0qLCEb78eDGniKNUFA==,
-            }
-        hasBin: true
-        dev: false
+  /@aspect-test/e/1.0.0:
+    resolution: {integrity: sha512-GyAxHYKN650db+xnimHnL2LPz65ilmQsVhCasWA7drDNQn/rfmPiEVMzjRiS7m46scXIERaBmiJMzYDf0bIUbA==}
+    hasBin: true
+    dev: false
 
-    /@aspect-test/g/1.0.0:
-        resolution:
-            {
-                integrity: sha512-nYxZCTIw+sHZfuKsqBBL7CW3KOliEoQh0D/ynWyUoB2Vi+DT2+nuvghXqL70/eNegjQ/8hUNTRBDBN2CPgoY8A==,
-            }
-        hasBin: true
-        dev: false
+  /@aspect-test/f/1.0.0:
+    resolution: {integrity: sha512-VjuHu/TXdK0dfMeArZoOFaBY0Z/wAjWuCNtEWDTVJftbDcBtcH3IrhLrOy0NdJu+/CjE0qLCEb78eDGniKNUFA==}
+    hasBin: true
+    dev: false
 
-    /@aspect-test/h/1.0.0:
-        resolution:
-            {
-                integrity: sha512-U1LStvh2QPmdQN7rlR0PTZZ1btTTcjiHxVmq5SvTxIRgIaJMCIsxcS5ghrd71H/JIwnJOmhI7BEQN3n6Hq9WSw==,
-            }
-        hasBin: true
-        dev: false
+  /@aspect-test/g/1.0.0:
+    resolution: {integrity: sha512-nYxZCTIw+sHZfuKsqBBL7CW3KOliEoQh0D/ynWyUoB2Vi+DT2+nuvghXqL70/eNegjQ/8hUNTRBDBN2CPgoY8A==}
+    hasBin: true
+    dev: false
+
+  /@aspect-test/h/1.0.0:
+    resolution: {integrity: sha512-U1LStvh2QPmdQN7rlR0PTZZ1btTTcjiHxVmq5SvTxIRgIaJMCIsxcS5ghrd71H/JIwnJOmhI7BEQN3n6Hq9WSw==}
+    hasBin: true
+    dev: false

--- a/e2e/rules_foo/foo/pnpm-lock.yaml
+++ b/e2e/rules_foo/foo/pnpm-lock.yaml
@@ -1,74 +1,57 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
-    '@aspect-test/a': 5.0.0
+  '@aspect-test/a': 5.0.0
 
 dependencies:
-    '@aspect-test/a': 5.0.0
+  '@aspect-test/a': 5.0.0
 
 packages:
-    /@aspect-test/a/5.0.0:
-        resolution:
-            {
-                integrity: sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==,
-            }
-        hasBin: true
-        dependencies:
-            '@aspect-test/b': 5.0.0
-            '@aspect-test/c': 1.0.0
-            '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
-        dev: false
 
-    /@aspect-test/b/5.0.0:
-        resolution:
-            {
-                integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==,
-            }
-        hasBin: true
-        dependencies:
-            '@aspect-test/a': 5.0.0
-            '@aspect-test/c': 2.0.0
-            '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
-        dev: false
+  /@aspect-test/a/5.0.0:
+    resolution: {integrity: sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/b': 5.0.0
+      '@aspect-test/c': 1.0.0
+      '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
+    dev: false
 
-    /@aspect-test/c/1.0.0:
-        resolution:
-            {
-                integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==,
-            }
-        hasBin: true
-        requiresBuild: true
-        dev: false
+  /@aspect-test/b/5.0.0:
+    resolution: {integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/c': 2.0.0
+      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
+    dev: false
 
-    /@aspect-test/c/2.0.0:
-        resolution:
-            {
-                integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==,
-            }
-        hasBin: true
-        requiresBuild: true
-        dev: false
+  /@aspect-test/c/1.0.0:
+    resolution: {integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==}
+    hasBin: true
+    requiresBuild: true
+    dev: false
 
-    /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
-        resolution:
-            {
-                integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@aspect-test/c': x.x.x
-        dependencies:
-            '@aspect-test/c': 1.0.0
-        dev: false
+  /@aspect-test/c/2.0.0:
+    resolution: {integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==}
+    hasBin: true
+    requiresBuild: true
+    dev: false
 
-    /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
-        resolution:
-            {
-                integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@aspect-test/c': x.x.x
-        dependencies:
-            '@aspect-test/c': 2.0.0
-        dev: false
+  /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 1.0.0
+    dev: false
+
+  /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 2.0.0
+    dev: false

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -1,988 +1,731 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
-    '@aspect-test/a': 5.0.0
-    '@aspect-test/b': 5.0.0
-    '@aspect-test/c': 2.0.0
-    '@gregmagolan/test-b': ^0.0.2
-    '@rollup/plugin-commonjs': ^21.1.0
-    '@types/node': ^15.12.2
-    bufferutil: 4.0.1
-    esbuild: 0.14.38
-    mobx: ^6.1.0
-    mobx-react: ^7.3.0
-    react: ^17
-    rollup: ^2.70.2
-    uvu: ^0.5.3
-    webpack-bundle-analyzer: 4.5.0
+  '@aspect-test/a': 5.0.0
+  '@aspect-test/b': 5.0.0
+  '@aspect-test/c': 2.0.0
+  '@gregmagolan/test-b': ^0.0.2
+  '@rollup/plugin-commonjs': ^21.1.0
+  '@types/node': ^15.12.2
+  bufferutil: 4.0.1
+  esbuild: 0.14.38
+  mobx: ^6.1.0
+  mobx-react: ^7.3.0
+  react: ^17
+  rollup: ^2.70.2
+  uvu: ^0.5.3
+  webpack-bundle-analyzer: 4.5.0
 
 devDependencies:
-    '@aspect-test/a': 5.0.0
-    '@aspect-test/b': 5.0.0
-    '@aspect-test/c': 2.0.0
-    '@gregmagolan/test-b': 0.0.2
-    '@rollup/plugin-commonjs': 21.1.0_rollup@2.70.2
-    '@types/node': 15.14.9
-    bufferutil: 4.0.1
-    esbuild: 0.14.38
-    mobx: 6.5.0
-    mobx-react: 7.3.0_mobx@6.5.0+react@17.0.2
-    react: 17.0.2
-    rollup: 2.70.2
-    uvu: 0.5.3
-    webpack-bundle-analyzer: 4.5.0_bufferutil@4.0.1
+  '@aspect-test/a': 5.0.0
+  '@aspect-test/b': 5.0.0
+  '@aspect-test/c': 2.0.0
+  '@gregmagolan/test-b': 0.0.2
+  '@rollup/plugin-commonjs': 21.1.0_rollup@2.70.2
+  '@types/node': 15.14.9
+  bufferutil: 4.0.1
+  esbuild: 0.14.38
+  mobx: 6.5.0
+  mobx-react: 7.3.0_mobx@6.5.0+react@17.0.2
+  react: 17.0.2
+  rollup: 2.70.2
+  uvu: 0.5.3
+  webpack-bundle-analyzer: 4.5.0_bufferutil@4.0.1
 
 packages:
-    /@aspect-test/a/5.0.0:
-        resolution:
-            {
-                integrity: sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==,
-            }
-        hasBin: true
-        dependencies:
-            '@aspect-test/b': 5.0.0
-            '@aspect-test/c': 1.0.0
-            '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
-        dev: true
 
-    /@aspect-test/b/5.0.0:
-        resolution:
-            {
-                integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==,
-            }
-        hasBin: true
-        dependencies:
-            '@aspect-test/a': 5.0.0
-            '@aspect-test/c': 2.0.0
-            '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
-        dev: true
+  /@aspect-test/a/5.0.0:
+    resolution: {integrity: sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/b': 5.0.0
+      '@aspect-test/c': 1.0.0
+      '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
+    dev: true
 
-    /@aspect-test/c/1.0.0:
-        resolution:
-            {
-                integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==,
-            }
-        hasBin: true
-        requiresBuild: true
-        dev: true
+  /@aspect-test/b/5.0.0:
+    resolution: {integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/c': 2.0.0
+      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
+    dev: true
 
-    /@aspect-test/c/2.0.0:
-        resolution:
-            {
-                integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==,
-            }
-        hasBin: true
-        requiresBuild: true
-        dev: true
+  /@aspect-test/c/1.0.0:
+    resolution: {integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==}
+    hasBin: true
+    requiresBuild: true
+    dev: true
 
-    /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
-        resolution:
-            {
-                integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@aspect-test/c': x.x.x
-        dependencies:
-            '@aspect-test/c': 1.0.0
-        dev: true
+  /@aspect-test/c/2.0.0:
+    resolution: {integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==}
+    hasBin: true
+    requiresBuild: true
+    dev: true
 
-    /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
-        resolution:
-            {
-                integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@aspect-test/c': x.x.x
-        dependencies:
-            '@aspect-test/c': 2.0.0
-        dev: true
+  /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 1.0.0
+    dev: true
 
-    /@gregmagolan/test-a/0.0.1:
-        resolution:
-            {
-                integrity: sha512-nMZ3MKkXZ+uYbrm8R3dfdt3v1gOOLtf88CdDciWxMYGLr29oVjQG11y2fz4IRBR6R7hI2Gj+G9sHZ69wLTnjfA==,
-            }
-        dev: true
+  /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 2.0.0
+    dev: true
 
-    /@gregmagolan/test-b/0.0.2:
-        resolution:
-            {
-                integrity: sha512-h+LeJUbUued9XyQwxKMUdklGiGxPYJ1RvTAK9612ctCiMS2Fn0wu/Au5kHsMHxm8l4bOfpgAWmQ0OQQy7wUBCg==,
-            }
-        dependencies:
-            '@gregmagolan/test-a': 0.0.1
-        dev: true
+  /@gregmagolan/test-a/0.0.1:
+    resolution: {integrity: sha512-nMZ3MKkXZ+uYbrm8R3dfdt3v1gOOLtf88CdDciWxMYGLr29oVjQG11y2fz4IRBR6R7hI2Gj+G9sHZ69wLTnjfA==}
+    dev: true
 
-    /@polka/url/1.0.0-next.21:
-        resolution:
-            {
-                integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==,
-            }
-        dev: true
+  /@gregmagolan/test-b/0.0.2:
+    resolution: {integrity: sha512-h+LeJUbUued9XyQwxKMUdklGiGxPYJ1RvTAK9612ctCiMS2Fn0wu/Au5kHsMHxm8l4bOfpgAWmQ0OQQy7wUBCg==}
+    dependencies:
+      '@gregmagolan/test-a': 0.0.1
+    dev: true
 
-    /@rollup/plugin-commonjs/21.1.0_rollup@2.70.2:
-        resolution:
-            {
-                integrity: sha512-6ZtHx3VHIp2ReNNDxHjuUml6ur+WcQ28N1yHgCQwsbNkQg2suhxGMDQGJOn/KuDxKtd1xuZP5xSTwBA4GQ8hbA==,
-            }
-        engines: { node: '>= 8.0.0' }
-        peerDependencies:
-            rollup: ^2.38.3
-        dependencies:
-            '@rollup/pluginutils': 3.1.0_rollup@2.70.2
-            commondir: 1.0.1
-            estree-walker: 2.0.2
-            glob: 7.2.0
-            is-reference: 1.2.1
-            magic-string: 0.25.9
-            resolve: 1.22.0
-            rollup: 2.70.2
-        dev: true
+  /@polka/url/1.0.0-next.21:
+    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
 
-    /@rollup/pluginutils/3.1.0_rollup@2.70.2:
-        resolution:
-            {
-                integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==,
-            }
-        engines: { node: '>= 8.0.0' }
-        peerDependencies:
-            rollup: ^1.20.0||^2.0.0
-        dependencies:
-            '@types/estree': 0.0.39
-            estree-walker: 1.0.1
-            picomatch: 2.3.1
-            rollup: 2.70.2
-        dev: true
+  /@rollup/plugin-commonjs/21.1.0_rollup@2.70.2:
+    resolution: {integrity: sha512-6ZtHx3VHIp2ReNNDxHjuUml6ur+WcQ28N1yHgCQwsbNkQg2suhxGMDQGJOn/KuDxKtd1xuZP5xSTwBA4GQ8hbA==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^2.38.3
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.2
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 7.2.0
+      is-reference: 1.2.1
+      magic-string: 0.25.9
+      resolve: 1.22.0
+      rollup: 2.70.2
+    dev: true
 
-    /@types/estree/0.0.39:
-        resolution:
-            {
-                integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==,
-            }
-        dev: true
+  /@rollup/pluginutils/3.1.0_rollup@2.70.2:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.1
+      rollup: 2.70.2
+    dev: true
 
-    /@types/estree/0.0.51:
-        resolution:
-            {
-                integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==,
-            }
-        dev: true
+  /@types/estree/0.0.39:
+    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
+    dev: true
 
-    /@types/node/15.14.9:
-        resolution:
-            {
-                integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==,
-            }
-        dev: true
+  /@types/estree/0.0.51:
+    resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
+    dev: true
 
-    /acorn-walk/8.2.0:
-        resolution:
-            {
-                integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==,
-            }
-        engines: { node: '>=0.4.0' }
-        dev: true
+  /@types/node/15.14.9:
+    resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
+    dev: true
 
-    /acorn/8.7.1:
-        resolution:
-            {
-                integrity: sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==,
-            }
-        engines: { node: '>=0.4.0' }
-        hasBin: true
-        dev: true
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
 
-    /ansi-styles/4.3.0:
-        resolution:
-            {
-                integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-            }
-        engines: { node: '>=8' }
-        dependencies:
-            color-convert: 2.0.1
-        dev: true
+  /acorn/8.7.1:
+    resolution: {integrity: sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
 
-    /balanced-match/1.0.2:
-        resolution:
-            {
-                integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
-            }
-        dev: true
+  /ansi-styles/4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: true
 
-    /brace-expansion/1.1.11:
-        resolution:
-            {
-                integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==,
-            }
-        dependencies:
-            balanced-match: 1.0.2
-            concat-map: 0.0.1
-        dev: true
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
 
-    /bufferutil/4.0.1:
-        resolution:
-            {
-                integrity: sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==,
-            }
-        requiresBuild: true
-        dependencies:
-            node-gyp-build: 3.7.0
-        dev: true
+  /brace-expansion/1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: true
 
-    /chalk/4.1.2:
-        resolution:
-            {
-                integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-            }
-        engines: { node: '>=10' }
-        dependencies:
-            ansi-styles: 4.3.0
-            supports-color: 7.2.0
-        dev: true
+  /bufferutil/4.0.1:
+    resolution: {integrity: sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==}
+    requiresBuild: true
+    dependencies:
+      node-gyp-build: 3.7.0
+    dev: true
 
-    /color-convert/2.0.1:
-        resolution:
-            {
-                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-            }
-        engines: { node: '>=7.0.0' }
-        dependencies:
-            color-name: 1.1.4
-        dev: true
+  /chalk/4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
 
-    /color-name/1.1.4:
-        resolution:
-            {
-                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-            }
-        dev: true
+  /color-convert/2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: true
 
-    /commander/7.2.0:
-        resolution:
-            {
-                integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==,
-            }
-        engines: { node: '>= 10' }
-        dev: true
+  /color-name/1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
 
-    /commondir/1.0.1:
-        resolution: { integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs= }
-        dev: true
+  /commander/7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+    dev: true
 
-    /concat-map/0.0.1:
-        resolution: { integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= }
-        dev: true
+  /commondir/1.0.1:
+    resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
+    dev: true
 
-    /dequal/2.0.2:
-        resolution:
-            {
-                integrity: sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==,
-            }
-        engines: { node: '>=6' }
-        dev: true
+  /concat-map/0.0.1:
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    dev: true
 
-    /diff/5.0.0:
-        resolution:
-            {
-                integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==,
-            }
-        engines: { node: '>=0.3.1' }
-        dev: true
+  /dequal/2.0.2:
+    resolution: {integrity: sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==}
+    engines: {node: '>=6'}
+    dev: true
 
-    /duplexer/0.1.2:
-        resolution:
-            {
-                integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==,
-            }
-        dev: true
+  /diff/5.0.0:
+    resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
+    engines: {node: '>=0.3.1'}
+    dev: true
 
-    /esbuild-android-64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==,
-            }
-        engines: { node: '>=12' }
-        cpu: [x64]
-        os: [android]
-        requiresBuild: true
-        dev: true
+  /duplexer/0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+    dev: true
+
+  /esbuild-android-64/0.14.38:
+    resolution: {integrity: sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.14.38:
+    resolution: {integrity: sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-64/0.14.38:
+    resolution: {integrity: sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.38:
+    resolution: {integrity: sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-64/0.14.38:
+    resolution: {integrity: sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.38:
+    resolution: {integrity: sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-32/0.14.38:
+    resolution: {integrity: sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.14.38:
+    resolution: {integrity: sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm/0.14.38:
+    resolution: {integrity: sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.38:
+    resolution: {integrity: sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-mips64le/0.14.38:
+    resolution: {integrity: sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.14.38:
+    resolution: {integrity: sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-riscv64/0.14.38:
+    resolution: {integrity: sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.14.38:
+    resolution: {integrity: sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-netbsd-64/0.14.38:
+    resolution: {integrity: sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.38:
+    resolution: {integrity: sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-sunos-64/0.14.38:
+    resolution: {integrity: sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.14.38:
+    resolution: {integrity: sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-64/0.14.38:
+    resolution: {integrity: sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.38:
+    resolution: {integrity: sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild/0.14.38:
+    resolution: {integrity: sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      esbuild-android-64: 0.14.38
+      esbuild-android-arm64: 0.14.38
+      esbuild-darwin-64: 0.14.38
+      esbuild-darwin-arm64: 0.14.38
+      esbuild-freebsd-64: 0.14.38
+      esbuild-freebsd-arm64: 0.14.38
+      esbuild-linux-32: 0.14.38
+      esbuild-linux-64: 0.14.38
+      esbuild-linux-arm: 0.14.38
+      esbuild-linux-arm64: 0.14.38
+      esbuild-linux-mips64le: 0.14.38
+      esbuild-linux-ppc64le: 0.14.38
+      esbuild-linux-riscv64: 0.14.38
+      esbuild-linux-s390x: 0.14.38
+      esbuild-netbsd-64: 0.14.38
+      esbuild-openbsd-64: 0.14.38
+      esbuild-sunos-64: 0.14.38
+      esbuild-windows-32: 0.14.38
+      esbuild-windows-64: 0.14.38
+      esbuild-windows-arm64: 0.14.38
+    dev: true
+
+  /estree-walker/1.0.1:
+    resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
+    dev: true
+
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
+  /fs.realpath/1.0.0:
+    resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
+    dev: true
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /function-bind/1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
+
+  /glob/7.2.0:
+    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
+  /gzip-size/6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      duplexer: 0.1.2
+    dev: true
+
+  /has-flag/4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /has/1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: true
+
+  /inflight/1.0.6:
+    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
+
+  /is-core-module/2.9.0:
+    resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
+  /is-reference/1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    dependencies:
+      '@types/estree': 0.0.51
+    dev: true
+
+  /js-tokens/4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /kleur/4.1.4:
+    resolution: {integrity: sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
+  /loose-envify/1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: true
+
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
+  /minimatch/3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /mobx-react-lite/3.3.0_mobx@6.5.0+react@17.0.2:
+    resolution: {integrity: sha512-U/kMSFtV/bNVgY01FuiGWpRkaQVHozBq5CEBZltFvPt4FcV111hEWkgwqVg9GPPZSEuEdV438PEz8mk8mKpYlA==}
+    peerDependencies:
+      mobx: ^6.1.0
+      react: ^16.8.0 || ^17
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
         optional: true
-
-    /esbuild-android-arm64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==,
-            }
-        engines: { node: '>=12' }
-        cpu: [arm64]
-        os: [android]
-        requiresBuild: true
-        dev: true
+      react-native:
         optional: true
+    dependencies:
+      mobx: 6.5.0
+      react: 17.0.2
+    dev: true
 
-    /esbuild-darwin-64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==,
-            }
-        engines: { node: '>=12' }
-        cpu: [x64]
-        os: [darwin]
-        requiresBuild: true
-        dev: true
+  /mobx-react/7.3.0_mobx@6.5.0+react@17.0.2:
+    resolution: {integrity: sha512-RGEcwZokopqyJE5JPwXKB9FWMSqFM9NJVO2QPI+z6laJTJeBHqvPicjnKgY5mvihxTeXB1+72TnooqUePeGV1g==}
+    peerDependencies:
+      mobx: ^6.1.0
+      react: ^16.8.0 || ^17
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
         optional: true
-
-    /esbuild-darwin-arm64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==,
-            }
-        engines: { node: '>=12' }
-        cpu: [arm64]
-        os: [darwin]
-        requiresBuild: true
-        dev: true
+      react-native:
         optional: true
+    dependencies:
+      mobx: 6.5.0
+      mobx-react-lite: 3.3.0_mobx@6.5.0+react@17.0.2
+      react: 17.0.2
+    dev: true
 
-    /esbuild-freebsd-64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==,
-            }
-        engines: { node: '>=12' }
-        cpu: [x64]
-        os: [freebsd]
-        requiresBuild: true
-        dev: true
+  /mobx/6.5.0:
+    resolution: {integrity: sha512-pHZ/cySF00FVENDWIDzJyoObFahK6Eg4d0papqm6d7yMkxWTZ/S/csqJX1A3PsYy4t5k3z2QnlwuCfMW5lSEwA==}
+    dev: true
+
+  /mri/1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /mrmime/1.0.0:
+    resolution: {integrity: sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /node-gyp-build/3.7.0:
+    resolution: {integrity: sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==}
+    hasBin: true
+    dev: true
+
+  /object-assign/4.1.1:
+    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /once/1.4.0:
+    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    dependencies:
+      wrappy: 1.0.2
+    dev: true
+
+  /opener/1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
+    dev: true
+
+  /path-is-absolute/1.0.1:
+    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /path-parse/1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
+  /react/17.0.2:
+    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+    dev: true
+
+  /resolve/1.22.0:
+    resolution: {integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.9.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /rollup/2.70.2:
+    resolution: {integrity: sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: true
+
+  /sirv/1.0.19:
+    resolution: {integrity: sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.21
+      mrmime: 1.0.0
+      totalist: 1.1.0
+    dev: true
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: true
+
+  /supports-color/7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
+  /supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /totalist/1.1.0:
+    resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /uvu/0.5.3:
+    resolution: {integrity: sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      dequal: 2.0.2
+      diff: 5.0.0
+      kleur: 4.1.4
+      sade: 1.8.1
+    dev: true
+
+  /webpack-bundle-analyzer/4.5.0_bufferutil@4.0.1:
+    resolution: {integrity: sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
+    dependencies:
+      acorn: 8.7.1
+      acorn-walk: 8.2.0
+      chalk: 4.1.2
+      commander: 7.2.0
+      gzip-size: 6.0.0
+      lodash: 4.17.21
+      opener: 1.5.2
+      sirv: 1.0.19
+      ws: 7.5.7_bufferutil@4.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /wrappy/1.0.2:
+    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    dev: true
+
+  /ws/7.5.7_bufferutil@4.0.1:
+    resolution: {integrity: sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
         optional: true
-
-    /esbuild-freebsd-arm64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==,
-            }
-        engines: { node: '>=12' }
-        cpu: [arm64]
-        os: [freebsd]
-        requiresBuild: true
-        dev: true
+      utf-8-validate:
         optional: true
-
-    /esbuild-linux-32/0.14.38:
-        resolution:
-            {
-                integrity: sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==,
-            }
-        engines: { node: '>=12' }
-        cpu: [ia32]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-linux-64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==,
-            }
-        engines: { node: '>=12' }
-        cpu: [x64]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-linux-arm/0.14.38:
-        resolution:
-            {
-                integrity: sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==,
-            }
-        engines: { node: '>=12' }
-        cpu: [arm]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-linux-arm64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==,
-            }
-        engines: { node: '>=12' }
-        cpu: [arm64]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-linux-mips64le/0.14.38:
-        resolution:
-            {
-                integrity: sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==,
-            }
-        engines: { node: '>=12' }
-        cpu: [mips64el]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-linux-ppc64le/0.14.38:
-        resolution:
-            {
-                integrity: sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==,
-            }
-        engines: { node: '>=12' }
-        cpu: [ppc64]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-linux-riscv64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==,
-            }
-        engines: { node: '>=12' }
-        cpu: [riscv64]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-linux-s390x/0.14.38:
-        resolution:
-            {
-                integrity: sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==,
-            }
-        engines: { node: '>=12' }
-        cpu: [s390x]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-netbsd-64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==,
-            }
-        engines: { node: '>=12' }
-        cpu: [x64]
-        os: [netbsd]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-openbsd-64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==,
-            }
-        engines: { node: '>=12' }
-        cpu: [x64]
-        os: [openbsd]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-sunos-64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==,
-            }
-        engines: { node: '>=12' }
-        cpu: [x64]
-        os: [sunos]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-windows-32/0.14.38:
-        resolution:
-            {
-                integrity: sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==,
-            }
-        engines: { node: '>=12' }
-        cpu: [ia32]
-        os: [win32]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-windows-64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==,
-            }
-        engines: { node: '>=12' }
-        cpu: [x64]
-        os: [win32]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-windows-arm64/0.14.38:
-        resolution:
-            {
-                integrity: sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==,
-            }
-        engines: { node: '>=12' }
-        cpu: [arm64]
-        os: [win32]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild/0.14.38:
-        resolution:
-            {
-                integrity: sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==,
-            }
-        engines: { node: '>=12' }
-        hasBin: true
-        requiresBuild: true
-        optionalDependencies:
-            esbuild-android-64: 0.14.38
-            esbuild-android-arm64: 0.14.38
-            esbuild-darwin-64: 0.14.38
-            esbuild-darwin-arm64: 0.14.38
-            esbuild-freebsd-64: 0.14.38
-            esbuild-freebsd-arm64: 0.14.38
-            esbuild-linux-32: 0.14.38
-            esbuild-linux-64: 0.14.38
-            esbuild-linux-arm: 0.14.38
-            esbuild-linux-arm64: 0.14.38
-            esbuild-linux-mips64le: 0.14.38
-            esbuild-linux-ppc64le: 0.14.38
-            esbuild-linux-riscv64: 0.14.38
-            esbuild-linux-s390x: 0.14.38
-            esbuild-netbsd-64: 0.14.38
-            esbuild-openbsd-64: 0.14.38
-            esbuild-sunos-64: 0.14.38
-            esbuild-windows-32: 0.14.38
-            esbuild-windows-64: 0.14.38
-            esbuild-windows-arm64: 0.14.38
-        dev: true
-
-    /estree-walker/1.0.1:
-        resolution:
-            {
-                integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==,
-            }
-        dev: true
-
-    /estree-walker/2.0.2:
-        resolution:
-            {
-                integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
-            }
-        dev: true
-
-    /fs.realpath/1.0.0:
-        resolution: { integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8= }
-        dev: true
-
-    /fsevents/2.3.2:
-        resolution:
-            {
-                integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
-            }
-        engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
-        os: [darwin]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /function-bind/1.1.1:
-        resolution:
-            {
-                integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==,
-            }
-        dev: true
-
-    /glob/7.2.0:
-        resolution:
-            {
-                integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==,
-            }
-        dependencies:
-            fs.realpath: 1.0.0
-            inflight: 1.0.6
-            inherits: 2.0.4
-            minimatch: 3.1.2
-            once: 1.4.0
-            path-is-absolute: 1.0.1
-        dev: true
-
-    /gzip-size/6.0.0:
-        resolution:
-            {
-                integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==,
-            }
-        engines: { node: '>=10' }
-        dependencies:
-            duplexer: 0.1.2
-        dev: true
-
-    /has-flag/4.0.0:
-        resolution:
-            {
-                integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-            }
-        engines: { node: '>=8' }
-        dev: true
-
-    /has/1.0.3:
-        resolution:
-            {
-                integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==,
-            }
-        engines: { node: '>= 0.4.0' }
-        dependencies:
-            function-bind: 1.1.1
-        dev: true
-
-    /inflight/1.0.6:
-        resolution: { integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk= }
-        dependencies:
-            once: 1.4.0
-            wrappy: 1.0.2
-        dev: true
-
-    /inherits/2.0.4:
-        resolution:
-            {
-                integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
-            }
-        dev: true
-
-    /is-core-module/2.9.0:
-        resolution:
-            {
-                integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==,
-            }
-        dependencies:
-            has: 1.0.3
-        dev: true
-
-    /is-reference/1.2.1:
-        resolution:
-            {
-                integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==,
-            }
-        dependencies:
-            '@types/estree': 0.0.51
-        dev: true
-
-    /js-tokens/4.0.0:
-        resolution:
-            {
-                integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-            }
-        dev: true
-
-    /kleur/4.1.4:
-        resolution:
-            {
-                integrity: sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==,
-            }
-        engines: { node: '>=6' }
-        dev: true
-
-    /lodash/4.17.21:
-        resolution:
-            {
-                integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
-            }
-        dev: true
-
-    /loose-envify/1.4.0:
-        resolution:
-            {
-                integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
-            }
-        hasBin: true
-        dependencies:
-            js-tokens: 4.0.0
-        dev: true
-
-    /magic-string/0.25.9:
-        resolution:
-            {
-                integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==,
-            }
-        dependencies:
-            sourcemap-codec: 1.4.8
-        dev: true
-
-    /minimatch/3.1.2:
-        resolution:
-            {
-                integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
-            }
-        dependencies:
-            brace-expansion: 1.1.11
-        dev: true
-
-    /mobx-react-lite/3.3.0_mobx@6.5.0+react@17.0.2:
-        resolution:
-            {
-                integrity: sha512-U/kMSFtV/bNVgY01FuiGWpRkaQVHozBq5CEBZltFvPt4FcV111hEWkgwqVg9GPPZSEuEdV438PEz8mk8mKpYlA==,
-            }
-        peerDependencies:
-            mobx: ^6.1.0
-            react: ^16.8.0 || ^17
-            react-dom: '*'
-            react-native: '*'
-        peerDependenciesMeta:
-            react-dom:
-                optional: true
-            react-native:
-                optional: true
-        dependencies:
-            mobx: 6.5.0
-            react: 17.0.2
-        dev: true
-
-    /mobx-react/7.3.0_mobx@6.5.0+react@17.0.2:
-        resolution:
-            {
-                integrity: sha512-RGEcwZokopqyJE5JPwXKB9FWMSqFM9NJVO2QPI+z6laJTJeBHqvPicjnKgY5mvihxTeXB1+72TnooqUePeGV1g==,
-            }
-        peerDependencies:
-            mobx: ^6.1.0
-            react: ^16.8.0 || ^17
-            react-dom: '*'
-            react-native: '*'
-        peerDependenciesMeta:
-            react-dom:
-                optional: true
-            react-native:
-                optional: true
-        dependencies:
-            mobx: 6.5.0
-            mobx-react-lite: 3.3.0_mobx@6.5.0+react@17.0.2
-            react: 17.0.2
-        dev: true
-
-    /mobx/6.5.0:
-        resolution:
-            {
-                integrity: sha512-pHZ/cySF00FVENDWIDzJyoObFahK6Eg4d0papqm6d7yMkxWTZ/S/csqJX1A3PsYy4t5k3z2QnlwuCfMW5lSEwA==,
-            }
-        dev: true
-
-    /mri/1.2.0:
-        resolution:
-            {
-                integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
-            }
-        engines: { node: '>=4' }
-        dev: true
-
-    /mrmime/1.0.0:
-        resolution:
-            {
-                integrity: sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==,
-            }
-        engines: { node: '>=10' }
-        dev: true
-
-    /node-gyp-build/3.7.0:
-        resolution:
-            {
-                integrity: sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==,
-            }
-        hasBin: true
-        dev: true
-
-    /object-assign/4.1.1:
-        resolution: { integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM= }
-        engines: { node: '>=0.10.0' }
-        dev: true
-
-    /once/1.4.0:
-        resolution: { integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E= }
-        dependencies:
-            wrappy: 1.0.2
-        dev: true
-
-    /opener/1.5.2:
-        resolution:
-            {
-                integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==,
-            }
-        hasBin: true
-        dev: true
-
-    /path-is-absolute/1.0.1:
-        resolution: { integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18= }
-        engines: { node: '>=0.10.0' }
-        dev: true
-
-    /path-parse/1.0.7:
-        resolution:
-            {
-                integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
-            }
-        dev: true
-
-    /picomatch/2.3.1:
-        resolution:
-            {
-                integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
-            }
-        engines: { node: '>=8.6' }
-        dev: true
-
-    /react/17.0.2:
-        resolution:
-            {
-                integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==,
-            }
-        engines: { node: '>=0.10.0' }
-        dependencies:
-            loose-envify: 1.4.0
-            object-assign: 4.1.1
-        dev: true
-
-    /resolve/1.22.0:
-        resolution:
-            {
-                integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==,
-            }
-        hasBin: true
-        dependencies:
-            is-core-module: 2.9.0
-            path-parse: 1.0.7
-            supports-preserve-symlinks-flag: 1.0.0
-        dev: true
-
-    /rollup/2.70.2:
-        resolution:
-            {
-                integrity: sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==,
-            }
-        engines: { node: '>=10.0.0' }
-        hasBin: true
-        optionalDependencies:
-            fsevents: 2.3.2
-        dev: true
-
-    /sade/1.8.1:
-        resolution:
-            {
-                integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==,
-            }
-        engines: { node: '>=6' }
-        dependencies:
-            mri: 1.2.0
-        dev: true
-
-    /sirv/1.0.19:
-        resolution:
-            {
-                integrity: sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==,
-            }
-        engines: { node: '>= 10' }
-        dependencies:
-            '@polka/url': 1.0.0-next.21
-            mrmime: 1.0.0
-            totalist: 1.1.0
-        dev: true
-
-    /sourcemap-codec/1.4.8:
-        resolution:
-            {
-                integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==,
-            }
-        dev: true
-
-    /supports-color/7.2.0:
-        resolution:
-            {
-                integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-            }
-        engines: { node: '>=8' }
-        dependencies:
-            has-flag: 4.0.0
-        dev: true
-
-    /supports-preserve-symlinks-flag/1.0.0:
-        resolution:
-            {
-                integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
-            }
-        engines: { node: '>= 0.4' }
-        dev: true
-
-    /totalist/1.1.0:
-        resolution:
-            {
-                integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==,
-            }
-        engines: { node: '>=6' }
-        dev: true
-
-    /uvu/0.5.3:
-        resolution:
-            {
-                integrity: sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==,
-            }
-        engines: { node: '>=8' }
-        hasBin: true
-        dependencies:
-            dequal: 2.0.2
-            diff: 5.0.0
-            kleur: 4.1.4
-            sade: 1.8.1
-        dev: true
-
-    /webpack-bundle-analyzer/4.5.0_bufferutil@4.0.1:
-        resolution:
-            {
-                integrity: sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==,
-            }
-        engines: { node: '>= 10.13.0' }
-        hasBin: true
-        dependencies:
-            acorn: 8.7.1
-            acorn-walk: 8.2.0
-            chalk: 4.1.2
-            commander: 7.2.0
-            gzip-size: 6.0.0
-            lodash: 4.17.21
-            opener: 1.5.2
-            sirv: 1.0.19
-            ws: 7.5.7_bufferutil@4.0.1
-        transitivePeerDependencies:
-            - bufferutil
-            - utf-8-validate
-        dev: true
-
-    /wrappy/1.0.2:
-        resolution: { integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= }
-        dev: true
-
-    /ws/7.5.7_bufferutil@4.0.1:
-        resolution:
-            {
-                integrity: sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==,
-            }
-        engines: { node: '>=8.3.0' }
-        peerDependencies:
-            bufferutil: ^4.0.1
-            utf-8-validate: ^5.0.2
-        peerDependenciesMeta:
-            bufferutil:
-                optional: true
-            utf-8-validate:
-                optional: true
-        dependencies:
-            bufferutil: 4.0.1
-        dev: true
+    dependencies:
+      bufferutil: 4.0.1
+    dev: true


### PR DESCRIPTION
My train of thought was that by using pnpm's formatting we could simplify the parsing logic, but then I realized that consumers may run any formatter on their lockfile before passing it in 🤷‍♂️ . So it doesn't matter if we do this or not.