### PR TITLE
chore: update to Bazel 6.0.0rc1

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-5.3.2
+6.0.0rc1
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -10,7 +10,7 @@ build:local --disk_cache=~/.cache/bazel
 
 # Generic remote cache
 build --remote_local_fallback
-build --remote_download_toplevel
+# build --remote_download_toplevel # BREAKS BUILD in Bazel 6.0.0rc1
 build --remote_timeout=3600
 build --remote_upload_local_results
 ## Fixes builds hanging on CI that get the TCP connection closed without sending RST packets.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,11 +28,24 @@ jobs:
               run: echo "::set-output name=config::local"
             - id: rbe
               run: echo "::set-output name=config::rbe"
-              # Don't run RBE if there is now EngFlow creds which is the case on forks.
+              # Don't run RBE if there are no EngFlow creds which is the case on forks
               if: ${{ env.ENGFLOW_PRIVATE_KEY != '' }}
         outputs:
             # Will look like '["local", "rbe"]'
             configs: ${{ toJSON(steps.*.outputs.config) }}
+
+    matrix-prep-bazelversion:
+        # Prepares the 'bazelversion' axis of the test matrix
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - id: bazel_6
+              run: echo "::set-output name=bazelversion::$(head -n 1 .bazelversion)"
+            - id: bazel_5
+              run: echo "::set-output name=bazelversion::5.3.2"
+        outputs:
+            # Will look like '["6.0.0rc1", "5.3.2"]'
+            bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
     matrix-prep-folder:
         # Prepares the 'folder' axis of the test matrix
@@ -79,12 +92,22 @@ jobs:
 
         needs:
             - matrix-prep-config
+            - matrix-prep-bazelversion
             - matrix-prep-folder
 
         strategy:
+            fail-fast: false
             matrix:
                 config: ${{ fromJSON(needs.matrix-prep-config.outputs.configs) }}
+                bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
                 folder: ${{ fromJSON(needs.matrix-prep-folder.outputs.folders) }}
+                exclude:
+                    # Don't test RBE with Bazel 5 (not supported)
+                    - config: rbe
+                      bazelversion: 5.3.2
+                    # Don't test bzlmod with Bazel 5 (not supported)
+                    - bazelversion: 5.3.2
+                      folder: e2e/bzlmod
 
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:
@@ -100,6 +123,10 @@ jobs:
                   key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', '**/*.js') }}
                   restore-keys: bazel-cache-
 
+            - name: Configure Bazel version
+              working-directory: ${{ matrix.folder }}
+              run: echo "USE_BAZEL_VERSION=${{ matrix.bazelversion }}" >> $GITHUB_ENV
+
             - name: Write EngFlow credentials
               # Writes EngFlow credential files for RBE configurations
               if: matrix.config == 'rbe'
@@ -109,7 +136,6 @@ jobs:
                   chmod 0600 engflow.crt engflow.key
                   echo "$ENGFLOW_CLIENT_CRT" > engflow.crt
                   echo "$ENGFLOW_PRIVATE_KEY" > engflow.key
-                  echo "USE_BAZEL_VERSION=6.0.0-pre.20220922.1" >> $GITHUB_ENV
               env:
                   ENGFLOW_CLIENT_CRT: ${{ secrets.ENGFLOW_CLIENT_CRT }}
                   ENGFLOW_PRIVATE_KEY: ${{ secrets.ENGFLOW_PRIVATE_KEY }}
@@ -148,6 +174,7 @@ jobs:
             - name: bazel coverage //...
               # Don't run if there is a test.sh file in the folder.
               # Don't run on RBE. Coverage does not work properly with RBE. See: bazelbuild/bazel#4685.
+              # Don't run coverage on e2e/bzlmod. It fails evaluating js/private/coverage/BUILD.bazel because write_source_files is not yet bzlmod compatible.
               if: steps.has_test_sh.outputs.files_exists != 'true' && matrix.config == 'local'
               working-directory: ${{ matrix.folder }}
               run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.13.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.14.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "rules_nodejs", version = "5.5.3")
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/e2e/bzlmod/.bazelversion
+++ b/e2e/bzlmod/.bazelversion
@@ -1,2 +1,1 @@
-6.0.0-pre.20220922.1
-# Bazel 5.3.0 has bzlmod bugs so we use 6.0 prerelease
+../../.bazelversion

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -34,7 +34,7 @@ def rules_js_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "c15e3bdb626973728c375ef78c58fdee27c9b9affea5c9db57c78eafda8395bf",
-        strip_prefix = "bazel-lib-1.13.1",
-        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.13.1.tar.gz",
+        sha256 = "9305799c6d9e425e6b73270a0f9eb0aa1082050823a7eefad95edcece545e77b",
+        strip_prefix = "bazel-lib-1.14.0",
+        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.14.0.tar.gz",
     )


### PR DESCRIPTION
Looks like --remote_download_toplevel regressed in the 6.0.0rc1 release. It now breaks the build.

Tested with yesterday's pre-release https://github.com/bazelbuild/bazel/releases/tag/6.0.0-pre.20221012.2 and it was not broken there.

Also adds bazelversion matrix axis so we continue to test bazel v5.3.2 on CI