### PR TITLE
refactor: expose bzl_library targets for generated bins

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ docs/
 min/
 **/pnpm-lock.yaml
 js/private/node-patches/fs.js
+examples/**/*-docs.md

--- a/examples/js_library/two/BUILD.bazel
+++ b/examples/js_library/two/BUILD.bazel
@@ -1,7 +1,9 @@
-load("@npm//:typescript/package_json.bzl", typescript_bin = "bin")
+load(":tsc.bzl", "tsc")
+load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
 load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-typescript_bin.tsc(
+tsc(
     name = "two",
     srcs = [
         "tsconfig.json",
@@ -12,11 +14,6 @@ typescript_bin.tsc(
     outs = [
         "two.js",
     ],
-    chdir = package_name(),
-    args = [
-        "-p",
-        "tsconfig.json",
-    ],
 )
 
 js_test(
@@ -24,3 +21,19 @@ js_test(
     data = ["//examples/js_library/one"],
     entry_point = "two.js",
 )
+
+bzl_library(
+    name = "tsc",
+    srcs = ["tsc.bzl"],
+    deps = [
+        # this is a bzl_library target, exposing the package_json.bzl file we depend on
+        "@npm//:typescript",
+    ],
+)
+
+stardoc_with_diff_test(
+    name = "tsc-docs",
+    bzl_library_target = ":tsc",
+)
+
+update_docs(name = "docs")

--- a/examples/js_library/two/tsc-docs.md
+++ b/examples/js_library/two/tsc-docs.md
@@ -1,0 +1,27 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Simple macro exposing the typescript tsc binary.
+
+Most users should use ts_project from aspect-build/rules_ts instead.
+
+
+<a id="#tsc"></a>
+
+## tsc
+
+<pre>
+tsc(<a href="#tsc-name">name</a>, <a href="#tsc-args">args</a>, <a href="#tsc-kwargs">kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="tsc-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="tsc-args"></a>args |  <p align="center"> - </p>   |  <code>["-p", "tsconfig.json"]</code> |
+| <a id="tsc-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+

--- a/examples/js_library/two/tsc.bzl
+++ b/examples/js_library/two/tsc.bzl
@@ -1,0 +1,15 @@
+"""Simple macro exposing the typescript tsc binary.
+
+Most users should use ts_project from aspect-build/rules_ts instead.
+"""
+
+load("@npm//:typescript/package_json.bzl", typescript_bin = "bin")
+
+def tsc(name, args = ["-p", "tsconfig.json"], **kwargs):
+    typescript_bin.tsc(
+        name = name,
+        args = args,
+        # Always run tsc with the working directory in the project folder
+        chdir = native.package_name(),
+        **kwargs
+    )

--- a/examples/macro/BUILD.bazel
+++ b/examples/macro/BUILD.bazel
@@ -1,4 +1,6 @@
 load("//examples/macro:mocha.bzl", "mocha_test")
+load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
 # Link all direct dependencies in /examples/macro/package.json to
@@ -9,3 +11,20 @@ mocha_test(
     name = "test",
     srcs = ["test.js"],
 )
+
+bzl_library(
+    name = "mocha",
+    srcs = ["mocha.bzl"],
+    deps = [
+        "@aspect_bazel_lib//lib:copy_to_bin",
+        # this is a bzl_library target, exposing the package_json.bzl file we depend on
+        "@npm//examples/macro:mocha",
+    ],
+)
+
+stardoc_with_diff_test(
+    name = "mocha-docs",
+    bzl_library_target = ":mocha",
+)
+
+update_docs(name = "docs")

--- a/examples/macro/mocha-docs.md
+++ b/examples/macro/mocha-docs.md
@@ -1,0 +1,27 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Example macro wrapping the mocha CLI
+
+<a id="#mocha_test"></a>
+
+## mocha_test
+
+<pre>
+mocha_test(<a href="#mocha_test-name">name</a>, <a href="#mocha_test-srcs">srcs</a>, <a href="#mocha_test-args">args</a>, <a href="#mocha_test-data">data</a>, <a href="#mocha_test-env">env</a>, <a href="#mocha_test-kwargs">kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="mocha_test-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="mocha_test-srcs"></a>srcs |  <p align="center"> - </p>   |  none |
+| <a id="mocha_test-args"></a>args |  <p align="center"> - </p>   |  <code>[]</code> |
+| <a id="mocha_test-data"></a>data |  <p align="center"> - </p>   |  <code>[]</code> |
+| <a id="mocha_test-env"></a>env |  <p align="center"> - </p>   |  <code>{}</code> |
+| <a id="mocha_test-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+


### PR DESCRIPTION
This allows users to document their starlark code which loads from the generated bins.
It also makes bazel query look better when exploring the @npm repository, as there are now targets everywhere.