### PR TITLE
fix: downgrade rollup back to 2.79.0

### DIFF
--- a/js/private/coverage/bundle/package.json
+++ b/js/private/coverage/bundle/package.json
@@ -3,7 +3,7 @@
         "c8": "7.12.0"
     },
     "devDependencies": {
-        "rollup": "3.1.0",
+        "rollup": "2.79.0",
         "@rollup/plugin-commonjs": "23.0.0",
         "@rollup/plugin-node-resolve": "15.0.0",
         "@rollup/plugin-json": "5.0.0"


### PR DESCRIPTION
This was the offending commit; https://github.com/aspect-build/rules_js/commit/893bbcbc4ebd70e7ed7e729c965c6ae52a53d53e

Looks like renovate did update the lockfile but maybe it was using an old version of pnpm as when I update the lockfile locally I still see changes that break the coverage bundle