### PR TITLE
docs: suggest --dir when bazel run pnpm

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,7 @@ Try running Bazel with `--experimental_check_output_files=false` so that your ed
 
 ## Can I use bazel-managed pnpm?
 
-Yes, just run `bazel run -- @pnpm//:pnpm` followed by the usual arguments to pnpm.
+Yes, just run `bazel run -- @pnpm//:pnpm --dir $PWD` followed by the usual arguments to pnpm.
 
 Document this as a good practice so that all developers run the exact same pnpm and node versions that Bazel does.
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -65,7 +65,7 @@ If you're ready to switch your repo to pnpm, then you'll use the `pnpm_lock` att
 
 > To make those commands shorter, we rely on the `npx` binary already on your machine.
 > However you could use the Bazel-managed node and pnpm instead, like so:
-> `bazel run -- @pnpm//:pnpm i --lockfile-only`
+> `bazel run -- @pnpm//:pnpm install --dir $PWD --lockfile-only`
 
 The new `pnpm-lock.yaml` file needs to be updated by engineers on the team as well,
 so when you're ready to switch over to rules_js, you'll have to train them to run `pnpm`


### PR DESCRIPTION
Otherwise it will run with a working directory in the bazel-out/.../pnpm.runfiles/