### PR TITLE
bug: js_library with 'deps' no longer pulls deps into sandbox output tree

### DIFF
--- a/examples/webpack_cli/BUILD.bazel
+++ b/examples/webpack_cli/BUILD.bazel
@@ -48,5 +48,4 @@ bin.webpack_cli(
     ],
     log_level = "debug",
     chdir = package_name(),
-    silent_on_success = False,
 )

--- a/examples/webpack_cli/BUILD.bazel
+++ b/examples/webpack_cli/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@aspect_rules_js//js:defs.bzl", "js_library", "js_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//examples/webpack_cli:webpack-cli/package_json.bzl", "bin")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
@@ -6,7 +6,6 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 copy_to_bin(
     name = "files",
     srcs = [
-        "index.js",
         "package.json",
         "webpack.config.js",
     ],
@@ -25,11 +24,21 @@ js_test(
     entry_point = "index.js",
 )
 
+js_library(
+    name = "lib",
+    srcs = [
+        "index.js",
+    ],
+    deps = [
+        ":node_modules/mathjs",
+    ],
+)
+
 bin.webpack_cli(
     name = "bundle",
     srcs = [
         ":files",
-        ":node_modules/mathjs",
+        ":lib",
     ],
     args = [
         "--config webpack.config.js",
@@ -39,4 +48,5 @@ bin.webpack_cli(
     ],
     log_level = "debug",
     chdir = package_name(),
+    silent_on_success = False,
 )

--- a/examples/webpack_cli/index.js
+++ b/examples/webpack_cli/index.js
@@ -11,7 +11,6 @@ const {
     sqrt,
 } = require('mathjs')
 
-
 // functions and constants
 round(e, 3) // 2.718
 atan2(3, -3) / pi // 0.75

--- a/examples/webpack_cli/index.js
+++ b/examples/webpack_cli/index.js
@@ -11,6 +11,7 @@ const {
     sqrt,
 } = require('mathjs')
 
+
 // functions and constants
 round(e, 3) // 2.718
 atan2(3, -3) / pi // 0.75


### PR DESCRIPTION
After updating to the latest release of rules_js, I hit an issue where `js_library` targets no longer pull the files from their `deps` into the sandbox's bin directory. I bisected the problem to #252, which modified the `DefaultInfo` for `js_library`.

I'm not sure if I'm not following the correct usage pattern for `js_library`, but also noticed that there are no cases of `js_library` with `deps` on a `:node_modules/*` target within the `examples/` or `e2e/` directories.

This PR reproduces what I'm seeing by building on top of the existing `webpack_cli` example. You can see the build failure with `bazel build //examples/webpack_cli:bundle`

Should `js_library` work in the way showcased here? If not, what is the recommended way to express a library target with srcs and a dependency on an npm library that gets consumed by a `js_run_binary` target?