### PR TITLE
fix: fix node_modules/.bin script pathing when pnpm workspace is not at the root of the WORKSPACE

### DIFF
--- a/e2e/pnpm_workspace/BUILD.bazel
+++ b/e2e/pnpm_workspace/BUILD.bazel
@@ -1,3 +1,18 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages(name = "node_modules")
+
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+    args = ["$(NODE_PATH)"],
+    data = [
+        "//:node_modules/typescript",
+        # This eager toolchain fetching could be cleaed up in the future
+        "@nodejs_darwin_amd64//:node_files",
+        "@nodejs_darwin_arm64//:node_files",
+        "@nodejs_linux_amd64//:node_files",
+        "@nodejs_linux_arm64//:node_files",
+    ],
+    toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
+)

--- a/e2e/pnpm_workspace/WORKSPACE
+++ b/e2e/pnpm_workspace/WORKSPACE
@@ -20,6 +20,13 @@ load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
 
 npm_translate_lock(
     name = "npm",
+    bins = {
+        # derived from "bin" attribute in node_modules/typescript/package.json
+        "typescript": {
+            "tsc": "./bin/tsc",
+            "tsserver": "./bin/tsserver",
+        },
+    },
     pnpm_lock = "//:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
 )

--- a/e2e/pnpm_workspace/package.json
+++ b/e2e/pnpm_workspace/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
+        "typescript": "4.7.4",
         "@aspect-test/a": "5.0.0"
     },
     "devDependencies": {

--- a/e2e/pnpm_workspace/pnpm-lock.yaml
+++ b/e2e/pnpm_workspace/pnpm-lock.yaml
@@ -7,8 +7,10 @@ importers:
       '@aspect-test/a': 5.0.0
       '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.2
+      typescript: 4.7.4
     dependencies:
       '@aspect-test/a': 5.0.0
+      typescript: 4.7.4
     optionalDependencies:
       '@aspect-test/c': 2.0.2
     devDependencies:
@@ -165,6 +167,12 @@ packages:
 
   /@aspect-test/h/1.0.0:
     resolution: {integrity: sha512-U1LStvh2QPmdQN7rlR0PTZZ1btTTcjiHxVmq5SvTxIRgIaJMCIsxcS5ghrd71H/JIwnJOmhI7BEQN3n6Hq9WSw==}
+    hasBin: true
+    dev: false
+
+  /typescript/4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+    engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
 

--- a/e2e/pnpm_workspace/test.sh
+++ b/e2e/pnpm_workspace/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset
+
+# put node on the path
+node_path=$(dirname "$1")
+if [[ "$node_path" == external/* ]]; then
+    node_path="${node_path:9}"
+fi
+PATH="$PWD/../$node_path:$PATH"
+
+node ./node_modules/typescript/bin/tsc --version
+./node_modules/.bin/tsc --version

--- a/e2e/pnpm_workspace_rerooted/BUILD.bazel
+++ b/e2e/pnpm_workspace_rerooted/BUILD.bazel
@@ -1,0 +1,14 @@
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+    args = ["$(NODE_PATH)"],
+    data = [
+        "//root:node_modules/typescript",
+        # This eager toolchain fetching could be cleaed up in the future
+        "@nodejs_darwin_amd64//:node_files",
+        "@nodejs_darwin_arm64//:node_files",
+        "@nodejs_linux_amd64//:node_files",
+        "@nodejs_linux_arm64//:node_files",
+    ],
+    toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
+)

--- a/e2e/pnpm_workspace_rerooted/WORKSPACE
+++ b/e2e/pnpm_workspace_rerooted/WORKSPACE
@@ -18,6 +18,13 @@ load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
 
 npm_translate_lock(
     name = "npm",
+    bins = {
+        # derived from "bin" attribute in node_modules/typescript/package.json
+        "typescript": {
+            "tsc": "./bin/tsc",
+            "tsserver": "./bin/tsserver",
+        },
+    },
     pnpm_lock = "//root:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
 )

--- a/e2e/pnpm_workspace_rerooted/root/package.json
+++ b/e2e/pnpm_workspace_rerooted/root/package.json
@@ -1,3 +1,6 @@
 {
-    "private": true
+    "private": true,
+    "dependencies": {
+        "typescript": "4.7.4"
+    }
 }

--- a/e2e/pnpm_workspace_rerooted/root/pnpm-lock.yaml
+++ b/e2e/pnpm_workspace_rerooted/root/pnpm-lock.yaml
@@ -3,18 +3,21 @@ lockfileVersion: 5.4
 importers:
 
   .:
-    specifiers: {}
+    specifiers:
+      typescript: 4.7.4
+    dependencies:
+      typescript: 4.7.4
 
   ../app/a:
     specifiers:
       '@aspect-test/a': 5.0.0
-      '@aspect-test/b': 1.0.0
+      '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.2
       '@aspect-test/g': 1.0.0
       '@lib/a': workspace:*
     dependencies:
       '@aspect-test/a': 5.0.0
-      '@aspect-test/b': 1.0.0
+      '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.2
       '@aspect-test/g': 1.0.0
       '@lib/a': link:../../lib/a
@@ -22,14 +25,14 @@ importers:
   ../app/b:
     specifiers:
       '@aspect-test/a': 1.0.0
-      '@aspect-test/b': 1.0.0
+      '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.2
       '@aspect-test/h': 1.0.0
       '@lib/b': workspace:*
       '@lib/b_alias': workspace:@lib/b@*
     dependencies:
       '@aspect-test/a': 1.0.0
-      '@aspect-test/b': 1.0.0
+      '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.2
       '@aspect-test/h': 1.0.0
       '@lib/b': link:../../lib/b
@@ -38,13 +41,13 @@ importers:
   ../app/c:
     specifiers:
       '@aspect-test/a': 5.0.0
-      '@aspect-test/b': 1.0.0
+      '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.2
       '@aspect-test/g': 1.0.0
       '@lib/c': file:../../lib/c
     dependencies:
       '@aspect-test/a': 5.0.0
-      '@aspect-test/b': 1.0.0
+      '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.2
       '@aspect-test/g': 1.0.0
       '@lib/c': file:../lib/c
@@ -90,6 +93,15 @@ packages:
       '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
     dev: false
 
+  /@aspect-test/a/5.0.2:
+    resolution: {integrity: sha512-bURS+F0+tS2XPxUPbrqsTZxIre1U5ZglwzDqcOCrU7MbxuRrkO24hesgTMGJldCglwL/tiEGRlvdMndlPgRdNw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/b': 5.0.2
+      '@aspect-test/c': 2.0.2
+      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.2
+    dev: false
+
   /@aspect-test/b/1.0.0:
     resolution: {integrity: sha512-IlLB5ZYT2Guryz+hQrgl/IgRMutfJfa78TuznRhaM5o+aLbmeHx0hvC83sc6dACLC1h/Bix0fimZBf/vz9j3Cw==}
     hasBin: true
@@ -105,6 +117,15 @@ packages:
       '@aspect-test/a': 5.0.0
       '@aspect-test/c': 2.0.0
       '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
+    dev: false
+
+  /@aspect-test/b/5.0.2:
+    resolution: {integrity: sha512-I8wnJV5J0h8ui1O3K6XPq1qGHKopTl/OnvkSfor7uJ9yRCm2Qv6Tf2LsTgR2xzkgiwhA4iBwdYFwecwinF244w==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/a': 5.0.2
+      '@aspect-test/c': 2.0.2
+      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.2
     dev: false
 
   /@aspect-test/c/1.0.0:
@@ -143,6 +164,15 @@ packages:
       '@aspect-test/c': 2.0.0
     dev: false
 
+  /@aspect-test/d/2.0.0_@aspect-test+c@2.0.2:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 2.0.2
+    dev: false
+
   /@aspect-test/e/1.0.0:
     resolution: {integrity: sha512-GyAxHYKN650db+xnimHnL2LPz65ilmQsVhCasWA7drDNQn/rfmPiEVMzjRiS7m46scXIERaBmiJMzYDf0bIUbA==}
     hasBin: true
@@ -160,6 +190,12 @@ packages:
 
   /@aspect-test/h/1.0.0:
     resolution: {integrity: sha512-U1LStvh2QPmdQN7rlR0PTZZ1btTTcjiHxVmq5SvTxIRgIaJMCIsxcS5ghrd71H/JIwnJOmhI7BEQN3n6Hq9WSw==}
+    hasBin: true
+    dev: false
+
+  /typescript/4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+    engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
 

--- a/e2e/pnpm_workspace_rerooted/test.sh
+++ b/e2e/pnpm_workspace_rerooted/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset
+
+# put node on the path
+node_path=$(dirname "$1")
+if [[ "$node_path" == external/* ]]; then
+    node_path="${node_path:9}"
+fi
+PATH="$PWD/../$node_path:$PATH"
+
+node ./root/node_modules/typescript/bin/tsc --version
+./root/node_modules/.bin/tsc --version

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -5,7 +5,6 @@ load(":utils.bzl", "utils")
 load(":npm_linked_package_info.bzl", "NpmLinkedPackageInfo")
 load(":npm_package_store_info.bzl", "NpmPackageStoreInfo")
 load("//js:providers.bzl", "JsInfo", "js_info")
-load("@aspect_bazel_lib//lib:paths.bzl", "relative_file")
 
 _DOC = """Links an npm package that is backed by an npm_package_store into a node_modules tree as a direct dependency.
 
@@ -95,7 +94,10 @@ def _impl(ctx):
     files = utils.make_symlink(ctx, root_symlink_path, virtual_store_directory)
 
     for bin_name, bin_path in ctx.attr.bins.items():
-        path_to_root = relative_file(store_info.root_package, ctx.label.package + "/file")
+        if ctx.label.package:
+            path_to_root = "/".join([".."] * len(ctx.label.package.split("/")))
+        else:
+            path_to_root = "."
         bin_file = ctx.actions.declare_file(paths.join("node_modules", ".bin", bin_name))
         bin_path = paths.normalize(paths.join("../..", path_to_root, virtual_store_directory.short_path, bin_path))
         ctx.actions.write(


### PR DESCRIPTION
Missed this case in the original impl