### PR TITLE
renovate - group recommended/monorepo including major version, reduce stabilityDays to 3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,8 @@
         ":preserveSemverRanges",
         ":rebaseStalePrs",
         "schedule:weekly",
+        "group:recommended",
+        "group:monorepos",
         "group:allNonMajor",
         "workarounds:all"
     ],
@@ -16,7 +18,7 @@
     "packageRules": [
         {
             "matchPackagePatterns": ["*"],
-            "stabilityDays": 5
+            "stabilityDays": 3
         }
     ]
 }


### PR DESCRIPTION
This to to (hopefully) merge things like the 3 rollup major updates in shown in https://github.com/aspect-build/rules_js/issues/179 into a single PR instead of 3. I'm not sure if these rollup ones are actually in the recommended/monorepos but lets start with just these 2 preset configs.

I think non-major version will all still be in one giant PR such as https://github.com/aspect-build/rules_js/pull/509 and this will only effect major versions.

Reducing the `stabilityDays` to 3 which is the standard value since npm packages can be unpublished the first 3 days.