### PR TITLE
fix: support non-https registry protocols

### DIFF
--- a/npm/private/test/npm_auth_test.bzl
+++ b/npm/private/test/npm_auth_test.bzl
@@ -182,7 +182,7 @@ def _pkg_scope_test_impl(ctx):
         (
             {},
             {
-                "@scope1": "registry1",
+                "@scope1": "https://registry1",
             },
         ),
         get_npm_auth(
@@ -199,8 +199,8 @@ def _pkg_scope_test_impl(ctx):
         (
             {},
             {
-                "@scope1": "registry1",
-                "@scope2": "registry2",
+                "@scope1": "https://registry1",
+                "@scope2": "https://registry2",
             },
         ),
         get_npm_auth(
@@ -218,8 +218,50 @@ def _pkg_scope_test_impl(ctx):
         (
             {},
             {
-                "@scope1": "registry/scope1",
-                "@scope2": "registry/scope2",
+                "@scope1": "https://registry/scope1",
+                "@scope2": "https://registry/scope2",
+            },
+        ),
+        get_npm_auth(
+            {
+                "@scope1:registry": "https://registry/scope1",
+                "@scope2:registry": "https://registry/scope2",
+            },
+            "",
+            {},
+        ),
+    )
+
+    asserts.equals(
+        env,
+        (
+            {},
+            {
+                "@scope1": "http://registry/scope1",
+                "@scope2": "https://registry/scope2",
+                "@scope3": "//registry/scope3",
+                "@scope4": "https://registry4.com",
+            },
+        ),
+        get_npm_auth(
+            {
+                "@scope1:registry": "http://registry/scope1",
+                "@scope2:registry": "https://registry/scope2",
+                "@scope3:registry": "//registry/scope3",
+                "@scope4:registry": "registry4.com",
+            },
+            "",
+            {},
+        ),
+    )
+
+    asserts.equals(
+        env,
+        (
+            {},
+            {
+                "@scope1": "https://registry/scope1",
+                "@scope2": "https://registry/scope2",
             },
         ),
         get_npm_auth(

--- a/npm/private/test/utils_tests.bzl
+++ b/npm/private/test/utils_tests.bzl
@@ -66,6 +66,41 @@ def test_parse_package_name(ctx):
     return unittest.end(env)
 
 # buildifier: disable=function-docstring
+def test_npm_registry_url(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        "https://default",
+        utils.npm_registry_url("a", {}, "https://default"),
+    )
+    asserts.equals(
+        env,
+        "http://default",
+        utils.npm_registry_url("a", {}, "http://default"),
+    )
+    asserts.equals(
+        env,
+        "//default",
+        utils.npm_registry_url("a", {}, "//default"),
+    )
+    asserts.equals(
+        env,
+        "https://default",
+        utils.npm_registry_url("@a/b", {}, "https://default"),
+    )
+    asserts.equals(
+        env,
+        "https://default",
+        utils.npm_registry_url("@a/b", {"@ab": "not me"}, "https://default"),
+    )
+    asserts.equals(
+        env,
+        "https://scoped-registry",
+        utils.npm_registry_url("@a/b", {"@a": "https://scoped-registry"}, "https://default"),
+    )
+    return unittest.end(env)
+
+# buildifier: disable=function-docstring
 def test_npm_registry_download_url(ctx):
     env = unittest.begin(ctx)
     asserts.equals(
@@ -75,13 +110,23 @@ def test_npm_registry_download_url(ctx):
     )
     asserts.equals(
         env,
+        "http://registry.npmjs.org/y/-/y-1.2.3.tgz",
+        utils.npm_registry_download_url("y", "1.2.3", {}, "http://registry.npmjs.org/"),
+    )
+    asserts.equals(
+        env,
         "https://registry.npmjs.org/@scope/y/-/y-1.2.3.tgz",
         utils.npm_registry_download_url("@scope/y", "1.2.3", {}, "https://registry.npmjs.org/"),
     )
     asserts.equals(
         env,
+        "https://registry.npmjs.org/@scope/y/-/y-1.2.3.tgz",
+        utils.npm_registry_download_url("@scope/y", "1.2.3", {"@scopyy": "foobar"}, "https://registry.npmjs.org/"),
+    )
+    asserts.equals(
+        env,
         "https://npm.pkg.github.com/@scope/y/-/y-1.2.3.tgz",
-        utils.npm_registry_download_url("@scope/y", "1.2.3", {"@scope": "npm.pkg.github.com/"}, "https://registry.npmjs.org/"),
+        utils.npm_registry_download_url("@scope/y", "1.2.3", {"@scope": "https://npm.pkg.github.com/"}, "https://registry.npmjs.org/"),
     )
     asserts.equals(
         env,
@@ -98,6 +143,7 @@ t4_test = unittest.make(test_virtual_store_name)
 t5_test = unittest.make(test_version_supported)
 t6_test = unittest.make(test_parse_package_name)
 t7_test = unittest.make(test_npm_registry_download_url)
+t8_test = unittest.make(test_npm_registry_url)
 
 def utils_tests(name):
     unittest.suite(
@@ -110,4 +156,5 @@ def utils_tests(name):
         t5_test,
         t6_test,
         t7_test,
+        t8_test,
     )

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -134,11 +134,16 @@ def _parse_package_name(package):
         return (segments[0], segments[1])
     return ("", segments[0])
 
+def _npm_registry_url(package, registries, default_registry):
+    (package_scope, _) = _parse_package_name(package)
+
+    return registries[package_scope] if package_scope in registries else default_registry
+
 def _npm_registry_download_url(package, version, registries, default_registry):
     "Make a registry download URL for a given package and version"
 
-    (package_scope, package_name_no_scope) = _parse_package_name(package)
-    registry = "https://{}".format(registries[package_scope]) if package_scope in registries else default_registry
+    (_, package_name_no_scope) = _parse_package_name(package)
+    registry = _npm_registry_url(package, registries, default_registry)
 
     return "{0}/{1}/-/{2}-{3}.tgz".format(
         registry.removesuffix("/"),
@@ -163,6 +168,7 @@ utils = struct(
     links_repo_suffix = "__links",
     # Output group name for the package directory of a linked package
     package_directory_output_group = "package_directory",
+    npm_registry_url = _npm_registry_url,
     npm_registry_download_url = _npm_registry_download_url,
     parse_package_name = _parse_package_name,
 )


### PR DESCRIPTION
Assigning the default registry protocol is now done when reading them from npmrc instead of when using them. So the `registries` map passed around now has the protocols in the URLs.

I'm not sure how the `//no-protocol.com` cases should be handled though. Normally that means to "use the current protocol", but idk what the "current" is?