### PR TITLE
renovate: group rollup related updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,11 @@
             "stabilityDays": 3
         },
         {
+            "matchPackagePatterns": ["^rollup-", "^@rollup/", "*-rollup-"],
+            "groupName": "rollup",
+            "groupSlug": "rollup"
+        },
+        {
             "matchPackagePatterns": ["*"],
             "matchUpdateTypes": ["patch"],
             "groupName": "all patch updates",


### PR DESCRIPTION
Currently rules_js has 3 of these in separate PRs (or they will be once the schedule runs). They are unfortunately not part of the `group:monorepos` or `group:recommended` I guess because they aren't versioned together. But I'd like to take the chance of one of them breaking just to reduce PRs.

Again I haven't found a way of testing this so we'll have to merge to test it :(