### PR TITLE
feat: support file: links in package.json & pnpm lockfile

### DIFF
--- a/e2e/pnpm_workspace/.bazelignore
+++ b/e2e/pnpm_workspace/.bazelignore
@@ -1,5 +1,7 @@
 node_modules/
 app/a/node_modules/
 app/b/node_modules/
+app/c/node_modules/
 lib/a/node_modules/
 lib/b/node_modules/
+lib/c/node_modules/

--- a/e2e/pnpm_workspace/app/c/BUILD.bazel
+++ b/e2e/pnpm_workspace/app/c/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_test")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//app/a:@aspect-test/a/package_json.bzl", aspect_test_a_bin = "bin")
+
+npm_link_all_packages(name = "node_modules")
+
+js_binary(
+    name = "main",
+    args = ["foo"],
+    data = [
+        ":node_modules/@lib/c",
+        "//:node_modules/@aspect-test",
+    ],
+    entry_point = "main.js",
+)
+
+js_test(
+    name = "test",
+    args = ["foo"],
+    data = [
+        ":node_modules",
+        "//:node_modules/@aspect-test",
+    ],
+    entry_point = "main.js",
+    log_level = "info",
+)
+
+aspect_test_a_bin.bin_a_test(
+    name = "aspect_test_a_bin_test",
+)

--- a/e2e/pnpm_workspace/app/c/main.js
+++ b/e2e/pnpm_workspace/app/c/main.js
@@ -1,0 +1,6 @@
+console.log(process.argv)
+console.log('--@aspect-test/a--', require('@aspect-test/a').id())
+console.log('--@aspect-test/b--', require('@aspect-test/b').id())
+console.log('--@aspect-test/c--', require('@aspect-test/c').id())
+console.log('--@aspect-test/g--', require('@aspect-test/g').id())
+console.log('--@lib/c--', require('@lib/c').id())

--- a/e2e/pnpm_workspace/app/c/package.json
+++ b/e2e/pnpm_workspace/app/c/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "@app/c",
+    "private": true,
+    "dependencies": {
+        "@aspect-test/a": "5.0.0",
+        "@aspect-test/g": "1.0.0",
+        "@lib/c": "file:../../lib/c"
+    }
+}

--- a/e2e/pnpm_workspace/lib/c/BUILD.bazel
+++ b/e2e/pnpm_workspace/lib/c/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages(name = "node_modules")
+
+npm_package(
+    name = "c",
+    srcs = [
+        "index.js",
+        "package.json",
+    ],
+    out = "pkg",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/pnpm_workspace/lib/c/index.js
+++ b/e2e/pnpm_workspace/lib/c/index.js
@@ -1,11 +1,9 @@
 const packageJson = require('./package.json')
-const e = require('@aspect-test/e')
-const libB = require('@lib/b')
+const f = require('@aspect-test/f')
 module.exports = {
     id: () =>
         `${packageJson.name}@${
             packageJson.version ? package.version : '0.0.0'
         }`,
-    idE: () => e.id(),
-    idLibB: () => libB.id(),
+    idF: () => f.id(),
 }

--- a/e2e/pnpm_workspace/lib/c/package.json
+++ b/e2e/pnpm_workspace/lib/c/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@lib/c",
+    "private": true,
+    "dependencies": {
+        "@aspect-test/f": "1.0.0"
+    }
+}

--- a/e2e/pnpm_workspace/pnpm-lock.yaml
+++ b/e2e/pnpm_workspace/pnpm-lock.yaml
@@ -34,6 +34,16 @@ importers:
       '@lib/b': link:../../lib/b
       '@lib/b_alias': link:../../lib/b
 
+  app/c:
+    specifiers:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/g': 1.0.0
+      '@lib/c': file:../../lib/c
+    dependencies:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/g': 1.0.0
+      '@lib/c': file:lib/c
+
   lib/a:
     specifiers:
       '@aspect-test/e': 1.0.0
@@ -43,6 +53,12 @@ importers:
       '@lib/b': link:../b
 
   lib/b:
+    specifiers:
+      '@aspect-test/f': 1.0.0
+    dependencies:
+      '@aspect-test/f': 1.0.0
+
+  lib/c:
     specifiers:
       '@aspect-test/f': 1.0.0
     dependencies:
@@ -117,4 +133,11 @@ packages:
   /@aspect-test/h/1.0.0:
     resolution: {integrity: sha512-U1LStvh2QPmdQN7rlR0PTZZ1btTTcjiHxVmq5SvTxIRgIaJMCIsxcS5ghrd71H/JIwnJOmhI7BEQN3n6Hq9WSw==}
     hasBin: true
+    dev: false
+
+  file:lib/c:
+    resolution: {directory: lib/c, type: directory}
+    name: '@lib/c'
+    dependencies:
+      '@aspect-test/f': 1.0.0
     dev: false

--- a/e2e/pnpm_workspace_dot_dot/.bazelignore
+++ b/e2e/pnpm_workspace_dot_dot/.bazelignore
@@ -2,5 +2,7 @@ root/node_modules/
 root/sub/node_modules/
 app/a/node_modules/
 app/b/node_modules/
+app/c/node_modules
 lib/a/node_modules/
 lib/b/node_modules/
+lib/c/node_modules

--- a/e2e/pnpm_workspace_dot_dot/app/c/BUILD.bazel
+++ b/e2e/pnpm_workspace_dot_dot/app/c/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_test")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//app/a:@aspect-test/a/package_json.bzl", aspect_test_a_bin = "bin")
+
+npm_link_all_packages(name = "node_modules")
+
+js_binary(
+    name = "main",
+    args = ["foo"],
+    data = [
+        ":node_modules/@lib/c",
+        "//root:node_modules/@aspect-test",
+    ],
+    entry_point = "main.js",
+)
+
+js_test(
+    name = "test",
+    args = ["foo"],
+    data = [
+        ":node_modules",
+        "//root:node_modules/@aspect-test",
+    ],
+    entry_point = "main.js",
+    log_level = "info",
+)
+
+aspect_test_a_bin.bin_a_test(
+    name = "aspect_test_a_bin_test",
+)

--- a/e2e/pnpm_workspace_dot_dot/app/c/main.js
+++ b/e2e/pnpm_workspace_dot_dot/app/c/main.js
@@ -1,0 +1,6 @@
+console.log(process.argv)
+console.log('--@aspect-test/a--', require('@aspect-test/a').id())
+console.log('--@aspect-test/b--', require('@aspect-test/b').id())
+console.log('--@aspect-test/c--', require('@aspect-test/c').id())
+console.log('--@aspect-test/g--', require('@aspect-test/g').id())
+console.log('--@lib/c--', require('@lib/c').id())

--- a/e2e/pnpm_workspace_dot_dot/app/c/package.json
+++ b/e2e/pnpm_workspace_dot_dot/app/c/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "@app/c",
+    "private": true,
+    "dependencies": {
+        "@aspect-test/a": "5.0.0",
+        "@aspect-test/b": "1.0.0",
+        "@aspect-test/c": "2.0.2",
+        "@aspect-test/g": "1.0.0",
+        "@lib/c": "file:../../lib/c"
+    }
+}

--- a/e2e/pnpm_workspace_dot_dot/lib/c/BUILD.bazel
+++ b/e2e/pnpm_workspace_dot_dot/lib/c/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages(name = "node_modules")
+
+npm_package(
+    name = "c",
+    srcs = [
+        "index.js",
+        "package.json",
+    ],
+    out = "pkg",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/pnpm_workspace_dot_dot/lib/c/index.js
+++ b/e2e/pnpm_workspace_dot_dot/lib/c/index.js
@@ -1,11 +1,9 @@
 const packageJson = require('./package.json')
-const e = require('@aspect-test/e')
-const libB = require('@lib/b')
+const f = require('@aspect-test/f')
 module.exports = {
     id: () =>
         `${packageJson.name}@${
             packageJson.version ? package.version : '0.0.0'
         }`,
-    idE: () => e.id(),
-    idLibB: () => libB.id(),
+    idF: () => f.id(),
 }

--- a/e2e/pnpm_workspace_dot_dot/lib/c/package.json
+++ b/e2e/pnpm_workspace_dot_dot/lib/c/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@lib/c",
+    "private": true,
+    "dependencies": {
+        "@aspect-test/f": "1.0.0"
+    }
+}

--- a/e2e/pnpm_workspace_dot_dot/root/pnpm-lock.yaml
+++ b/e2e/pnpm_workspace_dot_dot/root/pnpm-lock.yaml
@@ -44,6 +44,20 @@ importers:
       '@lib/b': link:../../lib/b
       '@lib/b_alias': link:../../lib/b
 
+  ../app/c:
+    specifiers:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/b': 1.0.0
+      '@aspect-test/c': 2.0.2
+      '@aspect-test/g': 1.0.0
+      '@lib/c': file:../../lib/c
+    dependencies:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/b': 1.0.0
+      '@aspect-test/c': 2.0.2
+      '@aspect-test/g': 1.0.0
+      '@lib/c': file:../lib/c
+
   ../lib/a:
     specifiers:
       '@aspect-test/e': 1.0.0
@@ -53,6 +67,12 @@ importers:
       '@lib/b': link:../b
 
   ../lib/b:
+    specifiers:
+      '@aspect-test/f': 1.0.0
+    dependencies:
+      '@aspect-test/f': 1.0.0
+
+  ../lib/c:
     specifiers:
       '@aspect-test/f': 1.0.0
     dependencies:
@@ -142,4 +162,11 @@ packages:
   /@aspect-test/h/1.0.0:
     resolution: {integrity: sha512-U1LStvh2QPmdQN7rlR0PTZZ1btTTcjiHxVmq5SvTxIRgIaJMCIsxcS5ghrd71H/JIwnJOmhI7BEQN3n6Hq9WSw==}
     hasBin: true
+    dev: false
+
+  file:../lib/c:
+    resolution: {directory: ../lib/c, type: directory}
+    name: '@lib/c'
+    dependencies:
+      '@aspect-test/f': 1.0.0
     dev: false

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -183,7 +183,7 @@ def js_run_binary(
         for log_level_env in _js_binary_envs_for_log_level(log_level):
             extra_env[log_level_env] = "1"
 
-    if len(outs) + len(out_dirs) < 1:
+    if not stdout and not stderr and not exit_code_out and (len(outs) + len(out_dirs) < 1):
         # run_binary will produce the actual error, but we want to give an additional JS-specific
         # warning message here. Note that as a macro, we can't tell the name of the rule provided
         # by the users BUILD file (e.g. for "typescript_bin.tsc(outs = [])" we'd wish to say


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_js/issues/167

NB: packages references by `file:` links cannot themselves `file:` or `workspace:` links. You'll get a friendly error message if you try. For that pattern just switch to pnpm workspaces and drop the `file:` links altogether and use `workspace:` links between packages.