### PR TITLE
fix: bcr actions not triggering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,4 @@ jobs:
                   # Use GH feature to populate the changelog automatically
                   generate_release_notes: true
                   body_path: release_notes.txt
+                  token: ${{ secrets.JASON_RELEASE_TOKEN }}


### PR DESCRIPTION
The reason this works is because the default github actions token is not allowed to trigger followup actions, so the bcr actions that listen for releases won't be triggered unless a more authoritative token is used here.