### PR TITLE
fix: apply npm_import patches before reading the package.json file incase package.json itself needs patching

### DIFF
--- a/js/private/npm_import.bzl
+++ b/js/private/npm_import.bzl
@@ -269,6 +269,10 @@ def _impl(rctx):
             msg = "chmod %s failed: \nSTDOUT:\n%s\nSTDERR:\n%s" % (_EXTRACT_TO_DIRNAME, result.stdout, result.stderr)
             fail(msg)
 
+    # apply patches to the extracted package before reading the package.json incase
+    # the patch targets the package.json itself
+    patch(rctx, patch_args = rctx.attr.patch_args, patch_directory = _EXTRACT_TO_DIRNAME)
+
     pkg_json_path = paths.join(_EXTRACT_TO_DIRNAME, "package.json")
 
     pkg_json = json.decode(rctx.read(pkg_json_path))
@@ -320,9 +324,6 @@ def _impl(rctx):
 
     if rctx.attr.custom_postinstall:
         _inject_custom_postinstall(rctx, pkg_json_path, rctx.attr.custom_postinstall)
-
-    # Apply patches to the extracted package
-    patch(rctx, patch_args = rctx.attr.patch_args, patch_directory = _EXTRACT_TO_DIRNAME)
 
     build_file = generated_by_lines + [
         """load("@aspect_rules_js//js/private:js_package_internal.bzl", _js_package = "js_package_internal")""",


### PR DESCRIPTION
to support patches such as these

```
translate_pnpm_lock(
    name = "npm",
    pnpm_lock = "//:pnpm-lock.yaml",
    patches = {
        # these npm packages have package.json files with duplicate 'typeCoverage' keys which
        # Bazel's json.decode fails on:
        # https://unpkg.com/stringify-entities@4.0.2/package.json
        # https://unpkg.com/decode-named-character-reference@1.0.1/package.json
        "stringify-entities@4.0.2": ["//:patches/stringify-entities@4.0.2.patch"],
        "decode-named-character-reference@1.0.1": ["//:patches/decode-named-character-reference@1.0.1.patch"],
    },
)
```