### PR TITLE
refactor: tweak ':' separator locations in package_json.bzl load paths

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -128,7 +128,7 @@ npm_check(
 Example, after:
 
 ```starlark
-load("@npm//npm-check:package_json.bzl", "bin")
+load("@npm//:npm-check/package_json.bzl", "bin")
 
 exports_files(["package.json"])
 

--- a/e2e/npm_link_package/BUILD.bazel
+++ b/e2e/npm_link_package/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
-load("@rules_foo_npm//foo/@aspect-test/a:package_json.bzl", aspect_test_a_bin = "bin")
+load("@rules_foo_npm//foo:@aspect-test/a/package_json.bzl", aspect_test_a_bin = "bin")
 
 npm_link_all_packages(name = "node_modules")
 

--- a/e2e/pnpm_workspace/app/a/BUILD.bazel
+++ b/e2e/pnpm_workspace/app/a/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//app/a/@aspect-test/a:package_json.bzl", aspect_test_a_bin = "bin")
+load("@npm//app/a:@aspect-test/a/package_json.bzl", aspect_test_a_bin = "bin")
 
 npm_link_all_packages(name = "node_modules")
 

--- a/e2e/pnpm_workspace_dot_dot/app/a/BUILD.bazel
+++ b/e2e/pnpm_workspace_dot_dot/app/a/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//app/a/@aspect-test/a:package_json.bzl", aspect_test_a_bin = "bin")
+load("@npm//app/a:@aspect-test/a/package_json.bzl", aspect_test_a_bin = "bin")
 
 npm_link_all_packages(name = "node_modules")
 

--- a/examples/js_binary/BUILD.bazel
+++ b/examples/js_binary/BUILD.bazel
@@ -8,7 +8,7 @@ load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@npm//examples/npm_deps/@aspect-test/a:package_json.bzl", aspect_test_a_bin = "bin")
+load("@npm//examples/npm_deps:@aspect-test/a/package_json.bzl", aspect_test_a_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
 # Link all direct dependencies in /examples/npm_deps/package.json to

--- a/examples/js_library/two/BUILD.bazel
+++ b/examples/js_library/two/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//typescript:package_json.bzl", typescript_bin = "bin")
+load("@npm//:typescript/package_json.bzl", typescript_bin = "bin")
 load("@aspect_rules_js//js:defs.bzl", "js_test")
 
 typescript_bin.tsc(

--- a/examples/macro/mocha.bzl
+++ b/examples/macro/mocha.bzl
@@ -1,6 +1,6 @@
 "Example macro wrapping the mocha CLI"
 
-load("@npm//examples/macro/mocha:package_json.bzl", "bin")
+load("@npm//examples/macro:mocha/package_json.bzl", "bin")
 
 def mocha_test(name, srcs, args = [], data = [], env = {}, **kwargs):
     bin.mocha_test(

--- a/examples/npm_deps/BUILD.bazel
+++ b/examples/npm_deps/BUILD.bazel
@@ -11,7 +11,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm__rollup__2.70.2//examples/npm_deps:package_json.bzl", "rollup", "rollup_binary", "rollup_test")
 
 # Load from the "bin" property from the package.json of the uvu package
-load("@npm//examples/npm_deps/uvu:package_json.bzl", uvu_bin = "bin")
+load("@npm//examples/npm_deps:uvu/package_json.bzl", uvu_bin = "bin")
 
 ###########################
 

--- a/js/private/node-patches/src/BUILD.bazel
+++ b/js/private/node-patches/src/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//typescript:package_json.bzl", typescript_bin = "bin")
+load("@npm//:typescript/package_json.bzl", typescript_bin = "bin")
 
 typescript_bin.tsc(
     name = "compile",

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -176,7 +176,7 @@ _NPM_IMPORT_TMPL = \
 """
 
 _BIN_TMPL = \
-    """load("@{repo_name}//{repo_package_json_bzl}", _bin = "bin", _bin_factory = "bin_factory")
+    """load("{repo_package_json_bzl}", _bin = "bin", _bin_factory = "bin_factory")
 bin = _bin
 bin_factory = _bin_factory
 """
@@ -733,17 +733,17 @@ load("@aspect_rules_js//npm/private:npm_linked_packages.bzl", "npm_linked_packag
             # If this is a problem, we could lookup into the packages again like
             # if lockfile.get("packages").values()[i].get("hasBin"):
             if True:
-                build_file_path = paths.normalize(paths.join(link_package, _import.package, "BUILD.bazel"))
+                build_file_path = paths.normalize(paths.join(link_package, "BUILD.bazel"))
                 rctx.file(build_file_path, "\n".join(generated_by_lines))
                 package_json_bzl_file_path = paths.normalize(paths.join(link_package, _import.package, _PACKAGE_JSON_BZL_FILENAME))
-                repo_package_json_bzl = paths.normalize(paths.join(link_package, _PACKAGE_JSON_BZL_FILENAME)).rsplit("/", 1)
-                if len(repo_package_json_bzl) == 1:
-                    repo_package_json_bzl = [""] + repo_package_json_bzl
-                repo_package_json_bzl = ":".join(repo_package_json_bzl)
+                repo_package_json_bzl = "@{repo_name}//{link_package}:{package_json_bzl}".format(
+                    repo_name = _import.name,
+                    link_package = link_package,
+                    package_json_bzl = _PACKAGE_JSON_BZL_FILENAME,
+                )
                 rctx.file(package_json_bzl_file_path, "\n".join([
                     _BIN_TMPL.format(
                         repo_package_json_bzl = repo_package_json_bzl,
-                        repo_name = _import.name,
                     ),
                 ]))
 


### PR DESCRIPTION
(small) BREAKING CHANGE

Examples:

------------

```
load("@npm//typescript:package_json.bzl", typescript_bin = "bin")
```
becomes,
```
load("@npm//:typescript/package_json.bzl", typescript_bin = "bin")
```

------------

```
load("@rules_foo_npm//foo/@aspect-test/a:package_json.bzl", aspect_test_a_bin = "bin")
```
becomes,
```
load("@rules_foo_npm//foo:@aspect-test/a/package_json.bzl", aspect_test_a_bin = "bin")
```