### PR TITLE
fix: fix bug when setting log_level in `run_js_binary`

### DIFF
--- a/examples/js_binary/BUILD.bazel
+++ b/examples/js_binary/BUILD.bazel
@@ -31,6 +31,10 @@ run_js_binary(
     args = ["actual4"],
     chdir = package_name(),
     tool = ":bin",
+    log_level = "debug",
+    # Uncomment the setting below to see debug output even on a
+    # successful run of the build action.
+    # silent_on_success = False,
 )
 
 diff_test(

--- a/js/run_js_binary.bzl
+++ b/js/run_js_binary.bzl
@@ -150,8 +150,8 @@ def run_js_binary(
 
     # Configure log_level if specified
     if log_level:
-        for env in _js_binary_envs_for_log_level(log_level):
-            extra_env[env] = "1"
+        for log_level_env in _js_binary_envs_for_log_level(log_level):
+            extra_env[log_level_env] = "1"
 
     _run_binary(
         name = name,


### PR DESCRIPTION
### Summary

The dictionary value of `env` was being masked over by a for loop, resulting in a string (the debug key) being passed to `dicts.add`, which caused it to error out:

```
ERROR: Traceback (most recent call last):
        File "/home/alex.torok/code/rules_js/examples/js_binary/BUILD.bazel", line 27, column 14, in <toplevel>
                run_js_binary(
        File "/home/alex.torok/code/rules_js/js/run_js_binary.bzl", line 159, column 24, in run_js_binary
                env = dicts.add(extra_env, env),
        File "/home/alex.torok/.cache/bazel/_bazel_alex.torok/a35b6b5cd0642228cee40197cc66bc5c/external/bazel_skylib/lib/dicts.bzl", line 37, column 22, in _add
                result.update(d)
Error in update: in update, got string, want iterable
```

Use a new variable name when iterating over the log level env values and update an example to set the log_level so that this doesn't regress in the future.

### Test Plan

`bazel build //examples/js_binary:run4` passes with `log_level = "debug"`.