### PR TITLE
feat: add missing fixed_env attribute to create_launcher helper for downstream rules to use

### DIFF
--- a/docs/js_binary.md
+++ b/docs/js_binary.md
@@ -100,7 +100,7 @@ Identical to js_binary, but usable under `bazel test`.
 ## js_binary_lib.create_launcher
 
 <pre>
-js_binary_lib.create_launcher(<a href="#js_binary_lib.create_launcher-ctx">ctx</a>, <a href="#js_binary_lib.create_launcher-log_prefix_rule_set">log_prefix_rule_set</a>, <a href="#js_binary_lib.create_launcher-log_prefix_rule">log_prefix_rule</a>, <a href="#js_binary_lib.create_launcher-fixed_args">fixed_args</a>)
+js_binary_lib.create_launcher(<a href="#js_binary_lib.create_launcher-ctx">ctx</a>, <a href="#js_binary_lib.create_launcher-log_prefix_rule_set">log_prefix_rule_set</a>, <a href="#js_binary_lib.create_launcher-log_prefix_rule">log_prefix_rule</a>, <a href="#js_binary_lib.create_launcher-fixed_args">fixed_args</a>, <a href="#js_binary_lib.create_launcher-fixed_env">fixed_env</a>)
 </pre>
 
 
@@ -114,6 +114,7 @@ js_binary_lib.create_launcher(<a href="#js_binary_lib.create_launcher-ctx">ctx</
 | <a id="js_binary_lib.create_launcher-log_prefix_rule_set"></a>log_prefix_rule_set |  <p align="center"> - </p>   |  none |
 | <a id="js_binary_lib.create_launcher-log_prefix_rule"></a>log_prefix_rule |  <p align="center"> - </p>   |  none |
 | <a id="js_binary_lib.create_launcher-fixed_args"></a>fixed_args |  <p align="center"> - </p>   |  <code>[]</code> |
+| <a id="js_binary_lib.create_launcher-fixed_env"></a>fixed_env |  <p align="center"> - </p>   |  <code>{}</code> |
 
 
 <a id="js_binary_lib.implementation"></a>

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -217,7 +217,7 @@ def js_run_binary(
         extra_srcs.append(":{}".format(copy_to_bin_name))
 
     # Automatically add common and useful make variables to the environment for js_run_binary build targets
-    extra_env = {
+    fixed_env = {
         "BAZEL_BINDIR": "$(BINDIR)",
         "BAZEL_BUILD_FILE_PATH": "$(BUILD_FILE_PATH)",
         "BAZEL_COMPILATION_MODE": "$(COMPILATION_MODE)",
@@ -228,35 +228,35 @@ def js_run_binary(
 
     # Configure working directory to `chdir` is set
     if chdir:
-        extra_env["JS_BINARY__CHDIR"] = chdir
+        fixed_env["JS_BINARY__CHDIR"] = chdir
 
     # Configure capturing stdout, stderr and/or the exit code
     extra_outs = []
     if stdout:
-        extra_env["JS_BINARY__STDOUT_OUTPUT_FILE"] = "$(execpath {})".format(stdout)
+        fixed_env["JS_BINARY__STDOUT_OUTPUT_FILE"] = "$(execpath {})".format(stdout)
         extra_outs.append(stdout)
     if stderr:
-        extra_env["JS_BINARY__STDERR_OUTPUT_FILE"] = "$(execpath {})".format(stderr)
+        fixed_env["JS_BINARY__STDERR_OUTPUT_FILE"] = "$(execpath {})".format(stderr)
         extra_outs.append(stderr)
     if exit_code_out:
-        extra_env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = "$(execpath {})".format(exit_code_out)
+        fixed_env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = "$(execpath {})".format(exit_code_out)
         extra_outs.append(exit_code_out)
 
     # Configure silent on success
     if silent_on_success:
-        extra_env["JS_BINARY__SILENT_ON_SUCCESS"] = "1"
+        fixed_env["JS_BINARY__SILENT_ON_SUCCESS"] = "1"
 
     # Disable node patches if requested
     if patch_node_fs:
-        extra_env["JS_BINARY__PATCH_NODE_FS"] = "1"
+        fixed_env["JS_BINARY__PATCH_NODE_FS"] = "1"
     else:
         # Set explicitly to "0" so disable overrides any enable in the js_binary
-        extra_env["JS_BINARY__PATCH_NODE_FS"] = "0"
+        fixed_env["JS_BINARY__PATCH_NODE_FS"] = "0"
 
     # Configure log_level if specified
     if log_level:
         for log_level_env in _envs_for_log_level(log_level):
-            extra_env[log_level_env] = "1"
+            fixed_env[log_level_env] = "1"
 
     if not stdout and not stderr and not exit_code_out and (len(outs) + len(out_dirs) < 1):
         # run_binary will produce the actual error, but we want to give an additional JS-specific
@@ -276,7 +276,7 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
     _run_binary(
         name = name,
         tool = tool,
-        env = dicts.add(extra_env, env),
+        env = dicts.add(fixed_env, env),
         srcs = srcs + extra_srcs,
         outs = outs + extra_outs,
         out_dirs = out_dirs,

--- a/js/private/test/create_launcher/BUILD.bazel
+++ b/js/private/test/create_launcher/BUILD.bazel
@@ -1,0 +1,6 @@
+load(":custom_test.bzl", "custom_test")
+
+custom_test(
+    name = "test",
+    entry_point = "test.js",
+)

--- a/js/private/test/create_launcher/custom_test.bzl
+++ b/js/private/test/create_launcher/custom_test.bzl
@@ -1,0 +1,54 @@
+"custom_test rule"
+
+load("@aspect_rules_js//js:libs.bzl", "js_binary_lib", "js_lib_helpers")
+
+def _impl(ctx):
+    fixed_args = ["--arg1", "--arg2"]
+    fixed_env = {
+        "ENV1": "foo",
+        "ENV2": "bar",
+    }
+
+    launcher = js_binary_lib.create_launcher(
+        ctx,
+        log_prefix_rule_set = "aspect_rules_js",
+        log_prefix_rule = "custom_test",
+        fixed_args = fixed_args,
+        fixed_env = fixed_env,
+    )
+
+    runfiles = ctx.runfiles(
+        files = ctx.files.data,
+        transitive_files = js_lib_helpers.gather_files_from_js_providers(
+            targets = ctx.attr.data,
+            include_transitive_sources = ctx.attr.include_transitive_sources,
+            include_declarations = ctx.attr.include_declarations,
+            include_npm_linked_packages = ctx.attr.include_npm_linked_packages,
+        ),
+    ).merge(launcher.runfiles).merge_all([
+        target[DefaultInfo].default_runfiles
+        for target in ctx.attr.data
+    ])
+
+    return [
+        DefaultInfo(
+            executable = launcher.executable,
+            runfiles = runfiles,
+        ),
+    ]
+
+_custom_test = rule(
+    attrs = js_binary_lib.attrs,
+    implementation = _impl,
+    test = True,
+    toolchains = js_binary_lib.toolchains,
+)
+
+def custom_test(**kwargs):
+    _custom_test(
+        enable_runfiles = select({
+            "//js/private:enable_runfiles": True,
+            "//conditions:default": False,
+        }),
+        **kwargs
+    )

--- a/js/private/test/create_launcher/test.js
+++ b/js/private/test/create_launcher/test.js
@@ -1,0 +1,9 @@
+const assert = require('assert')
+
+const args = process.argv.slice(2)
+assert.equal(args.length, 2)
+assert.equal(args[0], '--arg1')
+assert.equal(args[1], '--arg2')
+
+assert.equal(process.env['ENV1'], 'foo')
+assert.equal(process.env['ENV2'], 'bar')


### PR DESCRIPTION
@mrmeku's work on rules_cypress showed that there is a need for this

The API change here is not breaking and only affects downstream rules