### PR TITLE
fix: keep lockfile up to date example windows regression

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.2.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.2.1")
 bazel_dep(name = "bazel_skylib", version = "1.1.1")
 bazel_dep(name = "rules_nodejs", version = "5.5.0")
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/examples/assert_lockfile_up_to_date/BUILD
+++ b/examples/assert_lockfile_up_to_date/BUILD
@@ -12,12 +12,25 @@ js_test(
         ":pnpm-lock.yaml",
     ],
     entry_point = "assert_lockfile_frozen.js",
+    env = {
+        # The script overrides the cache dir to point to the output tree but pnpm
+        # will complain on Windows if it can't resolve a path to the default one.
+        # The env var APPDATA just needs to exist but not be undefined.
+        "APPDATA": "unused"
+
+    }
 )
 
 js_binary(
     name = "update_lockfile_js",
     data = [":node_modules/pnpm"],
     entry_point = ":update_lockfile.js",
+    env = {
+        # The script overrides the cache dir to point to the output tree but pnpm
+        # will complain on Windows if it can't resolve a path to the default one.
+        # The env var APPDATA just needs to exist but not be undefined.
+        "APPDATA": "unused"
+    }
 )
 
 js_run_binary(

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -38,7 +38,7 @@ def rules_js_dependencies():
     maybe(
         http_archive,
         name = "aspect_bazel_lib",
-        sha256 = "2db5b7176459c23f35a6cd45ff466fc3784bb17fdfa17a9bfeb1ac837796464c",
-        strip_prefix = "bazel-lib-1.2.0",
-        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.2.0.tar.gz",
+        sha256 = "a62838a8bb32478db2cf557b59279e566d628e064f91071daf1986c32463c2c9",
+        strip_prefix = "bazel-lib-1.2.1",
+        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.2.1.tar.gz",
     )


### PR DESCRIPTION
This is the last windows regression aside from the `node-gyp` issue.