### PR TITLE
renovate: only group patch updates of unrelated deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
         "schedule:weekly",
         "group:recommended",
         "group:monorepos",
-        "group:allNonMajor",
         "workarounds:all"
     ],
 
@@ -19,6 +18,12 @@
         {
             "matchPackagePatterns": ["*"],
             "stabilityDays": 3
+        },
+        {
+            "matchPackagePatterns": ["*"],
+            "matchUpdateTypes": ["patch"],
+            "groupName": "all patch updates",
+            "groupSlug": "all-patch"
         }
     ]
 }


### PR DESCRIPTION
The current PR (see https://github.com/aspect-build/rules_js/commit/327b79c77ae3093f14d98942d30be5aabe2405da) with every minor+patch update is too big and hard to determine the reason for the CI error, so everyone has ignored it for a week now.

So lets try only grouping patches? Minor+major updates will (hopefully 🤞) be grouped by monorepo and "recommended" groups.

This is a modified version of https://docs.renovatebot.com/presets-group/#groupallnonmajor