### PR TITLE
feat: supply a @pnpm//:pnpm binary

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,13 +30,9 @@ Try running Bazel with `--experimental_check_output_files=false` so that your ed
 
 ## Can I use bazel-managed pnpm?
 
-Yes, but it's a bit clumsy right now.
+Yes, just run `bazel run -- @pnpm//:pnpm` followed by the usual arguments to pnpm.
 
-First, make sure you fetched it: `bazel fetch @pnpm//:*`
-
-Then run `bazel run -- @nodejs_host//:node $(bazel info output_base)/external/pnpm/package/bin/pnpm.cjs`
-
-You can use this recipe to make sure your developers run the exact same pnpm and node versions that Bazel does.
+Document this as a good practice so that all developers run the exact same pnpm and node versions that Bazel does.
 
 ## Why can't Bazel fetch an npm package?
 
@@ -46,11 +42,11 @@ then you are hitting https://github.com/bazelbuild/bazel/issues/15605
 The workaround is to patch the package.json of any offending packages in npm_translate_lock, see https://github.com/aspect-build/rules_js/issues/148#issuecomment-1144378565.
 Or, if a newer version of the package has fixed the duplicate keys, you could upgrade.
 
-If the error looks like this: `ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@my-workspace%2Ffoo: Not Found - 404`, where `foo` is a package living in a workspace in your local 
+If the error looks like this: `ERR_PNPM_FETCH_404 GET https://registry.npmjs.org/@my-workspace%2Ffoo: Not Found - 404`, where `foo` is a package living in a workspace in your local
 codebase and it's being declared [`pnpm-workspace.yaml`](https://pnpm.io/pnpm-workspace_yaml) and that you are relying on the `yarn_lock` attribute of `npm_translate_lock`, then
-you're hitting a caveat of the migration process. 
+you're hitting a caveat of the migration process.
 
-The workaround is to generate the `pnpm-lock.yaml` on your own as mentioned in the migration guide and to use the `pnpm_lock` attribute of `npm_translate_lock` instead. 
+The workaround is to generate the `pnpm-lock.yaml` on your own as mentioned in the migration guide and to use the `pnpm_lock` attribute of `npm_translate_lock` instead.
 
 ## In my monorepo, can Bazel output multiple packages under one dist/ folder?
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -64,8 +64,8 @@ If you're ready to switch your repo to pnpm, then you'll use the `pnpm_lock` att
    you could just run `npx pnpm install --lockfile-only` which generates a new lockfile.
 
 > To make those commands shorter, we rely on the `npx` binary already on your machine.
-> However you could use the Bazel-managed one from rules_nodejs instead, like so:
-> `bazel run -- @nodejs_host//:npx_bin pnpm@latest i --lockfile-only`
+> However you could use the Bazel-managed node and pnpm instead, like so:
+> `bazel run -- @pnpm//:pnpm i --lockfile-only`
 
 The new `pnpm-lock.yaml` file needs to be updated by engineers on the team as well,
 so when you're ready to switch over to rules_js, you'll have to train them to run `pnpm`

--- a/docs/npm_import.md
+++ b/docs/npm_import.md
@@ -32,8 +32,8 @@ Advanced users may want to directly fetch a package from npm rather than start f
 ## npm_import
 
 <pre>
-npm_import(<a href="#npm_import-name">name</a>, <a href="#npm_import-package">package</a>, <a href="#npm_import-version">version</a>, <a href="#npm_import-deps">deps</a>, <a href="#npm_import-transitive_closure">transitive_closure</a>, <a href="#npm_import-root_package">root_package</a>, <a href="#npm_import-link_workspace">link_workspace</a>,
-           <a href="#npm_import-link_packages">link_packages</a>, <a href="#npm_import-run_lifecycle_hooks">run_lifecycle_hooks</a>, <a href="#npm_import-lifecycle_hooks_execution_requirements">lifecycle_hooks_execution_requirements</a>,
+npm_import(<a href="#npm_import-name">name</a>, <a href="#npm_import-package">package</a>, <a href="#npm_import-version">version</a>, <a href="#npm_import-deps">deps</a>, <a href="#npm_import-extra_build_content">extra_build_content</a>, <a href="#npm_import-transitive_closure">transitive_closure</a>, <a href="#npm_import-root_package">root_package</a>,
+           <a href="#npm_import-link_workspace">link_workspace</a>, <a href="#npm_import-link_packages">link_packages</a>, <a href="#npm_import-run_lifecycle_hooks">run_lifecycle_hooks</a>, <a href="#npm_import-lifecycle_hooks_execution_requirements">lifecycle_hooks_execution_requirements</a>,
            <a href="#npm_import-lifecycle_hooks_env">lifecycle_hooks_env</a>, <a href="#npm_import-lifecycle_hooks_no_sandbox">lifecycle_hooks_no_sandbox</a>, <a href="#npm_import-integrity">integrity</a>, <a href="#npm_import-url">url</a>, <a href="#npm_import-patch_args">patch_args</a>, <a href="#npm_import-patches">patches</a>,
            <a href="#npm_import-custom_postinstall">custom_postinstall</a>, <a href="#npm_import-bins">bins</a>)
 </pre>
@@ -123,12 +123,14 @@ To change the proxy URL we use to fetch, configure the Bazel downloader:
 
 1. Make a file containing a rewrite rule like
 
-    rewrite (registry.nodejs.org)/(.*) artifactory.build.internal.net/artifactory/$1/$2
+    `rewrite (registry.nodejs.org)/(.*) artifactory.build.internal.net/artifactory/$1/$2`
 
 1. To understand the rewrites, see [UrlRewriterConfig] in Bazel sources.
 
 1. Point bazel to the config with a line in .bazelrc like
 common --experimental_downloader_config=.bazel_downloader_config
+
+Read more about the downloader config: <https://blog.aspect.dev/configuring-bazels-downloader>
 
 [UrlRewriterConfig]: https://github.com/bazelbuild/bazel/blob/4.2.1/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java#L66
 
@@ -142,6 +144,7 @@ common --experimental_downloader_config=.bazel_downloader_config
 | <a id="npm_import-package"></a>package |  Name of the npm package, such as <code>acorn</code> or <code>@types/node</code>   |  none |
 | <a id="npm_import-version"></a>version |  Version of the npm package, such as <code>8.4.0</code>   |  none |
 | <a id="npm_import-deps"></a>deps |  A dict other npm packages this one depends on where the key is the package name and value is the version   |  <code>{}</code> |
+| <a id="npm_import-extra_build_content"></a>extra_build_content |  Additional content to append on the generated BUILD file at the root of the created repository, either as a string or a list of lines similar to &lt;https://github.com/bazelbuild/bazel-skylib/blob/main/docs/write_file_doc.md&gt;.   |  <code>""</code> |
 | <a id="npm_import-transitive_closure"></a>transitive_closure |  A dict all npm packages this one depends on directly or transitively where the key is the package name and value is a list of version(s) depended on in the closure.   |  <code>{}</code> |
 | <a id="npm_import-root_package"></a>root_package |  The root package where the node_modules virtual store is linked to. Typically this is the package that the pnpm-lock.yaml file is located when using <code>npm_translate_lock</code>.   |  <code>""</code> |
 | <a id="npm_import-link_workspace"></a>link_workspace |  The workspace name where links will be created for this package.<br><br>This is typically set in rule sets and libraries that are to be consumed as external repositories so links are created in the external repository and not the user workspace.<br><br>Can be left unspecified if the link workspace is the user workspace.   |  <code>""</code> |

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -415,6 +415,9 @@ def _impl(rctx):
         version = rctx.attr.version,
     ))
 
+    if rctx.attr.extra_build_content:
+        rctx_files["BUILD.bazel"].append("\n" + rctx.attr.extra_build_content)
+
     if bins:
         virtual_store_name = utils.virtual_store_name(rctx.attr.package, rctx.attr.version)
 
@@ -678,6 +681,7 @@ _ATTRS_LINKS = dicts.add(_COMMON_ATTRS, {
 })
 
 _ATTRS = dicts.add(_COMMON_ATTRS, {
+    "extra_build_content": attr.string(),
     "integrity": attr.string(),
     "patch_args": attr.string_list(default = ["-p0"]),
     "patches": attr.label_list(),


### PR DESCRIPTION
This lets us document how to run Bazel's managed node and pnpm, without leaking out to the system node.

Requires a new feature on npm_import so that we can inject more content to the BUILD file.

Fixes #247