### PR TITLE
renovate: rollup, aspect, bazel groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,19 @@
             "groupSlug": "rollup"
         },
         {
+            "groupName": "Aspect rules",
+            "groupSlug": "aspect_rules",
+            "matchManagers": ["bazel"],
+            "matchPackageNames": ["^aspect_"],
+            "matchUpdateTypes": ["patch", "minor"]
+        },
+        {
+            "groupName": "Bazel rules",
+            "groupSlug": "bazel_rules",
+            "matchManagers": ["bazel"],
+            "matchUpdateTypes": ["patch", "minor"]
+        },
+        {
             "matchPackagePatterns": ["*"],
             "matchUpdateTypes": ["patch"],
             "groupName": "all patch updates",

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,12 @@
             "stabilityDays": 3
         },
         {
-            "matchPackagePatterns": ["^rollup-", "^@rollup/", ".*-rollup-"],
+            "matchPackagePatterns": [
+                "^rollup$",
+                "^rollup-",
+                "^@rollup/",
+                ".*-rollup-"
+            ],
             "groupName": "rollup",
             "groupSlug": "rollup"
         },


### PR DESCRIPTION
The main rollup was in its own PR, also adding bazel groups with aspect rules in their own group.