### PR TITLE
feat: add node_modules/.bin binary files support to npm_translate_lock, npm_import and npm_link_package_store

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,6 +56,13 @@ load("@aspect_rules_js//npm:npm_import.bzl", "npm_import", "npm_translate_lock")
 
 npm_translate_lock(
     name = "npm",
+    bins = {
+        # derived from "bin" attribute in node_modules/typescript/package.json
+        "typescript": {
+            "tsc": "./bin/tsc",
+            "tsserver": "./bin/tsserver",
+        },
+    },
     custom_postinstalls = {
         "@aspect-test/c": "echo moo > cow.txt",
         "@aspect-test/c@2.0.2": "echo mooo >> cow.txt",
@@ -89,6 +96,7 @@ npm_repositories()
 # Just a demonstration of the syntax de-sugaring.
 npm_import(
     name = "acorn__8.4.0",
+    bins = {"acorn": "./bin/acorn"},
     integrity = "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==",
     package = "acorn",
     # Root package where to link the virtual store

--- a/docs/npm_import.md
+++ b/docs/npm_import.md
@@ -27,125 +27,6 @@ Advanced users may want to directly fetch a package from npm rather than start f
 [`npm_import`](#npm_import) does this.
 
 
-<a id="npm_translate_lock_rule"></a>
-
-## npm_translate_lock_rule
-
-<pre>
-npm_translate_lock_rule(<a href="#npm_translate_lock_rule-name">name</a>, <a href="#npm_translate_lock_rule-custom_postinstalls">custom_postinstalls</a>, <a href="#npm_translate_lock_rule-dev">dev</a>, <a href="#npm_translate_lock_rule-lifecycle_hooks_envs">lifecycle_hooks_envs</a>,
-                        <a href="#npm_translate_lock_rule-lifecycle_hooks_exclude">lifecycle_hooks_exclude</a>, <a href="#npm_translate_lock_rule-lifecycle_hooks_execution_requirements">lifecycle_hooks_execution_requirements</a>,
-                        <a href="#npm_translate_lock_rule-lifecycle_hooks_no_sandbox">lifecycle_hooks_no_sandbox</a>, <a href="#npm_translate_lock_rule-no_optional">no_optional</a>, <a href="#npm_translate_lock_rule-npm_package_lock">npm_package_lock</a>, <a href="#npm_translate_lock_rule-package_json">package_json</a>,
-                        <a href="#npm_translate_lock_rule-patch_args">patch_args</a>, <a href="#npm_translate_lock_rule-patches">patches</a>, <a href="#npm_translate_lock_rule-pnpm_lock">pnpm_lock</a>, <a href="#npm_translate_lock_rule-prod">prod</a>, <a href="#npm_translate_lock_rule-public_hoist_packages">public_hoist_packages</a>, <a href="#npm_translate_lock_rule-repo_mapping">repo_mapping</a>,
-                        <a href="#npm_translate_lock_rule-run_lifecycle_hooks">run_lifecycle_hooks</a>, <a href="#npm_translate_lock_rule-verify_node_modules_ignored">verify_node_modules_ignored</a>,
-                        <a href="#npm_translate_lock_rule-warn_on_unqualified_tarball_url">warn_on_unqualified_tarball_url</a>, <a href="#npm_translate_lock_rule-yarn_lock">yarn_lock</a>)
-</pre>
-
-Repository rule to generate npm_import rules from pnpm lock file.
-
-The pnpm lockfile format includes all the information needed to define npm_import rules,
-including the integrity hash, as calculated by the package manager.
-
-For more details see, https://github.com/pnpm/pnpm/blob/main/packages/lockfile-types/src/index.ts.
-
-Instead of manually declaring the `npm_imports`, this helper generates an external repository
-containing a helper starlark module `repositories.bzl`, which supplies a loadable macro
-`npm_repositories`. This macro creates an `npm_import` for each package.
-
-The generated repository also contains BUILD files declaring targets for the packages
-listed as `dependencies` or `devDependencies` in `package.json`, so you can declare
-dependencies on those packages without having to repeat version information.
-
-Bazel will only fetch the packages which are required for the requested targets to be analyzed.
-Thus it is performant to convert a very large pnpm-lock.yaml file without concern for
-users needing to fetch many unnecessary packages.
-
-**Setup**
-
-In `WORKSPACE`, call the repository rule pointing to your pnpm-lock.yaml file:
-
-```starlark
-load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
-
-# Read the pnpm-lock.yaml file to automate creation of remaining npm_import rules
-npm_translate_lock(
-    # Creates a new repository named "@npm_deps"
-    name = "npm_deps",
-    pnpm_lock = "//:pnpm-lock.yaml",
-    # Recommended attribute that also checks the .bazelignore file
-    verify_node_modules_ignored = "//:.bazelignore",
-)
-```
-
-Next, there are two choices, either load from the generated repo or check in the generated file.
-The tradeoffs are similar to
-[this rules_python thread](https://github.com/bazelbuild/rules_python/issues/608).
-
-1. Immediately load from the generated `repositories.bzl` file in `WORKSPACE`.
-This is similar to the
-[`pip_parse`](https://github.com/bazelbuild/rules_python/blob/main/docs/pip.md#pip_parse)
-rule in rules_python for example.
-It has the advantage of also creating aliases for simpler dependencies that don't require
-spelling out the version of the packages.
-However it causes Bazel to eagerly evaluate the `npm_translate_lock` rule for every build,
-even if the user didn't ask for anything JavaScript-related.
-
-```starlark
-# Following our example above, we named this "npm_deps"
-load("@npm_deps//:repositories.bzl", "npm_repositories")
-
-npm_repositories()
-```
-
-2. Check in the `repositories.bzl` file to version control, and load that instead.
-This makes it easier to ship a ruleset that has its own npm dependencies, as users don't
-have to install those dependencies. It also avoids eager-evaluation of `npm_translate_lock`
-for builds that don't need it.
-This is similar to the [`update-repos`](https://github.com/bazelbuild/bazel-gazelle#update-repos)
-approach from bazel-gazelle.
-
-In a BUILD file, use a rule like
-[write_source_files](https://github.com/aspect-build/bazel-lib/blob/main/docs/write_source_files.md)
-to copy the generated file to the repo and test that it stays updated:
-
-```starlark
-write_source_files(
-    name = "update_repos",
-    files = {
-        "repositories.bzl": "@npm_deps//:repositories.bzl",
-    },
-)
-```
-
-Then in `WORKSPACE`, load from that checked-in copy or instruct your users to do so.
-
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="npm_translate_lock_rule-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="npm_translate_lock_rule-custom_postinstalls"></a>custom_postinstalls |  A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")         to a custom postinstall script to apply to the downloaded npm package after its lifecycle scripts runs.         If the version is left out of the package name, the script will run on every version of the npm package. If         a custom postinstall scripts exists for a package as well as for a specific version, the script for the versioned package         will be appended with <code>&&</code> to the non-versioned package script.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
-| <a id="npm_translate_lock_rule-dev"></a>dev |  If true, only install devDependencies   | Boolean | optional | False |
-| <a id="npm_translate_lock_rule-lifecycle_hooks_envs"></a>lifecycle_hooks_envs |  Environment variables applied to the preinstall, install and postinstall lifecycle hooks on npm packages.         The environment variables can be defined per package by package name or globally using "*".         Variables are declared as key/value pairs of the form "key=value".         For example:         lifecycle_hooks_envs: {             "*": ["GLOBAL_KEY1=value1", "GLOBAL_KEY2=value2"],             "@foo/bar": ["PREBULT_BINARY=http://downloadurl"],         }   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> List of strings</a> | optional | {} |
-| <a id="npm_translate_lock_rule-lifecycle_hooks_exclude"></a>lifecycle_hooks_exclude |  A list of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")         to not run lifecycle hooks on   | List of strings | optional | [] |
-| <a id="npm_translate_lock_rule-lifecycle_hooks_execution_requirements"></a>lifecycle_hooks_execution_requirements |  Execution requirements applied to the preinstall, install and postinstall lifecycle hooks on npm packages.         The execution requirements can be defined per package by package name or globally using "*".         For example:         lifecycle_hooks_execution_requirements: {             "*": ["requires-network"],             "@foo/bar": ["no-sandbox"],         }   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> List of strings</a> | optional | {} |
-| <a id="npm_translate_lock_rule-lifecycle_hooks_no_sandbox"></a>lifecycle_hooks_no_sandbox |  If True, a "no-sandbox" execution requirement is added to all lifecycle hooks.<br><br>        Equivalent to adding <code>"*": ["no-sandbox"]</code> to lifecycle_hooks_execution_requirements.<br><br>        This defaults to True to limit the overhead of sandbox creation and copying the output         TreeArtifacts out of the sandbox.   | Boolean | optional | True |
-| <a id="npm_translate_lock_rule-no_optional"></a>no_optional |  If true, optionalDependencies are not installed   | Boolean | optional | False |
-| <a id="npm_translate_lock_rule-npm_package_lock"></a>npm_package_lock |  The package-lock.json file written by <code>npm install</code>.<br><br>        When set, the <code>package_json</code> attribute must be set as well.         Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
-| <a id="npm_translate_lock_rule-package_json"></a>package_json |  The package.json file. From this file and the corresponding package-lock.json/yarn.lock file         (specified with the npm_package_lock/yarn_lock attributes),         a pnpm-lock.yaml file will be generated using <code>pnpm import</code>.<br><br>        Note that *any* changes to the package.json file will invalidate the npm_translate_lock         repository rule, causing it to re-run on the next invocation of Bazel.<br><br>        Mandatory when using npm_package_lock or yarn_lock, otherwise must be unset.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
-| <a id="npm_translate_lock_rule-patch_args"></a>patch_args |  A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")         to a label list arguments to pass to the patch tool. Defaults to -p0, but -p1 will         usually be needed for patches generated by git. If patch args exists for a package         as well as a package version, then the version-specific args will be appended to the args for the package.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> List of strings</a> | optional | {} |
-| <a id="npm_translate_lock_rule-patches"></a>patches |  A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")         to a label list of patches to apply to the downloaded npm package. Paths in the patch         file must start with <code>extract_tmp/package</code> where <code>package</code> is the top-level folder in         the archive on npm. If the version is left out of the package name, the patch will be         applied to every version of the npm package.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> List of strings</a> | optional | {} |
-| <a id="npm_translate_lock_rule-pnpm_lock"></a>pnpm_lock |  The pnpm-lock.yaml file.<br><br>        Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
-| <a id="npm_translate_lock_rule-prod"></a>prod |  If true, only install dependencies   | Boolean | optional | False |
-| <a id="npm_translate_lock_rule-public_hoist_packages"></a>public_hoist_packages |  A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")         to a list of Bazel packages in which to hoist the package to the top-level of the node_modules tree when linking.<br><br>        This is similar to setting https://pnpm.io/npmrc#public-hoist-pattern in an .npmrc file outside of Bazel, however,         wild-cards are not yet supported and npm_translate_lock will fail if there are multiple versions of a package that         are to be hoisted.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> List of strings</a> | optional | {} |
-| <a id="npm_translate_lock_rule-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
-| <a id="npm_translate_lock_rule-run_lifecycle_hooks"></a>run_lifecycle_hooks |  If true, runs preinstall, install and postinstall lifecycle hooks on npm packages if they exist   | Boolean | optional | True |
-| <a id="npm_translate_lock_rule-verify_node_modules_ignored"></a>verify_node_modules_ignored |  node_modules folders in the source tree should be ignored by Bazel.<br><br>        This points to a <code>.bazelignore</code> file to verify that all nested node_modules directories         pnpm will create are listed.<br><br>        See https://github.com/bazelbuild/bazel/issues/8106   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
-| <a id="npm_translate_lock_rule-warn_on_unqualified_tarball_url"></a>warn_on_unqualified_tarball_url |  -   | Boolean | optional | True |
-| <a id="npm_translate_lock_rule-yarn_lock"></a>yarn_lock |  The yarn.lock file written by <code>yarn install</code>.<br><br>        When set, the <code>package_json</code> attribute must be set as well.         Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
-
-
 <a id="npm_import"></a>
 
 ## npm_import
@@ -154,7 +35,7 @@ Then in `WORKSPACE`, load from that checked-in copy or instruct your users to do
 npm_import(<a href="#npm_import-name">name</a>, <a href="#npm_import-package">package</a>, <a href="#npm_import-version">version</a>, <a href="#npm_import-deps">deps</a>, <a href="#npm_import-transitive_closure">transitive_closure</a>, <a href="#npm_import-root_package">root_package</a>, <a href="#npm_import-link_workspace">link_workspace</a>,
            <a href="#npm_import-link_packages">link_packages</a>, <a href="#npm_import-run_lifecycle_hooks">run_lifecycle_hooks</a>, <a href="#npm_import-lifecycle_hooks_execution_requirements">lifecycle_hooks_execution_requirements</a>,
            <a href="#npm_import-lifecycle_hooks_env">lifecycle_hooks_env</a>, <a href="#npm_import-lifecycle_hooks_no_sandbox">lifecycle_hooks_no_sandbox</a>, <a href="#npm_import-integrity">integrity</a>, <a href="#npm_import-url">url</a>, <a href="#npm_import-patch_args">patch_args</a>, <a href="#npm_import-patches">patches</a>,
-           <a href="#npm_import-custom_postinstall">custom_postinstall</a>)
+           <a href="#npm_import-custom_postinstall">custom_postinstall</a>, <a href="#npm_import-bins">bins</a>)
 </pre>
 
 Import a single npm package into Bazel.
@@ -274,6 +155,7 @@ common --experimental_downloader_config=.bazel_downloader_config
 | <a id="npm_import-patch_args"></a>patch_args |  Arguments to pass to the patch tool. <code>-p1</code> will usually be needed for patches generated by git.   |  <code>["-p0"]</code> |
 | <a id="npm_import-patches"></a>patches |  Patch files to apply onto the downloaded npm package.   |  <code>[]</code> |
 | <a id="npm_import-custom_postinstall"></a>custom_postinstall |  Custom string postinstall script to run on the installed npm package. Runs after any existing lifecycle hooks if <code>run_lifecycle_hooks</code> is True.   |  <code>""</code> |
+| <a id="npm_import-bins"></a>bins |  Dictionary of <code>node_modules/.bin</code> binary files to create mapped to their node entry points.<br><br>This is typically derived from the "bin" attribute in the package.json file of the npm package being linked.<br><br>For example:<br><br><pre><code> bins = {     "foo": "./foo.js",     "bar": "./bar.js", } </code></pre><br><br>In the future, this field may be automatically populated by npm_translate_lock from information in the pnpm lock file. That feature is currently blocked on https://github.com/pnpm/pnpm/issues/5131.   |  <code>{}</code> |
 
 
 <a id="npm_translate_lock"></a>
@@ -281,27 +163,123 @@ common --experimental_downloader_config=.bazel_downloader_config
 ## npm_translate_lock
 
 <pre>
-npm_translate_lock(<a href="#npm_translate_lock-name">name</a>, <a href="#npm_translate_lock-npm_package_lock">npm_package_lock</a>, <a href="#npm_translate_lock-yarn_lock">yarn_lock</a>, <a href="#npm_translate_lock-pnpm_version">pnpm_version</a>, <a href="#npm_translate_lock-kwargs">kwargs</a>)
+npm_translate_lock(<a href="#npm_translate_lock-name">name</a>, <a href="#npm_translate_lock-pnpm_lock">pnpm_lock</a>, <a href="#npm_translate_lock-package_json">package_json</a>, <a href="#npm_translate_lock-npm_package_lock">npm_package_lock</a>, <a href="#npm_translate_lock-yarn_lock">yarn_lock</a>, <a href="#npm_translate_lock-patches">patches</a>, <a href="#npm_translate_lock-patch_args">patch_args</a>,
+                   <a href="#npm_translate_lock-custom_postinstalls">custom_postinstalls</a>, <a href="#npm_translate_lock-prod">prod</a>, <a href="#npm_translate_lock-public_hoist_packages">public_hoist_packages</a>, <a href="#npm_translate_lock-dev">dev</a>, <a href="#npm_translate_lock-no_optional">no_optional</a>,
+                   <a href="#npm_translate_lock-lifecycle_hooks_exclude">lifecycle_hooks_exclude</a>, <a href="#npm_translate_lock-run_lifecycle_hooks">run_lifecycle_hooks</a>, <a href="#npm_translate_lock-lifecycle_hooks_envs">lifecycle_hooks_envs</a>,
+                   <a href="#npm_translate_lock-lifecycle_hooks_execution_requirements">lifecycle_hooks_execution_requirements</a>, <a href="#npm_translate_lock-bins">bins</a>, <a href="#npm_translate_lock-lifecycle_hooks_no_sandbox">lifecycle_hooks_no_sandbox</a>,
+                   <a href="#npm_translate_lock-verify_node_modules_ignored">verify_node_modules_ignored</a>, <a href="#npm_translate_lock-warn_on_unqualified_tarball_url">warn_on_unqualified_tarball_url</a>, <a href="#npm_translate_lock-pnpm_version">pnpm_version</a>)
 </pre>
 
-Wrapper macro around [npm_translate_lock_rule](#npm_translate_lock_rule)
+Repository rule to generate npm_import rules from pnpm lock file or from a package.json and yarn/npm lock file.
 
-This macro creates a "pnpm" repository.
-rules_js currently only uses this repository
+The pnpm lockfile format includes all the information needed to define npm_import rules,
+including the integrity hash, as calculated by the package manager.
+
+For more details see, https://github.com/pnpm/pnpm/blob/main/packages/lockfile-types/src/index.ts.
+
+Instead of manually declaring the `npm_imports`, this helper generates an external repository
+containing a helper starlark module `repositories.bzl`, which supplies a loadable macro
+`npm_repositories`. This macro creates an `npm_import` for each package.
+
+The generated repository also contains BUILD files declaring targets for the packages
+listed as `dependencies` or `devDependencies` in `package.json`, so you can declare
+dependencies on those packages without having to repeat version information.
+
+Bazel will only fetch the packages which are required for the requested targets to be analyzed.
+Thus it is performant to convert a very large pnpm-lock.yaml file without concern for
+users needing to fetch many unnecessary packages.
+
+**Setup**
+
+In `WORKSPACE`, call the repository rule pointing to your pnpm-lock.yaml file:
+
+```starlark
+load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
+
+# Read the pnpm-lock.yaml file to automate creation of remaining npm_import rules
+npm_translate_lock(
+    # Creates a new repository named "@npm_deps"
+    name = "npm_deps",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    # Recommended attribute that also checks the .bazelignore file
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+```
+
+Next, there are two choices, either load from the generated repo or check in the generated file.
+The tradeoffs are similar to
+[this rules_python thread](https://github.com/bazelbuild/rules_python/issues/608).
+
+1. Immediately load from the generated `repositories.bzl` file in `WORKSPACE`.
+This is similar to the
+[`pip_parse`](https://github.com/bazelbuild/rules_python/blob/main/docs/pip.md#pip_parse)
+rule in rules_python for example.
+It has the advantage of also creating aliases for simpler dependencies that don't require
+spelling out the version of the packages.
+However it causes Bazel to eagerly evaluate the `npm_translate_lock` rule for every build,
+even if the user didn't ask for anything JavaScript-related.
+
+```starlark
+# Following our example above, we named this "npm_deps"
+load("@npm_deps//:repositories.bzl", "npm_repositories")
+
+npm_repositories()
+```
+
+2. Check in the `repositories.bzl` file to version control, and load that instead.
+This makes it easier to ship a ruleset that has its own npm dependencies, as users don't
+have to install those dependencies. It also avoids eager-evaluation of `npm_translate_lock`
+for builds that don't need it.
+This is similar to the [`update-repos`](https://github.com/bazelbuild/bazel-gazelle#update-repos)
+approach from bazel-gazelle.
+
+In a BUILD file, use a rule like
+[write_source_files](https://github.com/aspect-build/bazel-lib/blob/main/docs/write_source_files.md)
+to copy the generated file to the repo and test that it stays updated:
+
+```starlark
+write_source_files(
+    name = "update_repos",
+    files = {
+        "repositories.bzl": "@npm_deps//:repositories.bzl",
+    },
+)
+```
+
+Then in `WORKSPACE`, load from that checked-in copy or instruct your users to do so.
+
+This macro creates a "pnpm" repository. rules_js currently only uses this repository
 when npm_package_lock or yarn_lock are used rather than pnpm_lock.
 Set pnpm_version to None to inhibit this repository creation.
 
 The user can create a "pnpm" repository before calling this in order to override.
+
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="npm_translate_lock-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="npm_translate_lock-npm_package_lock"></a>npm_package_lock |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="npm_translate_lock-yarn_lock"></a>yarn_lock |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="npm_translate_lock-pnpm_version"></a>pnpm_version |  <p align="center"> - </p>   |  <code>"7.9.1"</code> |
-| <a id="npm_translate_lock-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+| <a id="npm_translate_lock-name"></a>name |  The repository rule name   |  none |
+| <a id="npm_translate_lock-pnpm_lock"></a>pnpm_lock |  The pnpm-lock.yaml file.<br><br>Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.   |  <code>None</code> |
+| <a id="npm_translate_lock-package_json"></a>package_json |  The package.json file. From this file and the corresponding package-lock.json/yarn.lock file (specified with the npm_package_lock/yarn_lock attributes), a pnpm-lock.yaml file will be generated using <code>pnpm import</code>.<br><br>Note that *any* changes to the package.json file will invalidate the npm_translate_lock repository rule, causing it to re-run on the next invocation of Bazel.<br><br>Mandatory when using npm_package_lock or yarn_lock, otherwise must be unset.   |  <code>None</code> |
+| <a id="npm_translate_lock-npm_package_lock"></a>npm_package_lock |  The package-lock.json file written by <code>npm install</code>.<br><br>When set, the <code>package_json</code> attribute must be set as well. Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.   |  <code>None</code> |
+| <a id="npm_translate_lock-yarn_lock"></a>yarn_lock |  The yarn.lock file written by <code>yarn install</code>.<br><br>When set, the <code>package_json</code> attribute must be set as well. Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.   |  <code>None</code> |
+| <a id="npm_translate_lock-patches"></a>patches |  A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3") to a label list of patches to apply to the downloaded npm package. Paths in the patch file must start with <code>extract_tmp/package</code> where <code>package</code> is the top-level folder in the archive on npm. If the version is left out of the package name, the patch will be applied to every version of the npm package.   |  <code>{}</code> |
+| <a id="npm_translate_lock-patch_args"></a>patch_args |  A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3") to a label list arguments to pass to the patch tool. Defaults to -p0, but -p1 will usually be needed for patches generated by git. If patch args exists for a package as well as a package version, then the version-specific args will be appended to the args for the package.   |  <code>{}</code> |
+| <a id="npm_translate_lock-custom_postinstalls"></a>custom_postinstalls |  A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3") to a custom postinstall script to apply to the downloaded npm package after its lifecycle scripts runs. If the version is left out of the package name, the script will run on every version of the npm package. If a custom postinstall scripts exists for a package as well as for a specific version, the script for the versioned package will be appended with <code>&&</code> to the non-versioned package script.   |  <code>{}</code> |
+| <a id="npm_translate_lock-prod"></a>prod |  If true, only install dependencies.   |  <code>False</code> |
+| <a id="npm_translate_lock-public_hoist_packages"></a>public_hoist_packages |  A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3") to a list of Bazel packages in which to hoist the package to the top-level of the node_modules tree when linking.<br><br>This is similar to setting https://pnpm.io/npmrc#public-hoist-pattern in an .npmrc file outside of Bazel, however, wild-cards are not yet supported and npm_translate_lock will fail if there are multiple versions of a package that are to be hoisted.   |  <code>{}</code> |
+| <a id="npm_translate_lock-dev"></a>dev |  If true, only install devDependencies   |  <code>False</code> |
+| <a id="npm_translate_lock-no_optional"></a>no_optional |  If true, optionalDependencies are not installed   |  <code>False</code> |
+| <a id="npm_translate_lock-lifecycle_hooks_exclude"></a>lifecycle_hooks_exclude |  A list of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3") to not run lifecycle hooks on   |  <code>[]</code> |
+| <a id="npm_translate_lock-run_lifecycle_hooks"></a>run_lifecycle_hooks |  If true, runs preinstall, install and postinstall lifecycle hooks on npm packages if they exist   |  <code>True</code> |
+| <a id="npm_translate_lock-lifecycle_hooks_envs"></a>lifecycle_hooks_envs |  Environment variables applied to the preinstall, install and postinstall lifecycle hooks on npm packages. The environment variables can be defined per package by package name or globally using "*". Variables are declared as key/value pairs of the form "key=value".<br><br>For example:<br><br><pre><code> lifecycle_hooks_envs: {     "*": ["GLOBAL_KEY1=value1", "GLOBAL_KEY2=value2"],     "@foo/bar": ["PREBULT_BINARY=http://downloadurl"], } </code></pre>   |  <code>{}</code> |
+| <a id="npm_translate_lock-lifecycle_hooks_execution_requirements"></a>lifecycle_hooks_execution_requirements |  Execution requirements applied to the preinstall, install and postinstall lifecycle hooks on npm packages.<br><br>The execution requirements can be defined per package by package name or globally using "*".<br><br>For example:<br><br><pre><code> lifecycle_hooks_execution_requirements: {     "*": ["requires-network"],     "@foo/bar": ["no-sandbox"], } </code></pre>   |  <code>{}</code> |
+| <a id="npm_translate_lock-bins"></a>bins |  Binary files to create in <code>node_modules/.bin</code> for packages in this lock file.<br><br>For a given package, this is typically derived from the "bin" attribute in the package.json file of that package.<br><br>For example:<br><br><pre><code> bins = {     "@foo/bar": {         "foo": "./foo.js",         "bar": "./bar.js"     }, } </code></pre><br><br>In the future, this field may be automatically populated from information in the pnpm lock file. That feature is currently blocked on https://github.com/pnpm/pnpm/issues/5131.   |  <code>{}</code> |
+| <a id="npm_translate_lock-lifecycle_hooks_no_sandbox"></a>lifecycle_hooks_no_sandbox |  If True, a "no-sandbox" execution requirement is added to all lifecycle hooks.<br><br>Equivalent to adding <code>"*": ["no-sandbox"]</code> to lifecycle_hooks_execution_requirements.<br><br>This defaults to True to limit the overhead of sandbox creation and copying the output TreeArtifacts out of the sandbox.   |  <code>True</code> |
+| <a id="npm_translate_lock-verify_node_modules_ignored"></a>verify_node_modules_ignored |  node_modules folders in the source tree should be ignored by Bazel.<br><br>This points to a <code>.bazelignore</code> file to verify that all nested node_modules directories pnpm will create are listed.<br><br>See https://github.com/bazelbuild/bazel/issues/8106   |  <code>None</code> |
+| <a id="npm_translate_lock-warn_on_unqualified_tarball_url"></a>warn_on_unqualified_tarball_url |  Warn if an unqualified tarball url is encountered   |  <code>True</code> |
+| <a id="npm_translate_lock-pnpm_version"></a>pnpm_version |  pnpm version to use when generating the @pnpm repository. Set to None to not create this repository.   |  <code>"7.9.1"</code> |
 
 

--- a/npm/npm_import.bzl
+++ b/npm/npm_import.bzl
@@ -30,23 +30,243 @@ load("//npm/private:versions.bzl", "PNPM_VERSIONS")
 load("//npm/private:utils.bzl", _utils = "utils")
 load("//npm/private:npm_translate_lock.bzl", _npm_translate_lock_lib = "npm_translate_lock")
 
-npm_translate_lock_rule = repository_rule(
-    doc = _npm_translate_lock_lib.doc,
+_npm_translate_lock = repository_rule(
     implementation = _npm_translate_lock_lib.implementation,
     attrs = _npm_translate_lock_lib.attrs,
 )
 
 LATEST_PNPM_VERSION = PNPM_VERSIONS.keys()[-1]
 
-def npm_translate_lock(name, npm_package_lock = None, yarn_lock = None, pnpm_version = LATEST_PNPM_VERSION, **kwargs):
-    """Wrapper macro around [npm_translate_lock_rule](#npm_translate_lock_rule)
+def npm_translate_lock(
+        name,
+        pnpm_lock = None,
+        package_json = None,
+        npm_package_lock = None,
+        yarn_lock = None,
+        patches = {},
+        patch_args = {},
+        custom_postinstalls = {},
+        prod = False,
+        public_hoist_packages = {},
+        dev = False,
+        no_optional = False,
+        lifecycle_hooks_exclude = [],
+        run_lifecycle_hooks = True,
+        lifecycle_hooks_envs = {},
+        lifecycle_hooks_execution_requirements = {},
+        bins = {},
+        lifecycle_hooks_no_sandbox = True,
+        verify_node_modules_ignored = None,
+        warn_on_unqualified_tarball_url = True,
+        pnpm_version = LATEST_PNPM_VERSION):
+    """Repository rule to generate npm_import rules from pnpm lock file or from a package.json and yarn/npm lock file.
 
-    This macro creates a "pnpm" repository.
-    rules_js currently only uses this repository
+    The pnpm lockfile format includes all the information needed to define npm_import rules,
+    including the integrity hash, as calculated by the package manager.
+
+    For more details see, https://github.com/pnpm/pnpm/blob/main/packages/lockfile-types/src/index.ts.
+
+    Instead of manually declaring the `npm_imports`, this helper generates an external repository
+    containing a helper starlark module `repositories.bzl`, which supplies a loadable macro
+    `npm_repositories`. This macro creates an `npm_import` for each package.
+
+    The generated repository also contains BUILD files declaring targets for the packages
+    listed as `dependencies` or `devDependencies` in `package.json`, so you can declare
+    dependencies on those packages without having to repeat version information.
+
+    Bazel will only fetch the packages which are required for the requested targets to be analyzed.
+    Thus it is performant to convert a very large pnpm-lock.yaml file without concern for
+    users needing to fetch many unnecessary packages.
+
+    **Setup**
+
+    In `WORKSPACE`, call the repository rule pointing to your pnpm-lock.yaml file:
+
+    ```starlark
+    load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
+
+    # Read the pnpm-lock.yaml file to automate creation of remaining npm_import rules
+    npm_translate_lock(
+        # Creates a new repository named "@npm_deps"
+        name = "npm_deps",
+        pnpm_lock = "//:pnpm-lock.yaml",
+        # Recommended attribute that also checks the .bazelignore file
+        verify_node_modules_ignored = "//:.bazelignore",
+    )
+    ```
+
+    Next, there are two choices, either load from the generated repo or check in the generated file.
+    The tradeoffs are similar to
+    [this rules_python thread](https://github.com/bazelbuild/rules_python/issues/608).
+
+    1. Immediately load from the generated `repositories.bzl` file in `WORKSPACE`.
+    This is similar to the
+    [`pip_parse`](https://github.com/bazelbuild/rules_python/blob/main/docs/pip.md#pip_parse)
+    rule in rules_python for example.
+    It has the advantage of also creating aliases for simpler dependencies that don't require
+    spelling out the version of the packages.
+    However it causes Bazel to eagerly evaluate the `npm_translate_lock` rule for every build,
+    even if the user didn't ask for anything JavaScript-related.
+
+    ```starlark
+    # Following our example above, we named this "npm_deps"
+    load("@npm_deps//:repositories.bzl", "npm_repositories")
+
+    npm_repositories()
+    ```
+
+    2. Check in the `repositories.bzl` file to version control, and load that instead.
+    This makes it easier to ship a ruleset that has its own npm dependencies, as users don't
+    have to install those dependencies. It also avoids eager-evaluation of `npm_translate_lock`
+    for builds that don't need it.
+    This is similar to the [`update-repos`](https://github.com/bazelbuild/bazel-gazelle#update-repos)
+    approach from bazel-gazelle.
+
+    In a BUILD file, use a rule like
+    [write_source_files](https://github.com/aspect-build/bazel-lib/blob/main/docs/write_source_files.md)
+    to copy the generated file to the repo and test that it stays updated:
+
+    ```starlark
+    write_source_files(
+        name = "update_repos",
+        files = {
+            "repositories.bzl": "@npm_deps//:repositories.bzl",
+        },
+    )
+    ```
+
+    Then in `WORKSPACE`, load from that checked-in copy or instruct your users to do so.
+
+    This macro creates a "pnpm" repository. rules_js currently only uses this repository
     when npm_package_lock or yarn_lock are used rather than pnpm_lock.
     Set pnpm_version to None to inhibit this repository creation.
 
     The user can create a "pnpm" repository before calling this in order to override.
+
+    Args:
+        name: The repository rule name
+
+        pnpm_lock: The pnpm-lock.yaml file.
+
+            Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.
+
+        package_json: The package.json file. From this file and the corresponding package-lock.json/yarn.lock file
+            (specified with the npm_package_lock/yarn_lock attributes),
+            a pnpm-lock.yaml file will be generated using `pnpm import`.
+
+            Note that *any* changes to the package.json file will invalidate the npm_translate_lock
+            repository rule, causing it to re-run on the next invocation of Bazel.
+
+            Mandatory when using npm_package_lock or yarn_lock, otherwise must be unset.
+
+        npm_package_lock: The package-lock.json file written by `npm install`.
+
+            When set, the `package_json` attribute must be set as well.
+            Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.
+
+        yarn_lock: The yarn.lock file written by `yarn install`.
+
+            When set, the `package_json` attribute must be set as well.
+            Exactly one of [pnpm_lock, npm_package_lock, yarn_lock] should be set.
+
+        patches: A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")
+            to a label list of patches to apply to the downloaded npm package. Paths in the patch
+            file must start with `extract_tmp/package` where `package` is the top-level folder in
+            the archive on npm. If the version is left out of the package name, the patch will be
+            applied to every version of the npm package.
+
+        patch_args: A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")
+            to a label list arguments to pass to the patch tool. Defaults to -p0, but -p1 will
+            usually be needed for patches generated by git. If patch args exists for a package
+            as well as a package version, then the version-specific args will be appended to the args for the package.
+
+        custom_postinstalls: A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")
+            to a custom postinstall script to apply to the downloaded npm package after its lifecycle scripts runs.
+            If the version is left out of the package name, the script will run on every version of the npm package. If
+            a custom postinstall scripts exists for a package as well as for a specific version, the script for the versioned package
+            will be appended with `&&` to the non-versioned package script.
+
+        prod: If true, only install dependencies.
+
+        public_hoist_packages: A map of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")
+            to a list of Bazel packages in which to hoist the package to the top-level of the node_modules tree when linking.
+
+            This is similar to setting https://pnpm.io/npmrc#public-hoist-pattern in an .npmrc file outside of Bazel, however,
+            wild-cards are not yet supported and npm_translate_lock will fail if there are multiple versions of a package that
+            are to be hoisted.
+
+        dev: If true, only install devDependencies
+
+        no_optional: If true, optionalDependencies are not installed
+
+        lifecycle_hooks_exclude: A list of package names or package names with their version (e.g., "my-package" or "my-package@v1.2.3")
+            to not run lifecycle hooks on
+
+        run_lifecycle_hooks: If true, runs preinstall, install and postinstall lifecycle hooks on npm packages if they exist
+
+        lifecycle_hooks_envs: Environment variables applied to the preinstall, install and postinstall lifecycle hooks on npm packages.
+            The environment variables can be defined per package by package name or globally using "*".
+            Variables are declared as key/value pairs of the form "key=value".
+
+            For example:
+
+            ```
+            lifecycle_hooks_envs: {
+                "*": ["GLOBAL_KEY1=value1", "GLOBAL_KEY2=value2"],
+                "@foo/bar": ["PREBULT_BINARY=http://downloadurl"],
+            }
+            ```
+
+        lifecycle_hooks_execution_requirements: Execution requirements applied to the preinstall, install and postinstall
+            lifecycle hooks on npm packages.
+
+            The execution requirements can be defined per package by package name or globally using "*".
+
+            For example:
+
+            ```
+            lifecycle_hooks_execution_requirements: {
+                "*": ["requires-network"],
+                "@foo/bar": ["no-sandbox"],
+            }
+            ```
+
+        bins: Binary files to create in `node_modules/.bin` for packages in this lock file.
+
+            For a given package, this is typically derived from the "bin" attribute in
+            the package.json file of that package.
+
+            For example:
+
+            ```
+            bins = {
+                "@foo/bar": {
+                    "foo": "./foo.js",
+                    "bar": "./bar.js"
+                },
+            }
+            ```
+
+            In the future, this field may be automatically populated from information in the pnpm lock
+            file. That feature is currently blocked on https://github.com/pnpm/pnpm/issues/5131.
+
+        lifecycle_hooks_no_sandbox: If True, a "no-sandbox" execution requirement is added to all lifecycle hooks.
+
+            Equivalent to adding `"*": ["no-sandbox"]` to lifecycle_hooks_execution_requirements.
+
+            This defaults to True to limit the overhead of sandbox creation and copying the output
+            TreeArtifacts out of the sandbox.
+
+        verify_node_modules_ignored: node_modules folders in the source tree should be ignored by Bazel.
+
+            This points to a `.bazelignore` file to verify that all nested node_modules directories
+            pnpm will create are listed.
+
+            See https://github.com/bazelbuild/bazel/issues/8106
+
+        warn_on_unqualified_tarball_url: Warn if an unqualified tarball url is encountered
+
+        pnpm_version: pnpm version to use when generating the @pnpm repository. Set to None to not create this repository.
     """
     if pnpm_version != None and not native.existing_rule("pnpm"):
         npm_import(
@@ -57,11 +277,39 @@ def npm_translate_lock(name, npm_package_lock = None, yarn_lock = None, pnpm_ver
             version = pnpm_version,
         )
 
-    npm_translate_lock_rule(
+    # convert bins to a string_list_dict to satisfy attr type in repository rule
+    bins_string_list_dict = {}
+    if type(bins) != "dict":
+        fail("Expected bins to be a dict")
+    for key, value in bins.items():
+        if type(value) != "dict":
+            fail("Expected values in bins to be a dicts")
+        if key not in bins_string_list_dict:
+            bins_string_list_dict[key] = []
+        for value_key, value_value in value.items():
+            bins_string_list_dict[key].append("{}={}".format(value_key, value_value))
+
+    _npm_translate_lock(
         name = name,
+        pnpm_lock = pnpm_lock,
+        package_json = package_json,
         npm_package_lock = npm_package_lock,
         yarn_lock = yarn_lock,
-        **kwargs
+        patches = patches,
+        patch_args = patch_args,
+        custom_postinstalls = custom_postinstalls,
+        prod = prod,
+        public_hoist_packages = public_hoist_packages,
+        dev = dev,
+        no_optional = no_optional,
+        lifecycle_hooks_exclude = lifecycle_hooks_exclude,
+        run_lifecycle_hooks = run_lifecycle_hooks,
+        lifecycle_hooks_envs = lifecycle_hooks_envs,
+        lifecycle_hooks_execution_requirements = lifecycle_hooks_execution_requirements,
+        bins = bins_string_list_dict,
+        lifecycle_hooks_no_sandbox = lifecycle_hooks_no_sandbox,
+        verify_node_modules_ignored = verify_node_modules_ignored,
+        warn_on_unqualified_tarball_url = warn_on_unqualified_tarball_url,
     )
 
 _npm_import_links = repository_rule(
@@ -91,7 +339,8 @@ def npm_import(
         url = "",
         patch_args = ["-p0"],
         patches = [],
-        custom_postinstall = ""):
+        custom_postinstall = "",
+        bins = {}):
     """Import a single npm package into Bazel.
 
     Normally you'd want to use `npm_translate_lock` to import all your packages at once.
@@ -256,6 +505,24 @@ def npm_import(
 
         custom_postinstall: Custom string postinstall script to run on the installed npm package. Runs after any
             existing lifecycle hooks if `run_lifecycle_hooks` is True.
+
+        bins: Dictionary of `node_modules/.bin` binary files to create mapped to their node entry points.
+
+            This is typically derived from the "bin" attribute in the package.json
+            file of the npm package being linked.
+
+            For example:
+
+            ```
+            bins = {
+                "foo": "./foo.js",
+                "bar": "./bar.js",
+            }
+            ```
+
+            In the future, this field may be automatically populated by npm_translate_lock
+            from information in the pnpm lock file. That feature is currently blocked on
+            https://github.com/pnpm/pnpm/issues/5131.
     """
 
     # By convention, the `{name}` repository contains the actual npm
@@ -289,4 +556,5 @@ def npm_import(
         lifecycle_hooks_env = lifecycle_hooks_env,
         lifecycle_hooks_execution_requirements = lifecycle_hooks_execution_requirements,
         lifecycle_hooks_no_sandbox = lifecycle_hooks_no_sandbox,
+        bins = bins,
     )

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -179,7 +179,7 @@ def npm_link_imported_package_store(
         use_declare_symlink = select({{
             "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
             "//conditions:default": False,
-        }}),
+        }}),{maybe_bins}
     )
 
     # filegroup target that provides a single file which is
@@ -622,6 +622,9 @@ def _impl_links(rctx):
     if rctx.attr.lifecycle_hooks_no_sandbox and "no-sandbox" not in lifecycle_hooks_execution_requirements:
         lifecycle_hooks_execution_requirements["no-sandbox"] = "1"
 
+    maybe_bins = ("""
+        bins = %s,""" % starlark_codegen_utils.to_dict_attr(rctx.attr.bins, 3)) if len(rctx.attr.bins) > 0 else ""
+
     npm_link_package_bzl = [_LINK_JS_PACKAGE_TMPL.format(
         deps = starlark_codegen_utils.to_dict_attr(deps, 2, quote_key = False),
         link_default = "None" if rctx.attr.link_packages else "True",
@@ -642,6 +645,7 @@ def _impl_links(rctx):
         transitive_closure_pattern = str(transitive_closure_pattern),
         version = rctx.attr.version,
         virtual_store_root = utils.virtual_store_root,
+        maybe_bins = maybe_bins,
     )]
 
     generated_by_lines = _make_generated_by_lines(rctx.attr.package, rctx.attr.version)
@@ -658,6 +662,7 @@ _COMMON_ATTRS = {
 }
 
 _ATTRS_LINKS = dicts.add(_COMMON_ATTRS, {
+    "bins": attr.string_dict(),
     "deps": attr.string_dict(),
     "transitive_closure": attr.string_list_dict(),
     "lifecycle_build_target": attr.bool(),

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -54,8 +54,11 @@ sh_test(
     srcs = ["bin_test.sh"],
     args = ["$(NODE_PATH)"],
     data = [
-        ":node_modules/typescript",
+        # Test that node_modules/.bin binaries work in both the root package
+        # and in subpackages. The relative paths in the two are different since the
+        # actual node entry is in the virtual store which is in the root package.
         "//:node_modules/typescript",
+        ":node_modules/typescript",
         # This eager toolchain fetching could be cleaed up in the future
         "@nodejs_darwin_amd64//:node_files",
         "@nodejs_darwin_arm64//:node_files",

--- a/npm/private/test/bin_test.sh
+++ b/npm/private/test/bin_test.sh
@@ -10,3 +10,7 @@ PATH="$PWD/../$node_path:$PATH"
 
 node ./node_modules/typescript/bin/tsc --version
 node ./npm/private/test/node_modules/typescript/bin/tsc --version
+
+# test bin entries
+./node_modules/.bin/tsc --version
+./npm/private/test/node_modules/.bin/tsc --version

--- a/npm/private/test/repositories_checked.bzl
+++ b/npm/private/test/repositories_checked.bzl
@@ -11078,6 +11078,10 @@ def npm_repositories():
         transitive_closure = {
             "typescript": ["4.7.2"],
         },
+        bins = {
+            "tsc": "./bin/tsc",
+            "tsserver": "./bin/tsserver",
+        },
     )
 
     npm_import(


### PR DESCRIPTION
This will be most useful for integration tests that want to run `node_modules/.bin` tools directly.

Only generating bash binaries for now. Windows can use sh_test.

For now the bin entries must be entered manually.

In the future, this field may be automatically populated by translate_lock_file from information in the pnpm lock file. That feature is currently blocked on https://github.com/pnpm/pnpm/issues/5131.