### PR TITLE
ci: use fixed releaser for bcr commit

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,1 @@
+fixedReleaser: jbedard


### PR DESCRIPTION
Because we use the github actions bot to publish a release, the Publish to BCR app doesn't have a way to identify someone as the commit author for a new bcr entry. This sets it to you always.