### PR TITLE
ci: run PR workflow on main repo and not forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,15 @@ on:
     # Triggers the workflow on push or pull request events but only for the main branch
     push:
         branches: [main]
-    pull_request:
+    pull_request_target:
         branches: [main]
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
+
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+permissions:
+  contents: read
 
 jobs:
     test:


### PR DESCRIPTION
... can this PR test the ability for forked PRs to run? 🤔 (I'll assume not)