### PR TITLE
Mark intermediary targets in package_json.bzl as manual

### DIFF
--- a/js/dev_repositories.bzl
+++ b/js/dev_repositories.bzl
@@ -35,9 +35,8 @@ def rules_js_dev_dependencies():
     # see https://github.com/bazelbuild/bazel-skylib/issues/250
     http_archive(
         name = "bazel_skylib",
-        sha256 = "07b4117379dde7ab382345c3b0f5edfc6b7cff6c93756eac63da121e0bbcc5de",
-        strip_prefix = "bazel-skylib-1.1.1",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.1.1.tar.gz"],
+        sha256 = "af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz"],
     )
 
     http_archive(

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -200,7 +200,8 @@ def js_run_binary(
             include_transitive_sources = include_transitive_sources,
             include_declarations = include_declarations,
             include_npm_linked_packages = include_npm_linked_packages,
-            tags = kwargs.get("tags"),
+            # Always tag the target manual since we should only build it when the final target is built.
+            tags = kwargs.get("tags", []) + ["manual"],
         )
         extra_srcs.append(":{}".format(js_filegroup_name))
 
@@ -210,7 +211,8 @@ def js_run_binary(
         _copy_to_bin(
             name = copy_to_bin_name,
             srcs = srcs,
-            tags = kwargs.get("tags"),
+            # Always tag the target manual since we should only build it when the final target is built.
+            tags = kwargs.get("tags", []) + ["manual"],
         )
         extra_srcs.append(":{}".format(copy_to_bin_name))
 

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -252,11 +252,13 @@ def _{bin_name}_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@{link_workspace}//{root_package}:{{}}/dir".format(store_target_name),
         path = "{bin_path}",
+        tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
         data = ["@{link_workspace}//{root_package}:{{}}".format(store_target_name)],
+        tags = ["manual"],
     )
     _js_run_binary(
         name = name,
@@ -271,6 +273,7 @@ def _{bin_name}_test_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@{link_workspace}//{root_package}:{{}}/dir".format(store_target_name),
         path = "{bin_path}",
+        tags = ["manual"],
     )
     _js_test(
         name = name,
@@ -285,6 +288,7 @@ def _{bin_name}_binary_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@{link_workspace}//{root_package}:{{}}/dir".format(store_target_name),
         path = "{bin_path}",
+        tags = ["manual"],
     )
     _js_binary(
         name = name,

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -74,6 +74,3 @@ sh_test(
     ],
     toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
 )
-
-
-

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -6,6 +6,7 @@ load(":yaml_tests.bzl", "yaml_tests")
 load(":utils_tests.bzl", "utils_tests")
 load(":ini_test.bzl", "ini_tests")
 load(":pkg_glob_tests.bzl", "pkg_glob_tests")
+load(":generated_pkg_json_test.bzl", "generated_pkg_json_test")
 
 # gazelle:exclude *_checked.bzl
 
@@ -23,6 +24,8 @@ transitive_closure_tests(name = "test_transitive_closure")
 translate_lock_tests(name = "test_translate_lock")
 
 yaml_tests(name = "test_yaml")
+
+generated_pkg_json_test(name = "test_generated_pkg_json")
 
 write_source_files(
     name = "write_npm_translate_lock",
@@ -71,3 +74,6 @@ sh_test(
     ],
     toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
 )
+
+
+

--- a/npm/private/test/empty.js
+++ b/npm/private/test/empty.js
@@ -1,0 +1,1 @@
+// Intentionally empty

--- a/npm/private/test/generated_pkg_json_test.bzl
+++ b/npm/private/test/generated_pkg_json_test.bzl
@@ -1,0 +1,71 @@
+"""Unit tests for generated package_json macros
+See https://docs.bazel.build/versions/main/skylark/testing.html#for-testing-starlark-utilities
+"""
+
+load(":package_json_checked.bzl", rollup_bin = "bin")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "loadingtest")
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
+
+def _get_functions_under_test_and_their_args():
+    return {
+        "rollup": {
+            "name": "__rollup-target",
+            "outs": ["foo.js"],
+            "srcs": [":empty.js"],
+            "chdir": native.package_name(),
+            "args": ["empty.js", "--format", "cjs", "--file", "foo.js"],
+        },
+        "rollup_test": {
+            "name": "__rollup-test",
+        },
+        "rollup_binary": {
+            "name": "__rollup-binary",
+        },
+    }
+
+def _target_names_used_for_test():
+    return [kwargs["name"] for _, kwargs in _get_functions_under_test_and_their_args().items()]
+
+def test_only_expected_bin_struct_methods(env, bin_struct):
+    """Ensure that no new methods have been added to the exported bin method.
+
+    If new methods were added or removed, the above struct defining how to
+    construct a target using each method will need to be updated to add
+    a new example usecase or removed.
+    """
+
+    relevant_methods = [m for m in sorted(dir(bin_struct)) if m.startswith("rollup")]
+
+    # If new generated methods are added to the package_json.bzl file, then the tests here will need
+    # to be updated to call those macros.
+    loadingtest.equals(env, "only_expected_methods", sorted(_get_functions_under_test_and_their_args().keys()), sorted(relevant_methods))
+
+def test_intermediate_targets_tagged_manual(env):
+    """Ensure all targets besides the final output target are tagged manual"""
+
+    existing_rules = native.existing_rules()
+    relevant_targets = [t for t in existing_rules.keys() if t.startswith("__rollup")]
+
+    expected_not_manual = _target_names_used_for_test()
+    generated_targets = sets.to_list(sets.difference(
+        sets.make(relevant_targets),
+        sets.make(expected_not_manual),
+    ))
+
+    for generated_target in generated_targets:
+        tagged_manual = "manual" in existing_rules[generated_target]["tags"]
+        loadingtest.equals(env, generated_target + "_tagged_manual", tagged_manual, True)
+
+def generated_pkg_json_test(name):
+    # Call each of our methods to construct targets as needed by the tests
+    for function_name, kwargs in _get_functions_under_test_and_their_args().items():
+        function = getattr(rollup_bin, function_name)
+        if function == None:
+            fail("{} does not exist in exported bin struct".format(function_name))
+
+        function(**kwargs)
+
+    env = loadingtest.make(name)
+
+    test_only_expected_bin_struct_methods(env, rollup_bin)
+    test_intermediate_targets_tagged_manual(env)

--- a/npm/private/test/generated_pkg_json_test.bzl
+++ b/npm/private/test/generated_pkg_json_test.bzl
@@ -3,23 +3,25 @@ See https://docs.bazel.build/versions/main/skylark/testing.html#for-testing-star
 """
 
 load(":package_json_checked.bzl", rollup_bin = "bin")
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "loadingtest")
+load("@bazel_skylib//lib:unittest.bzl", "loadingtest")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
+
+_TEST_TARGET_PREFIX="__rollup"
 
 def _get_functions_under_test_and_their_args():
     return {
         "rollup": {
-            "name": "__rollup-target",
+            "name": _TEST_TARGET_PREFIX + "-target",
             "outs": ["foo.js"],
             "srcs": [":empty.js"],
             "chdir": native.package_name(),
             "args": ["empty.js", "--format", "cjs", "--file", "foo.js"],
         },
         "rollup_test": {
-            "name": "__rollup-test",
+            "name": _TEST_TARGET_PREFIX + "-test",
         },
         "rollup_binary": {
-            "name": "__rollup-binary",
+            "name": _TEST_TARGET_PREFIX + "-binary",
         },
     }
 
@@ -44,7 +46,7 @@ def test_intermediate_targets_tagged_manual(env):
     """Ensure all targets besides the final output target are tagged manual"""
 
     existing_rules = native.existing_rules()
-    relevant_targets = [t for t in existing_rules.keys() if t.startswith("__rollup")]
+    relevant_targets = [t for t in existing_rules.keys() if t.startswith(_TEST_TARGET_PREFIX)]
 
     expected_not_manual = _target_names_used_for_test()
     generated_targets = sets.to_list(sets.difference(

--- a/npm/private/test/package_json_checked.bzl
+++ b/npm/private/test/package_json_checked.bzl
@@ -9,11 +9,13 @@ def _rollup_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@//:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
+        tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
         data = ["@//:{}".format(store_target_name)],
+        tags = ["manual"],
     )
     _js_run_binary(
         name = name,
@@ -28,6 +30,7 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@//:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
+        tags = ["manual"],
     )
     _js_test(
         name = name,
@@ -42,6 +45,7 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@//:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
+        tags = ["manual"],
     )
     _js_binary(
         name = name,

--- a/npm/private/test/package_json_with_dashes_checked.bzl
+++ b/npm/private/test/package_json_with_dashes_checked.bzl
@@ -9,11 +9,13 @@ def _webpack_bundle_analyzer_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@//:{}/dir".format(store_target_name),
         path = "lib/bin/analyzer.js",
+        tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
         data = ["@//:{}".format(store_target_name)],
+        tags = ["manual"],
     )
     _js_run_binary(
         name = name,
@@ -28,6 +30,7 @@ def _webpack_bundle_analyzer_test_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@//:{}/dir".format(store_target_name),
         path = "lib/bin/analyzer.js",
+        tags = ["manual"],
     )
     _js_test(
         name = name,
@@ -42,6 +45,7 @@ def _webpack_bundle_analyzer_binary_internal(name, link_root_name, **kwargs):
         name = "%s__entry_point" % name,
         directory = "@//:{}/dir".format(store_target_name),
         path = "lib/bin/analyzer.js",
+        tags = ["manual"],
     )
     _js_binary(
         name = name,


### PR DESCRIPTION
I noticed that building and testing a directory with some targets tagged manual still led to npm packages being fetched. This was due to the intermediary `*__entry_point` and `*__js_binary` targets not being tagged manual.

Update `npm/private/npm_import.bzl` to tag those targets as manual and add a test that calls each of the methods of the exported `bin` struct to ensure that the only non-manual-tagged targets are the ones we asked for from the macros.

The functional change in this PR is the smallest part - most of it is new tests to ensure there are no regressions. This was the first time I've used a starlark testing library, so seeking any feedback on if the tests should be written differently. One area that I think may be worth changing would be to put the tests into their own package so that I don't need to do filtering based on the prefix of the target names that I defined.

I also needed to update the skylib dev dependency to get access to `loadingtest` in `@bazel_skylib//lib:unittest.bz`.