### PR TITLE
fix: fix relative symlinks handing in node fs patches

### DIFF
--- a/js/private/node-patches/fs.js
+++ b/js/private/node-patches/fs.js
@@ -481,7 +481,7 @@ const patcher = (fs = _fs, roots) => {
                     return oneHop(maybe, cb);
                 }
                 if (!path.isAbsolute(str)) {
-                    str = path.resolve(maybe, str);
+                    str = path.resolve(path.dirname(maybe), str);
                 }
                 return cb(path.join(str, ...nested.reverse()));
             });
@@ -514,7 +514,7 @@ const patcher = (fs = _fs, roots) => {
                 continue;
             }
             if (!path.isAbsolute(readlink)) {
-                readlink = path.resolve(maybe, readlink);
+                readlink = path.resolve(path.dirname(maybe), readlink);
             }
             return path.join(readlink, ...nested.reverse());
         }

--- a/js/private/node-patches/src/fs.ts
+++ b/js/private/node-patches/src/fs.ts
@@ -519,7 +519,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
                     return oneHop(maybe, cb)
                 }
                 if (!path.isAbsolute(str)) {
-                    str = path.resolve(maybe, str)
+                    str = path.resolve(path.dirname(maybe), str)
                 }
                 return cb(path.join(str, ...nested.reverse()))
             })
@@ -554,7 +554,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
                 continue
             }
             if (!path.isAbsolute(readlink)) {
-                readlink = path.resolve(maybe, readlink)
+                readlink = path.resolve(path.dirname(maybe), readlink)
             }
             return path.join(readlink, ...nested.reverse())
         }


### PR DESCRIPTION
This fix comes from https://github.com/aspect-build/rules_js/pull/283 where we are using declare_symlink that creates relative symlinks. Coverage for regression will come when that lands so we support RBE with rules_js.