### PR TITLE
doc caveat with pnpm-workspace.yaml and auto import

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,6 +46,12 @@ then you are hitting https://github.com/bazelbuild/bazel/issues/15605
 The workaround is to patch the package.json of any offending packages in npm_translate_lock, see https://github.com/aspect-build/rules_js/issues/148#issuecomment-1144378565.
 Or, if a newer version of the package has fixed the duplicate keys, you could upgrade.
 
+If the error looks like this: `ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@my-workspace%2Ffoo: Not Found - 404`, where `foo` is a package living in a workspace in your local 
+codebase and it's being declared [`pnpm-workspace.yaml`](https://pnpm.io/pnpm-workspace_yaml) and that you are relying on the `yarn_lock` attribute of `npm_translate_lock`, then
+you're hitting a caveat of the migration process. 
+
+The workaround is to generate the `pnpm-lock.yaml` on your own as mentioned in the migration guide and to use the `pnpm_lock` attribute of `npm_translate_lock` instead. 
+
 ## In my monorepo, can Bazel output multiple packages under one dist/ folder?
 
 Many projects have a structure like the following:

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -62,6 +62,10 @@ rather than `npm` or `yarn` when changing dependency versions or adding new depe
 If needed, you might have both the pnpm lockfile and your legacy one checked into the repo during a migration window.
 You'll have to avoid version skew between the two files during that time.
 
+Please note that using the `yarn_lock` attributes of `npm_translate_lock` has caveat of not supporting the [`pnpm-workspace.yaml`](https://pnpm.io/pnpm-workspace_yaml) which is needed by 
+`pnpm` to declare workspaces. Therefore, if your project need this, the only option is to migrate to `pnpm` immediately and use solely the 
+`pnpm_lock` attribute of `npm_translate_lock`.
+
 ## Test whether pnpm is working
 
 A few packages have bugs which rely on "hoisting" behavior in yarn or npm, where undeclared dependencies can be loaded because they happen to be installed in an ancestor folder under `node_modules`.


### PR DESCRIPTION
Following up to our Slack conversation, here is a small addition to the migration guide that mentions how `npm_translate_lock` attributes interacts with `pnpm-workspace.yaml`.

Indirect follow-up of https://github.com/aspect-build/rules_js/issues/396 