### PR TITLE
fix: determine the RUNFILES directory when running a js_binary in an sh_binary

### DIFF
--- a/examples/js_binary/BUILD.bazel
+++ b/examples/js_binary/BUILD.bazel
@@ -327,3 +327,52 @@ diff_test(
 aspect_test_a_bin.bin_a_test(
     name = "aspect_bin_a_test",
 )
+
+####################################################
+# Use case 10
+# Show launching js_binary() indirectly from a sh_binary()
+
+write_file(
+    name = "write10_js",
+    out = "case10.js",
+    content = ["""\
+        console.log("js_binary: ", __filename);
+        process.exit(0);
+"""],
+)
+js_binary(
+    name = "bin10-js_binary",
+    entry_point = "case10.js",
+)
+
+write_file(
+    name = "write10_launch_sh",
+    out = "launch_case10.sh",
+    content = ["""\
+        echo "sh launcher: $0"
+
+        # --- begin runfiles.bash initialization v2 ---
+        # Copy-pasted from the Bazel Bash runfiles library v2.
+        set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+        source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+        source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+        source "$0.runfiles/$f" 2>/dev/null || \
+        source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+        source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+        { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+        # --- end runfiles.bash initialization v2 ---
+
+        $(rlocation aspect_rules_js/examples/js_binary/bin10-js_binary.sh) -h
+"""],
+)
+
+sh_binary(
+    name = "test10",
+    srcs = [":launch_case10.sh"],
+    data = [
+        ":bin10-js_binary",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/examples/js_binary/BUILD.bazel
+++ b/examples/js_binary/BUILD.bazel
@@ -269,7 +269,7 @@ js_test(
     log_level = "debug",
 )
 
-# bazel run //examples:test10_binary
+# bazel run //examples:case7_binary
 js_binary(
     name = "case7_binary",
     args = ["dummy"],
@@ -335,11 +335,9 @@ aspect_test_a_bin.bin_a_test(
 write_file(
     name = "write10_js",
     out = "case10.js",
-    content = ["""\
-        console.log("js_binary: ", __filename);
-        process.exit(0);
-"""],
+    content = ["require('fs').writeFileSync(process.argv[2], 'case10')"],
 )
+
 js_binary(
     name = "bin10-js_binary",
     entry_point = "case10.js",
@@ -349,10 +347,7 @@ write_file(
     name = "write10_launch_sh",
     out = "launch_case10.sh",
     content = ["""\
-        echo "sh launcher: $0"
-
         # --- begin runfiles.bash initialization v2 ---
-        # Copy-pasted from the Bazel Bash runfiles library v2.
         set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
         source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
         source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
@@ -362,17 +357,28 @@ write_file(
         { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
         # --- end runfiles.bash initialization v2 ---
 
-        $(rlocation aspect_rules_js/examples/js_binary/bin10-js_binary.sh) -h
+        $(rlocation aspect_rules_js/examples/js_binary/bin10-js_binary.sh) "$@"
 """],
 )
 
+# NB: https://github.com/aspect-build/rules_js/issues/285 is only reproducable
+# with 'bazel run //examples/js_binary:bin10'. The genrule below that runs
+# the same binary does not reproduce as the environment is setup differently.
 sh_binary(
-    name = "test10",
+    name = "bin10",
     srcs = [":launch_case10.sh"],
+    args = ["out10"],
     data = [
         ":bin10-js_binary",
-    ],
-    deps = [
         "@bazel_tools//tools/bash/runfiles",
     ],
+)
+
+genrule(
+    name = "test10",
+    outs = ["out10"],
+    # All js_binary rules need a BAZEL_BINDIR environment variable set so they can
+    # run from that directory as the working directory.
+    cmd = "BAZEL_BINDIR=$(BINDIR) $(execpath :bin10) {}/out10".format(package_name()),
+    tools = [":bin10"],
 )

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -138,13 +138,12 @@ function is_windows {
 # It helps to normalizes paths when running on Windows.
 #
 # Example:
-# C:/Users/XUser/_bazel_XUser/7q7kkv32/execroot/A/b/C -> /c/users/xuser/_bazel_xuser/7q7kkv32/execroot/a/b/c
+# C:/Users/XUser/_bazel_XUser/7q7kkv32/execroot/A/b/C -> /c/Users/XUser/_bazel_XUser/7q7kkv32/execroot/A/b/C
 function normalize_windows_path {
     # Apply the followings paths transformations to normalize paths on Windows
     # -process driver letter
     # -convert path separator
-    # -lowercase everything
-    sed -e 's#^\(.\):#/\L\1#' -e 's#\\#/#g' -e 's/[A-Z]/\L&/g' <<< "$1"
+    sed -e 's#^\(.\):#/\L\1#' -e 's#\\#/#g' <<< "$1"
     return
 }
 
@@ -173,15 +172,24 @@ function normalize_windows_path {
 if [ "${TEST_SRCDIR:-}" ]; then
     # Case 4, bazel has identified runfiles for us.
     RUNFILES="$TEST_SRCDIR"
-elif [ "${RUNFILES_MANIFEST_ONLY:-}" ]; then
-    # Windows only has a manifest file instead of symlinks.
+elif [ "${RUNFILES_MANIFEST_FILE:-}" ]; then
     if [ "$(is_windows)" -eq "1" ]; then
-        # If Windows normalizing the path and case insensitive removing the `/MANIFEST` part of the path
-        NORMALIZED_RUNFILES_MANIFEST_FILE_PATH=$(normalize_windows_path "$RUNFILES_MANIFEST_FILE")
-        # shellcheck disable=SC2001
-        RUNFILES=$(sed 's|\/MANIFEST$||i' <<< "$NORMALIZED_RUNFILES_MANIFEST_FILE_PATH")
+        # If Windows, normalize the path
+        NORMALIZED_RUNFILES_MANIFEST_FILE=$(normalize_windows_path "$RUNFILES_MANIFEST_FILE")
     else
-        RUNFILES=${RUNFILES_MANIFEST_FILE%/MANIFEST}
+        NORMALIZED_RUNFILES_MANIFEST_FILE="$RUNFILES_MANIFEST_FILE"
+    fi
+    if [[ "${NORMALIZED_RUNFILES_MANIFEST_FILE}" == *.runfiles_manifest ]]; then
+        # Newer versions of Bazel put the manifest besides the runfiles with the suffix .runfiles_manifest.
+        # For example, the runfiles directory is named my_binary.runfiles then the manifest is beside the
+        # runfiles directory and named my_binary.runfiles_manifest
+        RUNFILES=${NORMALIZED_RUNFILES_MANIFEST_FILE%_manifest}
+    elif [[ "${NORMALIZED_RUNFILES_MANIFEST_FILE}" == */MANIFEST ]]; then
+        # Older versions of Bazel put the manifest file named MANIFEST in the runfiles directory
+        RUNFILES=${NORMALIZED_RUNFILES_MANIFEST_FILE%/MANIFEST}
+    else
+        logf_fatal "Unexpected RUNFILES_MANIFEST_FILE value $RUNFILES_MANIFEST_FILE"
+        exit 1
     fi
 else
     case "$0" in


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_js/issues/285

Without the fix commit,

```
$ bazel run //examples/js_binary:bin10
INFO: Analyzed target //examples/js_binary:bin10 (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/js_binary:bin10 up-to-date:
  bazel-bin/examples/js_binary/launch_case10.sh
  bazel-bin/examples/js_binary/bin10
INFO: Elapsed time: 0.139s, Critical Path: 0.00s
INFO: 2 processes: 2 internal.
INFO: Build completed successfully, 2 total actions
INFO: Build completed successfully, 2 total actions
FATAL: aspect_rules_js[js_binary]: RUNFILES environment variable is not set
```

with the commit

```
$ bazel run //examples/js_binary:bin10
INFO: Analyzed target //examples/js_binary:bin10 (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/js_binary:bin10 up-to-date:
  bazel-bin/examples/js_binary/launch_case10.sh
  bazel-bin/examples/js_binary/bin10
INFO: Elapsed time: 0.191s, Critical Path: 0.00s
INFO: 2 processes: 2 internal.
INFO: Build completed successfully, 2 total actions
INFO: Build completed successfully, 2 total actions

```