### PR TITLE
fix: make `//js/private:enable_runfiles` explicitly have `//visibility:public`

### DIFF
--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -12,6 +12,7 @@ exports_files(["js_binary.sh.tpl"])
 config_setting(
     name = "enable_runfiles",
     values = {"enable_runfiles": "true"},
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(


### PR DESCRIPTION
This is a direct dependency of all `js_binary()` targets and is currently `//visibility:public` by default, however this behavior is changing and can be opted in early via the [`--incompatible_config_setting_private_default_visibility`](https://bazel.build/reference/command-line-reference#flag--incompatible_config_setting_private_default_visibility) flag. Making this target explicitly public passes the build with that flag.

See [this CI failure](https://github.com/dgp1130/rules_prerender/runs/7423144733?check_suite_focus=true) using the `--incompatible_*` flag.