### PR TITLE
chore: add reminder to clean up bazelrc once skylib fix is released

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -26,7 +26,10 @@ common --enable_platform_specific_config
 # Turn off legacy external runfiles on all platforms except Windows.
 # This prevents accidentally depending on this feature, which Bazel will remove.
 # Skylib's diff_test implementation for Windows depends on legacy external
-# runfiles so we cannot disable it fully.
+# runfiles so we cannot disable it fully. TODO: disable for all platforms and
+# remove the platform-specific config once the following fix is released:
+# https://github.com/bazelbuild/bazel-skylib/commit/872e9b06e18ae8ba2897cb65b9aaa172aa6279f3
+
 build:linux --nolegacy_external_runfiles
 build:macos --nolegacy_external_runfiles
 build:freebsd --nolegacy_external_runfiles


### PR DESCRIPTION
They fixed this issue I raised: https://github.com/bazelbuild/bazel-skylib/issues/376.