### PR TITLE
fix: don't pop data from kwargs attribute in generated bins build (run_js_binary) macro

### DIFF
--- a/js/private/npm_import.bzl
+++ b/js/private/npm_import.bzl
@@ -151,7 +151,7 @@ def {bin_name}(name, **kwargs):
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@{link_workspace}//{link_package}:{namespace}{bazel_name}"],
+        data = ["@{link_workspace}//{link_package}:{namespace}{bazel_name}"],
     )
     _run_js_binary(
         name = name,

--- a/js/private/test/package_json_checked.bzl
+++ b/js/private/test/package_json_checked.bzl
@@ -13,7 +13,7 @@ def rollup(name, **kwargs):
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//example:jsp__rollup__2.70.2"],
+        data = ["@//example:jsp__rollup__2.70.2"],
     )
     _run_js_binary(
         name = name,

--- a/js/private/test/package_json_with_dashes_checked.bzl
+++ b/js/private/test/package_json_with_dashes_checked.bzl
@@ -13,7 +13,7 @@ def webpack_bundle_analyzer(name, **kwargs):
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//example:jsp__webpack-bundle-analyzer__4.5.0__bufferutil_4.0.1"],
+        data = ["@//example:jsp__webpack-bundle-analyzer__4.5.0__bufferutil_4.0.1"],
     )
     _run_js_binary(
         name = name,

--- a/js/run_js_binary.bzl
+++ b/js/run_js_binary.bzl
@@ -89,6 +89,13 @@ def run_js_binary(
 
         **kwargs: Additional arguments
     """
+
+    # Friendly fail if user has specified data instead of srcs
+    data = kwargs.pop("data", None)
+    if data != None:
+        fail("Use srcs instead of data in run_js_binary: https://github.com/aspect-build/rules_js/blob/main/docs/run_js_binary.md#run_js_binary-srcs.")
+
+    # Copy srcs to bin
     extra_srcs = []
     if copy_srcs_to_bin:
         copy_to_bin_name = "%s_copy_srcs_to_bin" % name


### PR DESCRIPTION
Also add a friendly failure message if a user specifies data instead of srcs in `run_js_binary`