### PR TITLE
fix: use less RAM via depsets instead of lists

### DIFF
--- a/js/libs.bzl
+++ b/js/libs.bzl
@@ -22,12 +22,17 @@ load(
     _gather_runfiles = "gather_runfiles",
     _gather_transitive_declarations = "gather_transitive_declarations",
     _gather_transitive_sources = "gather_transitive_sources",
+    _gather_npm_linked_packages_legacy = "gather_npm_linked_packages_legacy",
+    _gather_npm_package_stores_legacy = "gather_npm_package_stores_legacy",
+    _gather_transitive_declarations_legacy = "gather_transitive_declarations_legacy",
+    _gather_transitive_sources_legacy = "gather_transitive_sources_legacy",
 )
 
 js_binary_lib = _js_binary_lib
 js_library_lib = _js_library_lib
 
-js_lib_helpers = struct(
+# The updated versions of helpers, returning depsets where appropriate.
+js_lib_depset_helpers = struct(
     envs_for_log_level = _envs_for_log_level,
     gather_files_from_js_providers = _gather_files_from_js_providers,
     gather_npm_linked_packages = _gather_npm_linked_packages,
@@ -35,6 +40,17 @@ js_lib_helpers = struct(
     gather_runfiles = _gather_runfiles,
     gather_transitive_declarations = _gather_transitive_declarations,
     gather_transitive_sources = _gather_transitive_sources,
+    JS_LIBRARY_DATA_ATTR = _JS_LIBRARY_DATA_ATTR,
+)
+
+js_lib_helpers = struct(
+    envs_for_log_level = _envs_for_log_level,
+    gather_files_from_js_providers = _gather_files_from_js_providers,
+    gather_npm_linked_packages = _gather_npm_linked_packages_legacy,
+    gather_npm_package_stores = _gather_npm_package_stores_legacy,
+    gather_runfiles = _gather_runfiles,
+    gather_transitive_declarations = _gather_transitive_declarations_legacy,
+    gather_transitive_sources = _gather_transitive_sources_legacy,
     JS_LIBRARY_DATA_ATTR = _JS_LIBRARY_DATA_ATTR,
 )
 

--- a/js/private/js_info.bzl
+++ b/js/private/js_info.bzl
@@ -3,26 +3,26 @@
 JsInfo = provider(
     doc = "Encapsulates information provided by rules in rules_js and derivative rule sets",
     fields = {
-        "declarations": "A list of declaration files produced by the target",
-        "npm_linked_packages": "A list of NpmLinkedPackageInfo providers that are dependencies of this target",
-        "npm_package_stores": "A list of NpmPackageStoreInfo providers from npm dependencies of this target to use as direct dependencies when linking downstream npm_package targets with npm_link_package",
-        "sources": "A list of source files produced by the target",
-        "transitive_declarations": "A list of declaration files produced by the target and the target's transitive deps",
-        "transitive_npm_linked_packages": "A list of NpmLinkedPackageInfo providers that are dependencies of this target and the target's transitive deps",
-        "transitive_npm_package_stores": "A list of NpmPackageStoreInfo providers from npm dependencies of this target and the target's transitive dependencies to use as direct dependencies when linking downstream npm_package targets with npm_link_package",
-        "transitive_sources": "A list of source files produced by the target and the target's transitive deps",
+        "declarations": "A depset of declaration files produced by the target",
+        "npm_linked_packages": "A depset of NpmLinkedPackageInfo providers that are dependencies of this target",
+        "npm_package_stores": "A depset of NpmPackageStoreInfo providers from npm dependencies of this target to use as direct dependencies when linking downstream npm_package targets with npm_link_package",
+        "sources": "A depset of source files produced by the target",
+        "transitive_declarations": "A depset of declaration files produced by the target and the target's transitive deps",
+        "transitive_npm_linked_packages": "A depset of NpmLinkedPackageInfo providers that are dependencies of this target and the target's transitive deps",
+        "transitive_npm_package_stores": "A depset of NpmPackageStoreInfo providers from npm dependencies of this target and the target's transitive dependencies to use as direct dependencies when linking downstream npm_package targets with npm_link_package",
+        "transitive_sources": "A depset of source files produced by the target and the target's transitive deps",
     },
 )
 
 def js_info(
-        declarations = [],
-        npm_linked_packages = [],
-        npm_package_stores = [],
-        sources = [],
-        transitive_declarations = [],
-        transitive_npm_linked_packages = [],
-        transitive_npm_package_stores = [],
-        transitive_sources = []):
+        declarations = None,
+        npm_linked_packages = None,
+        npm_package_stores = None,
+        sources = None,
+        transitive_declarations = None,
+        transitive_npm_linked_packages = None,
+        transitive_npm_package_stores = None,
+        transitive_sources = None):
     """Construct a JsInfo
 
     Args:
@@ -38,13 +38,31 @@ def js_info(
     Returns:
         A JsInfo provider
     """
+    # These are for legacy-users of js_info, who might pass in lists instead of depsets.
+    if type(declarations) == "list":
+      declarations = depset(declarations)
+    if type(npm_linked_packages) == "list":
+      npm_linked_packages = depset(npm_linked_packages)
+    if type(npm_package_stores) == "list":
+      npm_package_stores = depset(npm_package_stores)
+    if type(sources) == "list":
+      sources = depset(sources)
+    if type(transitive_declarations) == "list":
+      transitive_declarations = depset(transitive_declarations)
+    if type(transitive_npm_linked_packages) == "list":
+      transitive_npm_linked_packages = depset(transitive_npm_linked_packages)
+    if type(transitive_npm_package_stores) == "list":
+      transitive_npm_package_stores = depset(transitive_npm_package_stores)
+    if type(transitive_sources) == "list":
+      transitive_sources = depset(transitive_sources)
+
     return JsInfo(
-        declarations = declarations,
-        npm_linked_packages = npm_linked_packages,
-        npm_package_stores = npm_package_stores,
-        sources = sources,
-        transitive_declarations = transitive_declarations,
-        transitive_npm_linked_packages = transitive_npm_linked_packages,
-        transitive_npm_package_stores = transitive_npm_package_stores,
-        transitive_sources = transitive_sources,
+        declarations = declarations or depset(),
+        npm_linked_packages = npm_linked_packages or depset(),
+        npm_package_stores = npm_package_stores or depset(),
+        sources = sources or depset(),
+        transitive_declarations = transitive_declarations or depset(),
+        transitive_npm_linked_packages = transitive_npm_linked_packages or depset(),
+        transitive_npm_package_stores = transitive_npm_package_stores or depset(),
+        transitive_sources = transitive_sources or depset(),
     )

--- a/js/private/js_library_helpers.bzl
+++ b/js/private/js_library_helpers.bzl
@@ -33,15 +33,26 @@ def gather_transitive_sources(sources, targets):
     Returns:
         Depset of transitive sources
     """
+    if type(sources) == "list":
+        sources = depset(sources)
     transitive_deps = [
         target[JsInfo].transitive_sources
         for target in targets
         if JsInfo in target
     ]
-    if type(sources) == "list":
-      return depset(sources, transitive = transitive_deps)
-    else:
-      return depset([], transitive = [sources] + transitive_deps)
+    return depset([], transitive = [sources] + transitive_deps)
+
+def gather_transitive_sources_legacy(sources, targets):
+    """Gathers transitive sources from a list of direct sources and targets
+
+    Args:
+        sources: list or depset of direct sources which should be included in `transitive_sources`
+        targets: list of targets to gather `transitive_sources` from `JsInfo`
+
+    Returns:
+        List of transitive sources
+    """
+    return gather_transitive_sources(sources, targets).to_list()
 
 def gather_transitive_declarations(declarations, targets):
     """Gathers transitive sources from a list of direct sources and targets
@@ -53,15 +64,26 @@ def gather_transitive_declarations(declarations, targets):
     Returns:
         Depset of transitive sources
     """
+    if type(declarations) == "list":
+        declarations = depset(declarations)
     transitive_deps = [
         target[JsInfo].transitive_declarations
         for target in targets
         if JsInfo in target
     ]
-    if type(declarations) == "list":
-      return depset(declarations, transitive = transitive_deps)
-    else:
-      return depset([], transitive = [declarations] + transitive_deps)
+    return depset([], transitive = [declarations] + transitive_deps)
+
+def gather_transitive_declarations_legacy(declarations, targets):
+    """Gathers transitive sources from a list of direct sources and targets
+
+    Args:
+        declarations: list or depset of direct sources which should be included in `transitive_declarations`
+        targets: List of targets to gather `transitive_declarations` from `JsInfo`
+
+    Returns:
+        List of transitive sources
+    """
+    return gather_transitive_declarations(declarations, targets).to_list()
 
 def gather_npm_linked_packages(srcs, deps):
     """Gathers npm linked packages from a list of srcs and deps targets
@@ -91,6 +113,22 @@ def gather_npm_linked_packages(srcs, deps):
     return struct(
         direct = depset([], transitive = npm_linked_packages),
         transitive = transitive_npm_linked_packages,
+    )
+
+def gather_npm_linked_packages_legacy(srcs, deps):
+    """Gathers npm linked packages from a list of srcs and deps targets
+
+    Args:
+        srcs: source targets; these typically come from the `srcs` and/or `data` attributes of a rule
+        deps: dep targets; these typically come from the `deps` attribute of a rule
+
+    Returns:
+        A `struct(direct, transitive)` of direct and transitive npm linked packages gathered
+    """
+    pkgs = gather_npm_linked_packages(srcs, deps)
+    return struct(
+        direct = pkgs.direct.to_list(),
+        transitive = pkgs.transitive.to_list(),
     )
 
 def gather_npm_package_stores(targets):
@@ -126,6 +164,21 @@ def gather_npm_package_stores(targets):
     return struct(
         direct = depset([], transitive = npm_package_stores),
         transitive = depset([], transitive = transitive_npm_package_stores),
+    )
+
+def gather_npm_package_stores_legacy(targets):
+    """Gathers NpmPackageStoreInfo providers from the list of targets
+
+    Args:
+        targets: the list of targets to gather from
+
+    Returns:
+        A `struct(direct, transitive)` of direct and transitive npm package stores gathered
+    """
+    pkgs = gather_npm_package_stores(targets)
+    return struct(
+        direct = pkgs.direct.to_list(),
+        transitive = pkgs.transitive.to_list(),
     )
 
 def gather_runfiles(ctx, sources, data, deps):

--- a/js/private/test/js_library_test.bzl
+++ b/js/private/test/js_library_test.bzl
@@ -26,12 +26,12 @@ def _declarations_test_impl(ctx):
     target_under_test = analysistest.target_under_test(env)
 
     # declarations should only have the source declarations
-    declarations = target_under_test[JsInfo].declarations
+    declarations = target_under_test[JsInfo].declarations.to_list()
     asserts.equals(env, 1, len(declarations))
     asserts.true(env, declarations[0].path.find("/importing.d.ts") != -1)
 
     # declarations should only have the source declarations
-    transitive_declarations = target_under_test[JsInfo].transitive_declarations
+    transitive_declarations = target_under_test[JsInfo].transitive_declarations.to_list()
     asserts.equals(env, 1, len(transitive_declarations))
     asserts.true(env, transitive_declarations[0].path.find("/importing.d.ts") != -1)
 
@@ -45,11 +45,11 @@ def _declarations_empty_srcs_test_impl(ctx):
     target_under_test = analysistest.target_under_test(env)
 
     # declarations should only have the source declarations, in this case 0
-    declarations = target_under_test[JsInfo].declarations
+    declarations = target_under_test[JsInfo].declarations.to_list()
     asserts.equals(env, 0, len(declarations))
 
     # transitive_declarations should contain additional indirect deps
-    transitive_declarations = target_under_test[JsInfo].transitive_declarations
+    transitive_declarations = target_under_test[JsInfo].transitive_declarations.to_list()
     asserts.true(env, len(transitive_declarations) > len(declarations))
 
     # types OutputGroupInfo should be the same as direct declarations

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -61,7 +61,7 @@ def _impl(ctx):
 
     files = utils.make_symlink(ctx, root_symlink_path, virtual_store_directory)
 
-    transitive_files = files + store_info.transitive_files
+    transitive_files = depset(files, transitive = [store_info.transitive_files])
 
     npm_linked_package_info = NpmLinkedPackageInfo(
         label = ctx.label,
@@ -69,7 +69,7 @@ def _impl(ctx):
         package = store_info.package,
         version = store_info.version,
         store_info = store_info,
-        files = files,
+        files = depset(files),
         transitive_files = transitive_files,
     )
 
@@ -78,8 +78,8 @@ def _impl(ctx):
             files = depset(files),
         ),
         js_info(
-            npm_linked_packages = [npm_linked_package_info],
-            transitive_npm_linked_packages = [npm_linked_package_info],
+            npm_linked_packages = depset([npm_linked_package_info]),
+            transitive_npm_linked_packages = depset([npm_linked_package_info]),
         ),
     ]
     if OutputGroupInfo in ctx.attr.src:

--- a/npm/private/npm_linked_package_info.bzl
+++ b/npm/private/npm_linked_package_info.bzl
@@ -8,7 +8,7 @@ NpmLinkedPackageInfo = provider(
         "package": "name of this npm package",
         "version": "version of this npm package",
         "store_info": "the NpmPackageStoreInfo of the linked npm package store that is backing this link",
-        "files": "list of files that are part of the linked npm package",
-        "transitive_files": "list of the transitive files that are part of the linked npm package and its transitive deps",
+        "files": "depset of files that are part of the linked npm package",
+        "transitive_files": "depset of the transitive files that are part of the linked npm package and its transitive deps",
     },
 )

--- a/npm/private/npm_package_info.bzl
+++ b/npm/private/npm_package_info.bzl
@@ -6,6 +6,6 @@ NpmPackageInfo = provider(
         "package": "name of this npm package",
         "version": "version of this npm package",
         "directory": "the output directory (a TreeArtifact) that contains the package sources",
-        "npm_package_stores": "A list of NpmPackageStoreInfo providers from npm dependencies of the package and the packages's transitive deps to use as direct dependencies when linking with npm_link_package",
+        "npm_package_stores": "A depset of NpmPackageStoreInfo providers from npm dependencies of the package and the packages's transitive deps to use as direct dependencies when linking with npm_link_package",
     },
 )

--- a/npm/private/npm_package_internal.bzl
+++ b/npm/private/npm_package_internal.bzl
@@ -33,7 +33,7 @@ def _impl(ctx):
             package = ctx.attr.package,
             version = ctx.attr.version,
             directory = dst,
-            npm_package_stores = [],
+            npm_package_stores = depset([]),
         ),
     ]
 

--- a/npm/private/npm_package_store_info.bzl
+++ b/npm/private/npm_package_store_info.bzl
@@ -10,9 +10,9 @@ NpmPackageStoreInfo = provider(
         "root_package": "package that this npm package store is linked at",
         "package": "name of this npm package",
         "version": "version of this npm package",
-        "ref_deps": "list of dependency npm_package_store ref targets",
+        "ref_deps": "dictionary of dependency npm_package_store ref targets",
         "virtual_store_directory": "the TreeArtifact of this npm package's virtual store location",
-        "files": "list of files that are part of the npm package",
-        "transitive_files": "list of the files that are part of the npm package and its transitive deps",
+        "files": "depset of files that are part of the npm package",
+        "transitive_files": "depset of the files that are part of the npm package and its transitive deps",
     },
 )


### PR DESCRIPTION
When testing out these rules (and `aspect-build/rules_ts`) with a large package dependency tree in our monorepo, our bazel servers were OOMing pretty heavily. I finally got it to build by giving the heap 12GB of room (and it took most of it).

Looking at the heap dump, it seemed like the majority of the space was eaten up by `StarlarkLists` existing under the `JsInfo` and `NpmPackageStoreInfo` providers. One example had ~29,000,000 elements but only ~7000 unique. Another had ~15,000,000 elements with still just ~7000 unique.

A rules dump from Bazel also showed the following for `npm_*` rules:
```
RULE                             COUNT     ACTIONS          BYTES         EACH  
npm_package_store_internal       3,380       6,244     17,596,040        5,205  
npm_package_internal             1,685           0      1,311,080          778  
npm_link_package_store             170         170    370,766,376    2,180,978  
npm_package_store                   95       1,309        524,544        5,521  
npm_package                         90         129      2,127,552       23,639  
```

After this, our servers did not OOM, but build completed, and the rules dump has the following values for `npm_*` rules:
```
RULE                             COUNT     ACTIONS          BYTES         EACH  
npm_package_store_internal       3,380       6,244     17,564,960        5,196  
npm_package_internal             1,685           0      2,621,816        1,555  
npm_link_package_store             167         167        524,376        3,139  
npm_package_store                   92         978        524,264        5,698  
npm_package                         87         113      1,959,624       22,524  
```

A quick visual interpretation of the diff here:
<img width="877" alt="Screen Shot 2022-08-16 at 1 57 09 PM" src="https://user-images.githubusercontent.com/197306/184947440-c6d7cd2e-1fa7-46dc-9654-3835113e734c.png">
50% would be no change. I'm unsure why `npm_package_internal` nearly doubled, although I'd expect that to be just because the build actually completed (so they were fully populated), whereas you can see the `npm_link_package_store` is now negligible compared to before.