### PR TITLE
fix: failing windows test due to wrong expected line endings

### DIFF
--- a/examples/js_binary/BUILD.bazel
+++ b/examples/js_binary/BUILD.bazel
@@ -301,6 +301,7 @@ write_file(
         "        [--tokenize] [--locations] [---allow-hash-bang] [--allow-await-outside-function] [--compact] [--silent] [--module] [--help] [--] [infile]",
         "",
     ],
+    newline = "unix",
 )
 
 diff_test(


### PR DESCRIPTION
The test compares `js_run_binary` `stdout` which always seems to produce unix line endings, and a `write_file` which by default uses the platform's line ending format. I'm not sure which one of the two to change.