### PR TITLE
Delay expanding permissions on directories when extracting packages on linux

### DIFF
--- a/js/private/npm_import.bzl
+++ b/js/private/npm_import.bzl
@@ -229,6 +229,13 @@ def _impl(rctx):
     # npm packages are always published with one top-level directory inside the tarball, tho the name is not predictable
     # so we use tar here which takes a --strip-components N argument instead of rctx.download_and_extract
     untar_args = ["tar", "-xf", _TARBALL_FILENAME, "--strip-components", str(1), "-C", _EXTRACT_TO_DIRNAME]
+
+    if repo_utils.is_linux(rctx):
+        # Some packages have directory permissions missing the executable bit, which prevents GNU tar from
+        # extracting files into the directory. Delay permission restoration for directories until all files
+        # have been extracted. We assume that any linux platform is using GNU tar and has this flag available.
+        untar_args.append("--delay-directory-restore")
+
     result = rctx.execute(untar_args)
     if result.return_code:
         msg = "tar %s failed: \nSTDOUT:\n%s\nSTDERR:\n%s" % (_EXTRACT_TO_DIRNAME, result.stdout, result.stderr)


### PR DESCRIPTION
### Summary

Some packages have broken directory permissions. These broken permissions can prevent GNU tar from being able to extract the files contained within the directories. Give `tar` `--delay-directory-restore` to delay setting directory permissions until after the files have been extracted.

Only enable this on linux because it appears that macOS does not hit this issue. It likely uses delayed permission expansion by default, as it also doesn't have the flag available. I don't have a windows machine to test on, but given that the other `chmod` fix directly below executing `tar` only runs on non-windows platforms, I'm assuming we don't need to worry there.

One example package that hits this issue:
* https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz
 
### Test Plan

* After applying this patch, I was able to fetch all packages in my project on an Ubuntu 18.04 machine with GNU tar 1.29.
* Run tar commands manually on problematic `.tgz` file mentioned above to see tar pass/fail depending on passing `--delay-directory-restore`

```console
$ tar -xf react-virtualized-9.22.3.tgz --strip-components 1 -C out; echo "status: $?"
tar: dist/commonjs: Cannot mkdir: Permission denied
tar: dist/es: Cannot mkdir: Permission denied
tar: dist/umd: Cannot mkdir: Permission denied
...
tar: Exiting with failure status due to previous errors
status: 2
$ rm -rf out
$ tar -xf react-virtualized-9.22.3.tgz --strip-components 1 -C out --delay-directory-restore; echo "status: $?"
status: 0
```
