### PR TITLE
perf: prevent preparing stack traces in fs *Sync patches

### DIFF
--- a/js/private/node-patches/fs.js
+++ b/js/private/node-patches/fs.js
@@ -121,7 +121,7 @@ const patcher = (fs = _fs, roots) => {
             // there are no hops so lets report the stats of the real file;
             // we can't use origRealPathSync here since that function calls lstat internally
             // which can result in an infinite loop
-            return origLstatSync(unguardedRealPathSync(args[0]), args.slice(1));
+            return origLstatSync(unguardedRealPathSync(args[0]), ...args.slice(1));
         }
         catch (err) {
             if (err.code === 'ENOENT') {

--- a/js/private/node-patches/src/fs.ts
+++ b/js/private/node-patches/src/fs.ts
@@ -125,7 +125,10 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
             // there are no hops so lets report the stats of the real file;
             // we can't use origRealPathSync here since that function calls lstat internally
             // which can result in an infinite loop
-            return origLstatSync(unguardedRealPathSync(args[0]), args.slice(1))
+            return origLstatSync(
+                unguardedRealPathSync(args[0]),
+                ...args.slice(1)
+            )
         } catch (err) {
             if (err.code === 'ENOENT') {
                 // broken link so there is nothing more to do

--- a/js/private/test/node-patches/lstat.js
+++ b/js/private/test/node-patches/lstat.js
@@ -210,4 +210,19 @@ describe('testing lstat', async () => {
             }
         )
     })
+
+    await it('includes parent calls in stack traces', async function lstatStackTest1() {
+        let err
+        try {
+            fs.lstatSync(null)
+        } catch (e) {
+            err = e
+        } finally {
+            if (!err) assert.fail('lstat should fail on invalid path')
+            if (!err.stack.includes('lstatStackTest1'))
+                assert.fail(
+                    `lstat error stack should contain calling method: ${err.stack}`
+                )
+        }
+    })
 })

--- a/js/private/test/node-patches/readdir.js
+++ b/js/private/test/node-patches/readdir.js
@@ -216,4 +216,19 @@ describe('testing readdir', async () => {
             }
         )
     })
+
+    await it('includes parent calls in stack traces', async function readdirStackTest1() {
+        let err
+        try {
+            fs.readdirSync('/foo/bar' + Date.now())
+        } catch (e) {
+            err = e
+        } finally {
+            if (!err) assert.fail('readdirSync should fail on invalid path')
+            if (!err.stack.includes('readdirStackTest1'))
+                assert.fail(
+                    `readdirSync error stack should contain calling method: ${err.stack}`
+                )
+        }
+    })
 })

--- a/js/private/test/node-patches/readlink.js
+++ b/js/private/test/node-patches/readlink.js
@@ -226,4 +226,19 @@ describe('testing readlink', async () => {
             }
         )
     })
+
+    await it('includes parent calls in stack traces', async function readlinkStackTest1() {
+        let err
+        try {
+            fs.readlinkSync(null)
+        } catch (e) {
+            err = e
+        } finally {
+            if (!err) assert.fail('readlinkSync should fail on invalid path')
+            if (!err.stack.includes('readlinkStackTest1'))
+                assert.fail(
+                    `readlinkSync error stack should contain calling method: ${err.stack}`
+                )
+        }
+    })
 })

--- a/js/private/test/node-patches/realpath.js
+++ b/js/private/test/node-patches/realpath.js
@@ -900,4 +900,19 @@ describe('testing realpath', async () => {
             }
         )
     })
+
+    await it('includes parent calls in stack traces', async function realpathStackTest1() {
+        let err
+        try {
+            fs.realpathSync(null)
+        } catch (e) {
+            err = e
+        } finally {
+            if (!err) assert.fail('realpathSync should fail on invalid path')
+            if (!err.stack.includes('realpathStackTest1'))
+                assert.fail(
+                    `realpathSync error stack should contain calling method: ${err.stack}`
+                )
+        }
+    })
 })


### PR DESCRIPTION
This makes my test of 500 basic files about 2x faster, going from a fairly consistent 7.5-8 to 3.5-4. Those 500 files are just `expect(true).toBeTrue()` so the time invoking tests should be ~0 and it's all jest running, node loading files etc.

Originally I only wrapped some internal functions such as `guardedRealPathSync` but I think it's better to just wrap the full public methods so the `Error` try/catch modifications only happen once. The worry with that is stack traces thrown within the implementations wouldn't be complete but that seems to still work, see the stack trace tests.

See https://github.com/aspect-build/rules_jest/issues/50