### PR TITLE
fix(typescript): include all .json in JsInfo.declarations

### DIFF
--- a/js/private/js_library.bzl
+++ b/js/private/js_library.bzl
@@ -136,7 +136,8 @@ target in {file_basename}'s package and add that target to the deps of {this_tar
             file.path.endswith(".d.cts.map")
         ):
             declarations.append(file)
-        elif file.path.endswith("/package.json"):
+        elif file.path.endswith(".json"):
+            # Any .json can produce types: https://www.typescriptlang.org/tsconfig/#resolveJsonModule
             # package.json may be required to resolve declarations with the "typings" key
             declarations.append(file)
             sources.append(file)

--- a/js/private/test/js_library_test.bzl
+++ b/js/private/test/js_library_test.bzl
@@ -19,6 +19,12 @@ def _js_library_test_suite_data():
         content = ["export const dir: string;"],
         tags = ["manual"],
     )
+    write_file(
+        name = "data_json",
+        out = "data.json",
+        content = ["{\"name\": \"data\"}"],
+        tags = ["manual"],
+    )
 
 # Tests
 def _declarations_test_impl(ctx):
@@ -27,13 +33,15 @@ def _declarations_test_impl(ctx):
 
     # declarations should only have the source declarations
     declarations = target_under_test[JsInfo].declarations.to_list()
-    asserts.equals(env, 1, len(declarations))
+    asserts.equals(env, 2, len(declarations))
     asserts.true(env, declarations[0].path.find("/importing.d.ts") != -1)
+    asserts.true(env, declarations[1].path.find("/data.json") != -1)
 
     # declarations should only have the source declarations
     transitive_declarations = target_under_test[JsInfo].transitive_declarations.to_list()
-    asserts.equals(env, 1, len(transitive_declarations))
+    asserts.equals(env, 2, len(transitive_declarations))
     asserts.true(env, transitive_declarations[0].path.find("/importing.d.ts") != -1)
+    asserts.true(env, transitive_declarations[1].path.find("/data.json") != -1)
 
     # types OutputGroupInfo should be the same as direct declarations
     asserts.equals(env, declarations, target_under_test[OutputGroupInfo].types.to_list())
@@ -72,7 +80,7 @@ def js_library_test_suite(name):
     # Declarations in srcs + deps
     js_library(
         name = "transitive_type_deps",
-        srcs = ["importing.js", "importing.d.ts"],
+        srcs = ["importing.js", "importing.d.ts", "data.json"],
         deps = [
             "//:node_modules/@types/node",
         ],


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_nodejs/issues/3551