### PR TITLE
fix: fix typo in make_symlink helper for the declare_symlink path that is not load bearing yet

### DIFF
--- a/npm/private/npm_link_package.bzl
+++ b/npm/private/npm_link_package.bzl
@@ -192,7 +192,7 @@ def _make_symlink(ctx, symlink_path, target_file):
         symlink = ctx.actions.declare_symlink(symlink_path)
         ctx.actions.symlink(
             output = symlink,
-            target_path = relative_file(target_file, symlink.path),
+            target_path = relative_file(target_file.path, symlink.path),
         )
         files.append(target_file)
     else:


### PR DESCRIPTION
No CI for this yet as its not yet load bearing; waiting on support in Bazel