### PR TITLE
Mocha tests are escaping the sandbox

### DIFF
--- a/examples/macro/test.js
+++ b/examples/macro/test.js
@@ -4,4 +4,8 @@ describe('mocha', () => {
     it('integrates with Bazel', () => {
         assert(true)
     })
+
+    it('is sandboxed', () => {
+        assert.match(__dirname, /examples\/macro\/test\.sh\.runfiles/)
+    })
 })


### PR DESCRIPTION
The attached test fails with the following (snipping the error from #345):

```
~/figma/rules_js $ bazel test --test_output=all //examples/macro:test
INFO: Analyzed target //examples/macro:test (1 packages loaded, 6 targets configured).
INFO: Found 1 test target...
FAIL: //examples/macro:test (see /private/var/tmp/_bazel_johnfirebaugh/3cc5be9735d30b6128426fd19d172550/execroot/aspect_rules_js/bazel-out/darwin-fastbuild/testlogs/examples/macro/test/test.log)
INFO: From Testing //examples/macro:test:
==================== Test output for //examples/macro:test:

  mocha
    ✔ integrates with Bazel
    1) is sandboxed


  1 passing (4ms)
  1 failing

  1) mocha
       is sandboxed:
     AssertionError [ERR_ASSERTION]: The input did not match the regular expression /examples\/macro\/test\.sh\.runfiles/. Input:

'/Users/john/figma/rules_js/examples/macro'

      at Context.<anonymous> (/Users/john/figma/rules_js/examples/macro/test.js:9:16)
      at processImmediate (node:internal/timers:464:21)



================================================================================
```

As seen in the assertion failure, `__dirname` points into the source tree, indicating that this test has escaped the sandbox. In a real repository, this leads to require failures because from the source tree, tests can't resolve relative paths to .js outputs compiled from TypeScript.