### PR TITLE
fix: reduce memory usage from duplicate elements in rules_js providers

### DIFF
--- a/js/private/js_binary_helpers.bzl
+++ b/js/private/js_binary_helpers.bzl
@@ -43,7 +43,7 @@ def gather_files_from_js_providers(
         include_transitive_sources,
         include_declarations,
         include_npm_linked_packages):
-    """Gathers a list of depsets from JsInfo and NpmPackageStoreInfo providers.
+    """Gathers files from JsInfo and NpmPackageStoreInfo providers.
 
     Args:
         targets: list of target to gather from
@@ -95,4 +95,6 @@ def gather_files_from_js_providers(
             if NpmPackageStoreInfo in target
             for item in target[NpmPackageStoreInfo].transitive_files
         ])
-    return files
+
+    # pass list through a depset to remove duplicates
+    return depset(files).to_list()

--- a/js/private/js_binary_helpers.bzl
+++ b/js/private/js_binary_helpers.bzl
@@ -3,6 +3,7 @@
 
 load(":js_info.bzl", "JsInfo")
 load("//npm:providers.bzl", "NpmPackageStoreInfo")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 LOG_LEVELS = {
     "fatal": 1,
@@ -97,4 +98,4 @@ def gather_files_from_js_providers(
         ])
 
     # pass list through a depset to remove duplicates
-    return depset(files).to_list()
+    return sets.to_list(sets.make(files))

--- a/js/private/js_info.bzl
+++ b/js/private/js_info.bzl
@@ -1,5 +1,7 @@
 "JsInfo provider"
 
+load("@bazel_skylib//lib:sets.bzl", "sets")
+
 JsInfo = provider(
     doc = "Encapsulates information provided by rules in rules_js and derivative rule sets",
     fields = {
@@ -62,12 +64,12 @@ def js_info(
     """
     return JsInfo(
         # pass lists through depsets to remove duplicates
-        declarations = depset(declarations).to_list(),
-        npm_linked_packages = depset(npm_linked_packages).to_list(),
-        npm_package_stores = depset(npm_package_stores).to_list(),
-        sources = depset(sources).to_list(),
-        transitive_declarations = depset(transitive_declarations).to_list(),
-        transitive_npm_linked_packages = depset(transitive_npm_linked_packages).to_list(),
-        transitive_npm_package_stores = depset(transitive_npm_package_stores).to_list(),
-        transitive_sources = depset(transitive_sources).to_list(),
+        declarations = sets.to_list(sets.make(declarations)),
+        npm_linked_packages = sets.to_list(sets.make(npm_linked_packages)),
+        npm_package_stores = sets.to_list(sets.make(npm_package_stores)),
+        sources = sets.to_list(sets.make(sources)),
+        transitive_declarations = sets.to_list(sets.make(transitive_declarations)),
+        transitive_npm_linked_packages = sets.to_list(sets.make(transitive_npm_linked_packages)),
+        transitive_npm_package_stores = sets.to_list(sets.make(transitive_npm_package_stores)),
+        transitive_sources = sets.to_list(sets.make(transitive_sources)),
     )

--- a/js/private/js_info.bzl
+++ b/js/private/js_info.bzl
@@ -14,6 +14,26 @@ JsInfo = provider(
     },
 )
 
+def js_info_complete(js_info_partial):
+    """Construct a complete JsInfo from a partial JsInfo
+
+    Args:
+        js_info_partial: A partial JsInfo with some but not necessarily all fields populated
+
+    Returns:
+        A JsInfo provider
+    """
+    return JsInfo(
+        declarations = getattr(js_info_partial, "declarations", []),
+        npm_linked_packages = getattr(js_info_partial, "npm_linked_packages", []),
+        npm_package_stores = getattr(js_info_partial, "npm_package_stores", []),
+        sources = getattr(js_info_partial, "sources", []),
+        transitive_declarations = getattr(js_info_partial, "transitive_declarations", []),
+        transitive_npm_linked_packages = getattr(js_info_partial, "transitive_npm_linked_packages", []),
+        transitive_npm_package_stores = getattr(js_info_partial, "transitive_npm_package_stores", []),
+        transitive_sources = getattr(js_info_partial, "transitive_sources", []),
+    )
+
 def js_info(
         declarations = [],
         npm_linked_packages = [],
@@ -24,6 +44,8 @@ def js_info(
         transitive_npm_package_stores = [],
         transitive_sources = []):
     """Construct a JsInfo
+
+    Lists are passed through depsets to remove duplicates.
 
     Args:
         declarations: See JsInfo documentation
@@ -39,12 +61,13 @@ def js_info(
         A JsInfo provider
     """
     return JsInfo(
-        declarations = declarations,
-        npm_linked_packages = npm_linked_packages,
-        npm_package_stores = npm_package_stores,
-        sources = sources,
-        transitive_declarations = transitive_declarations,
-        transitive_npm_linked_packages = transitive_npm_linked_packages,
-        transitive_npm_package_stores = transitive_npm_package_stores,
-        transitive_sources = transitive_sources,
+        # pass lists through depsets to remove duplicates
+        declarations = depset(declarations).to_list(),
+        npm_linked_packages = depset(npm_linked_packages).to_list(),
+        npm_package_stores = depset(npm_package_stores).to_list(),
+        sources = depset(sources).to_list(),
+        transitive_declarations = depset(transitive_declarations).to_list(),
+        transitive_npm_linked_packages = depset(transitive_npm_linked_packages).to_list(),
+        transitive_npm_package_stores = depset(transitive_npm_package_stores).to_list(),
+        transitive_sources = depset(transitive_sources).to_list(),
     )

--- a/js/private/js_library_helpers.bzl
+++ b/js/private/js_library_helpers.bzl
@@ -3,6 +3,7 @@
 
 load(":js_binary_helpers.bzl", "gather_files_from_js_providers")
 load(":js_info.bzl", "JsInfo")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 # This attribute is exposed in //js:libs.bzl so that downstream build rules can use it
 JS_LIBRARY_DATA_ATTR = attr.label_list(
@@ -42,7 +43,7 @@ def gather_transitive_sources(sources, targets):
     transitive_sources = [file for file in transitive_sources if file]
 
     # pass list through a depset to remove duplicates
-    return depset(transitive_sources).to_list()
+    return sets.to_list(sets.make(transitive_sources))
 
 def gather_transitive_declarations(declarations, targets):
     """Gathers transitive sources from a list of direct sources and targets
@@ -63,7 +64,7 @@ def gather_transitive_declarations(declarations, targets):
     transitive_declarations = [file for file in transitive_declarations if file]
 
     # pass list through a depset to remove duplicates
-    return depset(transitive_declarations).to_list()
+    return sets.to_list(sets.make(transitive_declarations))
 
 def gather_npm_linked_packages(srcs, deps):
     """Gathers npm linked packages from a list of srcs and deps targets
@@ -96,8 +97,8 @@ def gather_npm_linked_packages(srcs, deps):
 
     return struct(
         # pass lists through depsets to remove duplicates
-        direct = depset(npm_linked_packages).to_list(),
-        transitive = depset(transitive_npm_linked_packages).to_list(),
+        direct = sets.to_list(sets.make(npm_linked_packages)),
+        transitive = sets.to_list(sets.make(transitive_npm_linked_packages)),
     )
 
 def gather_npm_package_stores(targets):
@@ -142,8 +143,8 @@ def gather_npm_package_stores(targets):
 
     return struct(
         # pass lists through depsets to remove duplicates
-        direct = depset(npm_package_stores).to_list(),
-        transitive = depset(transitive_npm_package_stores).to_list(),
+        direct = sets.to_list(sets.make(npm_package_stores)),
+        transitive = sets.to_list(sets.make(transitive_npm_package_stores)),
     )
 
 def gather_runfiles(ctx, sources, data, deps):

--- a/js/private/js_library_helpers.bzl
+++ b/js/private/js_library_helpers.bzl
@@ -40,7 +40,9 @@ def gather_transitive_sources(sources, targets):
         for item in target[JsInfo].transitive_sources
     ]
     transitive_sources = [file for file in transitive_sources if file]
-    return transitive_sources
+
+    # pass list through a depset to remove duplicates
+    return depset(transitive_sources).to_list()
 
 def gather_transitive_declarations(declarations, targets):
     """Gathers transitive sources from a list of direct sources and targets
@@ -59,7 +61,9 @@ def gather_transitive_declarations(declarations, targets):
         for item in target[JsInfo].transitive_declarations
     ]
     transitive_declarations = [file for file in transitive_declarations if file]
-    return transitive_declarations
+
+    # pass list through a depset to remove duplicates
+    return depset(transitive_declarations).to_list()
 
 def gather_npm_linked_packages(srcs, deps):
     """Gathers npm linked packages from a list of srcs and deps targets
@@ -91,8 +95,9 @@ def gather_npm_linked_packages(srcs, deps):
     transitive_npm_linked_packages = [package for package in transitive_npm_linked_packages if package]
 
     return struct(
-        direct = npm_linked_packages,
-        transitive = transitive_npm_linked_packages,
+        # pass lists through depsets to remove duplicates
+        direct = depset(npm_linked_packages).to_list(),
+        transitive = depset(transitive_npm_linked_packages).to_list(),
     )
 
 def gather_npm_package_stores(targets):
@@ -128,16 +133,17 @@ def gather_npm_package_stores(targets):
         if JsInfo in target:
             if hasattr(target[JsInfo], "npm_linked_packages"):
                 for package in target[JsInfo].npm_linked_packages:
-                    if package.store_info and package.store_info not in npm_package_stores:
+                    if package.store_info:
                         npm_package_stores.append(package.store_info)
             if hasattr(target[JsInfo], "transitive_npm_linked_packages"):
                 for package in target[JsInfo].transitive_npm_linked_packages:
-                    if package.store_info and package.store_info not in transitive_npm_package_stores:
+                    if package.store_info:
                         transitive_npm_package_stores.append(package.store_info)
 
     return struct(
-        direct = npm_package_stores,
-        transitive = transitive_npm_package_stores,
+        # pass lists through depsets to remove duplicates
+        direct = depset(npm_package_stores).to_list(),
+        transitive = depset(transitive_npm_package_stores).to_list(),
     )
 
 def gather_runfiles(ctx, sources, data, deps):

--- a/js/providers.bzl
+++ b/js/providers.bzl
@@ -4,7 +4,9 @@ load(
     "//js/private:js_info.bzl",
     _JsInfo = "JsInfo",
     _js_info = "js_info",
+    _js_info_complete = "js_info_complete",
 )
 
 JsInfo = _JsInfo
 js_info = _js_info
+js_info_complete = _js_info_complete

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -5,6 +5,7 @@ load(":utils.bzl", "utils")
 load(":npm_linked_package_info.bzl", "NpmLinkedPackageInfo")
 load(":npm_package_store_info.bzl", "NpmPackageStoreInfo")
 load("//js:providers.bzl", "JsInfo", "js_info_complete")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 _DOC = """Links an npm package that is backed by an npm_package_store into a node_modules tree as a direct dependency.
 
@@ -119,7 +120,7 @@ def _impl(ctx):
         store_info = store_info,
         # pass lists through depsets to remove duplicates
         files = files_depset.to_list(),
-        transitive_files = depset(transitive_files).to_list(),
+        transitive_files = sets.to_list(sets.make(transitive_files)),
     )
 
     providers = [

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -13,6 +13,7 @@ load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//js:providers.bzl", "JsInfo")
 load(":npm_package_info.bzl", "NpmPackageInfo")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 _DOC = """A rule that packages sources into a directory (a tree artifact) and provides an `NpmPackageInfo`.
 
@@ -180,7 +181,7 @@ def _impl(ctx):
             version = ctx.attr.version,
             directory = dst,
             # pass list through a depset to remove duplicates
-            npm_package_stores = depset(npm_package_stores).to_list(),
+            npm_package_stores = sets.to_list(sets.make(npm_package_stores)),
         ),
     ]
 

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -179,7 +179,8 @@ def _impl(ctx):
             package = ctx.attr.package,
             version = ctx.attr.version,
             directory = dst,
-            npm_package_stores = npm_package_stores,
+            # pass list through a depset to remove duplicates
+            npm_package_stores = depset(npm_package_stores).to_list(),
         ),
     ]
 

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -5,6 +5,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":utils.bzl", "utils")
 load(":npm_package_info.bzl", "NpmPackageInfo")
 load(":npm_package_store_info.bzl", "NpmPackageStoreInfo")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 _DOC = """Defines a npm package that is linked into a node_modules tree.
 
@@ -275,7 +276,7 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
             virtual_store_directory = virtual_store_directory,
             # pass lists through depsets to remove duplicates
             files = files_depset.to_list(),
-            transitive_files = depset(transitive_files).to_list(),
+            transitive_files = sets.to_list(sets.make(transitive_files)),
         ),
     ]
     if virtual_store_directory:

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -261,9 +261,11 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
         for item in npm_package_store.transitive_files
     ])
 
+    files_depset = depset(files)
+
     providers = [
         DefaultInfo(
-            files = depset(files),
+            files = files_depset,
         ),
         NpmPackageStoreInfo(
             root_package = ctx.label.package,
@@ -271,8 +273,9 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
             version = version,
             ref_deps = direct_ref_deps,
             virtual_store_directory = virtual_store_directory,
-            files = files,
-            transitive_files = transitive_files,
+            # pass lists through depsets to remove duplicates
+            files = files_depset.to_list(),
+            transitive_files = depset(transitive_files).to_list(),
         ),
     ]
     if virtual_store_directory:


### PR DESCRIPTION
As reported in https://github.com/aspect-build/rules_js/pull/391, memory is pilling up in providers lists due to duplicate items. In particular from `npm_link_package_store` rules likely due to the `transitive_files` list.

This attempts to resolve the issue without any breaking API changes by de-duping all lists in JsInfo, NpmPackageInfo, NpmPackageStoreInfo & NpmLinkedPackageInfo providers as well as in the js_library_helpers gather_* functions.

For rules_js 2.0 we should consider switching some or all of these to depsets. The NpmPackageInfo, NpmPackageStoreInfo & NpmLinkedPackageInfo should probably have been depsets from the start. JsInfo we chose lists so that it would be easier to iterate over files in rules without having to collapse a deeply nested depset which can be expensive.