### PR TITLE
Revert "fix: bcr actions not triggering"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,3 @@ jobs:
                   # Use GH feature to populate the changelog automatically
                   generate_release_notes: true
                   body_path: release_notes.txt
-                  token: ${{ secrets.JASON_RELEASE_TOKEN }}


### PR DESCRIPTION
This reverts commit 6ca32d5199ddc0bf19bd704f591030dc1468ca5f.

The Publish to BCR app shouldn't require credentials