### PR TITLE
fix debug message formatting

### DIFF
--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -24,10 +24,12 @@ fi
 LOG_PREFIX="{{log_prefix_rule_set}}[{{log_prefix_rule}}]"
 
 function logf_stderr {
+    local format_string="$1"
+    shift
     if [ "${STDERR_CAPTURE:-}" ]; then
-        printf "%s\n" "$*" >>"$STDERR_CAPTURE"
+        printf "$format_string\n" "$@" >>"$STDERR_CAPTURE"
     else
-        printf "%s\n" "$*" >&2
+        printf "$format_string\n" "$@" >&2
     fi
 }
 

--- a/js/private/test/shellcheck_launcher.sh
+++ b/js/private/test/shellcheck_launcher.sh
@@ -41,10 +41,12 @@ fi
 LOG_PREFIX="aspect_rules_js[js_binary]"
 
 function logf_stderr {
+    local format_string="$1"
+    shift
     if [ "${STDERR_CAPTURE:-}" ]; then
-        printf "%s\n" "$*" >>"$STDERR_CAPTURE"
+        printf "$format_string\n" "$@" >>"$STDERR_CAPTURE"
     else
-        printf "%s\n" "$*" >&2
+        printf "$format_string\n" "$@" >&2
     fi
 }
 


### PR DESCRIPTION
### Summary
Fix how the logging function in the `js_binary` runner calls printf.

Previously, the format string was being treated like an argument to be
placed in the formatted output. This lead to incorrect rendering of the
formatted string. This PR fixes that by pulling the format string out of
the args list and using that in the printf call.

### Test Plan:

Compare debug output and failing `expected_exit_code = X` tests
before/after this change:

before:
```
DEBUG: aspect_rules_js[js_binary]: BAZEL_BINDIR %s bazel-out/k8-fastbuild/bin
DEBUG: aspect_rules_js[js_binary]: BAZEL_TARGET_CPU %s k8
DEBUG: aspect_rules_js[js_binary]: BAZEL_COMPILATION_MODE %s fastbuild
```

```
ERROR: aspect_rules_js[js_test]: expected exit code to be '%s', but got '%s' 1 0
```

after:
```
DEBUG: aspect_rules_js[js_binary]: BAZEL_BINDIR bazel-out/k8-fastbuild/bin
DEBUG: aspect_rules_js[js_binary]: BAZEL_TARGET_CPU k8
DEBUG: aspect_rules_js[js_binary]: BAZEL_COMPILATION_MODE fastbuild
```

```
ERROR: aspect_rules_js[js_test]: expected exit code to be '1', but got '0'
```