### PR TITLE
fix: use camel case in generated bin mnemonics

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -379,11 +379,12 @@ def _impl(rctx):
                 """load("@aspect_rules_js//js:defs.bzl", _js_binary = "js_binary", _js_run_binary = "js_run_binary", _js_test = "js_test")""",
             ]
             for name in bins:
+                bin_name = _sanitize_bin_name(name)
                 bin_bzl.append(
                     _BIN_MACRO_TMPL.format(
                         bazel_name = bazel_name,
-                        bin_name = _sanitize_bin_name(name),
-                        bin_mnemonic = _mnemonic_for_bin(name),
+                        bin_name = bin_name,
+                        bin_mnemonic = _mnemonic_for_bin(bin_name),
                         bin_path = bins[name],
                         link_workspace = rctx.attr.link_workspace,
                         package = rctx.attr.package,
@@ -437,9 +438,13 @@ def _sanitize_bin_name(name):
     """ Sanitize a package name so we can use it in starlark function names """
     return name.replace("-", "_")
 
-def _mnemonic_for_bin(name):
-    """ Sanitize a package name so we can use it action mnemonics """
-    return name.replace("-", " ").replace("_", " ")
+def _mnemonic_for_bin(bin_name):
+    """ Sanitize a package name so we can use it action mnemonics.
+
+    Creates a CamelCase version of the bin name.
+    """
+    bin_words = bin_name.split("_")
+    return "".join([word.capitalize() for word in bin_words])
 
 def _impl_links(rctx):
     ref_deps = {}

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -235,7 +235,7 @@ def _{bin_name}_internal(name, link_root_name, **kwargs):
     _js_run_binary(
         name = name,
         tool = ":%s__js_binary" % name,
-        mnemonic = kwargs.pop("mnemonic", "{bin_name}"),
+        mnemonic = kwargs.pop("mnemonic", "{bin_mnemonic}"),
         **kwargs
     )
 
@@ -383,6 +383,7 @@ def _impl(rctx):
                     _BIN_MACRO_TMPL.format(
                         bazel_name = bazel_name,
                         bin_name = _sanitize_bin_name(name),
+                        bin_mnemonic = _mnemonic_for_bin(name),
                         bin_path = bins[name],
                         link_workspace = rctx.attr.link_workspace,
                         package = rctx.attr.package,
@@ -435,6 +436,10 @@ bin = bin_factory("node_modules")
 def _sanitize_bin_name(name):
     """ Sanitize a package name so we can use it in starlark function names """
     return name.replace("-", "_")
+
+def _mnemonic_for_bin(name):
+    """ Sanitize a package name so we can use it in starlark function names """
+    return name.replace("-", " ")
 
 def _impl_links(rctx):
     ref_deps = {}

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -439,7 +439,7 @@ def _sanitize_bin_name(name):
 
 def _mnemonic_for_bin(name):
     """ Sanitize a package name so we can use it in starlark function names """
-    return name.replace("-", " ")
+    return name.replace("-", " ").replace("_", " ")
 
 def _impl_links(rctx):
     ref_deps = {}

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -439,7 +439,7 @@ def _sanitize_bin_name(name):
     return name.replace("-", "_")
 
 def _mnemonic_for_bin(bin_name):
-    """ Sanitize a package name so we can use it action mnemonics.
+    """ Sanitize a bin name so we can use it as a mnemonic.
 
     Creates a CamelCase version of the bin name.
     """

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -438,7 +438,7 @@ def _sanitize_bin_name(name):
     return name.replace("-", "_")
 
 def _mnemonic_for_bin(name):
-    """ Sanitize a package name so we can use it in starlark function names """
+    """ Sanitize a package name so we can use it action mnemonics """
     return name.replace("-", " ").replace("_", " ")
 
 def _impl_links(rctx):

--- a/npm/private/test/package_json_checked.bzl
+++ b/npm/private/test/package_json_checked.bzl
@@ -18,7 +18,7 @@ def _rollup_internal(name, link_root_name, **kwargs):
     _js_run_binary(
         name = name,
         tool = ":%s__js_binary" % name,
-        mnemonic = kwargs.pop("mnemonic", "rollup"),
+        mnemonic = kwargs.pop("mnemonic", "Rollup"),
         **kwargs
     )
 

--- a/npm/private/test/package_json_with_dashes_checked.bzl
+++ b/npm/private/test/package_json_with_dashes_checked.bzl
@@ -18,7 +18,7 @@ def _webpack_bundle_analyzer_internal(name, link_root_name, **kwargs):
     _js_run_binary(
         name = name,
         tool = ":%s__js_binary" % name,
-        mnemonic = kwargs.pop("mnemonic", "webpack bundle analyzer"),
+        mnemonic = kwargs.pop("mnemonic", "WebpackBundleAnalyzer"),
         **kwargs
     )
 

--- a/npm/private/test/package_json_with_dashes_checked.bzl
+++ b/npm/private/test/package_json_with_dashes_checked.bzl
@@ -18,7 +18,7 @@ def _webpack_bundle_analyzer_internal(name, link_root_name, **kwargs):
     _js_run_binary(
         name = name,
         tool = ":%s__js_binary" % name,
-        mnemonic = kwargs.pop("mnemonic", "webpack_bundle_analyzer"),
+        mnemonic = kwargs.pop("mnemonic", "webpack bundle analyzer"),
         **kwargs
     )
 


### PR DESCRIPTION
https://github.com/aspect-build/rules_js/pull/218 added the ability to use the bin name as the default mnemonic for generated package_json.bzl entries. Some generated bin entries have underscores in their name, which is not allowed in action mnemonics. 

Without this change, you can get:
```
Error in run: mnemonic must only contain letters and/or digits, and have non-zero length, was: "webpack_cli"
```

Use a CamelCase version of the bin name instead.