### PR TITLE
Fix bazel caches in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,8 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: |
-                      "~/.cache/bazel"
-                      "~/.cache/bazel-repo"
+                      ~/.cache/bazel
+                      ~/.cache/bazel-repo
                   key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', '**/*.js') }}
                   restore-keys: bazel-cache-
             - name: bazel test //...


### PR DESCRIPTION
Currently,  caching outputs of `bazel test` seems not working when I looked at "Post Mount bazel caches" step:
``` 
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

When I removed double quotes from cache paths, the warning was gone.