### PR TITLE
Failing run_js_binary example

### DIFF
--- a/example/run_js_binary/BUILD.bazel
+++ b/example/run_js_binary/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//js:defs.bzl", "js_binary")
+load("//js:run_js_binary.bzl", "run_js_binary")
+
+js_binary(
+    name = "copy",
+    entry_point = "copy.js",
+)
+
+run_js_binary(
+    name = "run_copy",
+    srcs = ["in.txt"],
+    outs = ["out.txt"],
+    args = [
+        "$(location in.txt)",
+        "$(location out.txt)",
+    ],
+    tool = ":copy",
+)

--- a/example/run_js_binary/copy.js
+++ b/example/run_js_binary/copy.js
@@ -1,0 +1,4 @@
+const fs = require('fs')
+const [inFile, outFile] = process.argv.slice(2)
+console.log(`${inFile} -> ${outFile}`)
+fs.writeFileSync(outFile, fs.readFileSync(inFile))


### PR DESCRIPTION
I am not sure whether this is a bug or user error. I'm trying to replace a `nodejs_binary` + `genrule` combo with `js_binary` + `run_js_binary`, but can't get paths to line up.

```
$ bazel build //example/run_js_binary:run_copy
INFO: Analyzed target //example/run_js_binary:run_copy (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: /Users/john/figma/rules_js/example/run_js_binary/BUILD.bazel:9:14: RunBinary example/run_js_binary/out.txt failed: (Exit 1): _copy_launcher.sh failed: error executing command bazel-out/darwin-opt-exec-2B5CBBC6/bin/example/run_js_binary/_copy_launcher.sh example/run_js_binary/in.txt bazel-out/darwin-fastbuild/bin/example/run_js_binary/out.txt

Use --sandbox_debug to see verbose messages from the sandbox
example/run_js_binary/in.txt -> bazel-out/darwin-fastbuild/bin/example/run_js_binary/out.txt
node:internal/fs/utils:344
    throw err;
    ^

Error: ENOENT: no such file or directory, open 'bazel-out/darwin-fastbuild/bin/example/run_js_binary/out.txt'
    at Object.openSync (node:fs:585:3)
    at Object.writeFileSync (node:fs:2153:35)
    at Object.<anonymous> (/private/var/tmp/_bazel_johnfirebaugh/3cc5be9735d30b6128426fd19d172550/execroot/aspect_rules_js/bazel-out/darwin-opt-exec-2B5CBBC6/bin/example/run_js_binary/copy.js:4:4)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47 {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: 'bazel-out/darwin-fastbuild/bin/example/run_js_binary/out.txt'
}
Target //example/run_js_binary:run_copy failed to build
```