### PR TITLE
chore(deps): only open renovate PRs weekly, on packages stable for 3 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
-  "extends": [
-    "config:base",
-    ":preserveSemverRanges"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+    "extends": ["config:base", ":preserveSemverRanges", "schedule:weekly"],
+
+    "packageRules": [
+        {
+            "stabilityDays": 3
+        }
+    ]
 }


### PR DESCRIPTION
This configures the renovate bot to only open PRs Monday, and only on releases at least 3 days old. The `config:base` has a few things such as limiting the total number of PRs (I think 10) etc.