### PR TITLE
chore: configure renovate to group PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,22 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-    "extends": ["config:base", ":preserveSemverRanges", "schedule:weekly"],
+    "extends": [
+        "config:base",
+        ":preserveSemverRanges",
+        ":rebaseStalePrs",
+        "schedule:weekly",
+        "group:allNonMajor",
+        "workarounds:all"
+    ],
+
+    "labels": ["cleanup", "prioritize"],
+    "dependencyDashboard": true,
 
     "packageRules": [
         {
-            "matchDatasources": ["npm"],
-            "stabilityDays": 3
+            "matchPackagePatterns": ["*"],
+            "stabilityDays": 5
         }
     ]
 }


### PR DESCRIPTION
The main thing is group all non-major updates into single PRs.

I'm still tempted to group updates into smaller PRs instead of one giant one. Things like "all npm dev dependencies", "all npm non-dev dependencies", "all bazel deps", "all java deps" etc. Is that better then a single PR for everything? Or is less PRs better no matter what gets mixed in?