### PR TITLE
test: align commonjs + esm npm_link_package tests

### DIFF
--- a/e2e/npm_link_package-esm/BUILD.bazel
+++ b/e2e/npm_link_package-esm/BUILD.bazel
@@ -7,7 +7,6 @@ npm_link_all_packages(name = "node_modules")
 npm_link_package(
     name = "node_modules/@e2e/lib",
     src = "//lib",
-    visibility = ["//visibility:public"],
 )
 
 npm_link_package(

--- a/e2e/npm_link_package-esm/lib/BUILD.bazel
+++ b/e2e/npm_link_package-esm/lib/BUILD.bazel
@@ -6,6 +6,11 @@ npm_package(
         "index.mjs",
         "package.json",
     ],
+    data = [
+        # uvu is a runtime dependency of this package and should be linked into its direct dependencies
+        # by the downstream npm_link_package
+        "//:node_modules/uvu",
+    ],
     package = "@e2e/lib",
     visibility = ["//visibility:public"],
 )

--- a/e2e/npm_link_package-esm/lib/index.mjs
+++ b/e2e/npm_link_package-esm/lib/index.mjs
@@ -1,5 +1,6 @@
 import packageJson from './package.json';
-
+import * as assert from 'uvu/assert';
+assert.is(2 + 2, 4);
 export const id = () =>
         `${packageJson.name}@${
             packageJson.version ? packageJson.version : '0.0.0'

--- a/e2e/npm_link_package-esm/package.json
+++ b/e2e/npm_link_package-esm/package.json
@@ -2,7 +2,8 @@
     "name": "simple",
     "dependencies": {
         "@aspect-test/a": "5.0.0",
-        "sharp": "0.31.0"
+        "sharp": "0.31.0",
+        "uvu": "0.5.6"
     },
     "devDependencies": {
         "@aspect-test/b": "5.0.2"

--- a/e2e/npm_link_package-esm/pnpm-lock.yaml
+++ b/e2e/npm_link_package-esm/pnpm-lock.yaml
@@ -1,20 +1,22 @@
 lockfileVersion: 5.4
 
-specifiers:
-  '@aspect-test/a': 5.0.0
-  '@aspect-test/b': 5.0.0
-  '@aspect-test/c': 2.0.2
-  sharp: ^0.30.7
+importers:
 
-dependencies:
-  '@aspect-test/a': 5.0.0
-  sharp: 0.30.7
-
-optionalDependencies:
-  '@aspect-test/c': 2.0.2
-
-devDependencies:
-  '@aspect-test/b': 5.0.0
+  .:
+    specifiers:
+      '@aspect-test/a': 5.0.0
+      '@aspect-test/b': 5.0.2
+      '@aspect-test/c': 2.0.2
+      sharp: 0.30.7
+      uvu: 0.5.3
+    dependencies:
+      '@aspect-test/a': 5.0.0
+      sharp: 0.30.7
+      uvu: 0.5.3
+    optionalDependencies:
+      '@aspect-test/c': 2.0.2
+    devDependencies:
+      '@aspect-test/b': 5.0.2
 
 packages:
 
@@ -25,6 +27,16 @@ packages:
       '@aspect-test/b': 5.0.0
       '@aspect-test/c': 1.0.0
       '@aspect-test/d': 2.0.0_@aspect-test+c@1.0.0
+    dev: false
+
+  /@aspect-test/a/5.0.2:
+    resolution: {integrity: sha512-bURS+F0+tS2XPxUPbrqsTZxIre1U5ZglwzDqcOCrU7MbxuRrkO24hesgTMGJldCglwL/tiEGRlvdMndlPgRdNw==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/b': 5.0.2
+      '@aspect-test/c': 2.0.2
+      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.2
+    dev: true
 
   /@aspect-test/b/5.0.0:
     resolution: {integrity: sha512-MyIW6gHL3ds0BmDTOktorHLJUya5eZLGZlOxsKN2M9c3DWp+p1pBrA6KLQX1iq9BciryhpKwl82IAxP4jG52kw==}
@@ -33,23 +45,33 @@ packages:
       '@aspect-test/a': 5.0.0
       '@aspect-test/c': 2.0.0
       '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.0
+    dev: false
+
+  /@aspect-test/b/5.0.2:
+    resolution: {integrity: sha512-I8wnJV5J0h8ui1O3K6XPq1qGHKopTl/OnvkSfor7uJ9yRCm2Qv6Tf2LsTgR2xzkgiwhA4iBwdYFwecwinF244w==}
+    hasBin: true
+    dependencies:
+      '@aspect-test/a': 5.0.2
+      '@aspect-test/c': 2.0.2
+      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.2
+    dev: true
 
   /@aspect-test/c/1.0.0:
     resolution: {integrity: sha512-UorLD4TFr9CWFeYbUd5etaxSo201fYEFR+rSxXytfzefX41EWCBabsXhdhvXjK6v/HRuo1y1I1NiW2P3/bKJeA==}
     hasBin: true
     requiresBuild: true
+    dev: false
 
   /@aspect-test/c/2.0.0:
     resolution: {integrity: sha512-vRuHi/8zxZ+IRGdgdX4VoMNFZrR9UqO87yQx61IGIkjgV7QcKUeu5jfvIE3Mr0WNQeMdO1JpyTx1UUpsE73iug==}
     hasBin: true
     requiresBuild: true
+    dev: false
 
   /@aspect-test/c/2.0.2:
     resolution: {integrity: sha512-rMJmd3YBvY7y0jh+2m72TiAhe6dVKjMMNFFVOXFCbM233m7lsG4cq970H1C8rUsc3AcA5E/cEHlxSVffHlHD2Q==}
     hasBin: true
     requiresBuild: true
-    dev: false
-    optional: true
 
   /@aspect-test/d/2.0.0_@aspect-test+c@1.0.0:
     resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
@@ -58,6 +80,7 @@ packages:
       '@aspect-test/c': x.x.x
     dependencies:
       '@aspect-test/c': 1.0.0
+    dev: false
 
   /@aspect-test/d/2.0.0_@aspect-test+c@2.0.0:
     resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
@@ -66,6 +89,16 @@ packages:
       '@aspect-test/c': x.x.x
     dependencies:
       '@aspect-test/c': 2.0.0
+    dev: false
+
+  /@aspect-test/d/2.0.0_@aspect-test+c@2.0.2:
+    resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
+    hasBin: true
+    peerDependencies:
+      '@aspect-test/c': x.x.x
+    dependencies:
+      '@aspect-test/c': 2.0.2
+    dev: true
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -128,9 +161,19 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: false
 
+  /dequal/2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /detect-libc/2.0.1:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
+    dev: false
+
+  /diff/5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+    engines: {node: '>=0.3.1'}
     dev: false
 
   /end-of-stream/1.4.4:
@@ -149,7 +192,7 @@ packages:
     dev: false
 
   /github-from-package/0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+    resolution: {integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=}
     dev: false
 
   /ieee754/1.2.1:
@@ -166,6 +209,11 @@ packages:
 
   /is-arrayish/0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+    dev: false
+
+  /kleur/4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
     dev: false
 
   /lru-cache/6.0.0:
@@ -186,6 +234,11 @@ packages:
 
   /mkdirp-classic/0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: false
+
+  /mri/1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
     dev: false
 
   /napi-build-utils/1.0.2:
@@ -252,6 +305,13 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    dev: false
+
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
     dev: false
 
   /safe-buffer/5.2.1:
@@ -338,6 +398,17 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false
+
+  /uvu/0.5.3:
+    resolution: {integrity: sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      dequal: 2.0.3
+      diff: 5.1.0
+      kleur: 4.1.5
+      sade: 1.8.1
     dev: false
 
   /wrappy/1.0.2:

--- a/e2e/npm_link_package-esm/src/BUILD.bazel
+++ b/e2e/npm_link_package-esm/src/BUILD.bazel
@@ -4,7 +4,7 @@ js_binary(
     name = "main",
     args = ["foo"],
     node_options = [
-        "--experimental-json-modules",
+        "--experimental-json-modules",  # Required for importing .json from .mjs
     ],
     data = [
         "//:node_modules/@aspect-test/a",
@@ -22,7 +22,7 @@ js_test(
     name = "test",
     args = ["foo"],
     node_options = [
-        "--experimental-json-modules",
+        "--experimental-json-modules",  # Required for importing .json from .mjs
     ],
     data = [
         "//:node_modules/@aspect-test/a",

--- a/e2e/npm_link_package-esm/wrapper-lib/index.mjs
+++ b/e2e/npm_link_package-esm/wrapper-lib/index.mjs
@@ -1,3 +1,6 @@
 export const id = () => 'wrapper-lib';
+// NOTE: .mjs does not support index files unless it is alongside a package.json
+// containing an `"exports": {".": "index.mjs"}`.
+// See: https://nodejs.org/api/packages.html#exports
 export {id as subdirId} from './subdir/index.mjs';
 export {id as libId} from '@e2e/lib';


### PR DESCRIPTION
Closes #434

Adds the test using `uvu` and adds some comments clarifying things. Also trying to keep the diff between the folders to only be the cjs vs esm changes.