### PR TITLE
fix: fix windows regression in js_binary launcher bash script

### DIFF
--- a/js/private/bash.bzl
+++ b/js/private/bash.bzl
@@ -6,27 +6,26 @@
 # then it could be hoisted to bazel-lib where we have other bash snippets.
 BASH_INITIALIZE_RUNFILES = r"""
 # It helps to determine if we are running on a Windows environment (excludes WSL as it acts like Unix)
-function _is_windows {
-    case "$(uname -s)" in
-        CYGWIN*)    local IS_WINDOWS=1 ;;
-        MINGW*)     local IS_WINDOWS=1 ;;
-        MSYS_NT*)   local IS_WINDOWS=1 ;;
-        *)          local IS_WINDOWS=0 ;;
-    esac
-
-    echo $IS_WINDOWS
-    return
-}
+case "$(uname -s)" in
+    CYGWIN*)    _IS_WINDOWS=1 ;;
+    MINGW*)     _IS_WINDOWS=1 ;;
+    MSYS_NT*)   _IS_WINDOWS=1 ;;
+    *)          _IS_WINDOWS=0 ;;
+esac
 
 # It helps to normalizes paths when running on Windows.
 #
 # Example:
 # C:/Users/XUser/_bazel_XUser/7q7kkv32/execroot/A/b/C -> /c/Users/XUser/_bazel_XUser/7q7kkv32/execroot/A/b/C
-function _normalize_windows_path {
-    # Apply the followings paths transformations to normalize paths on Windows
-    # -process driver letter
-    # -convert path separator
-    sed -e 's#^\(.\):#/\L\1#' -e 's#\\#/#g' <<< "$1"
+function _normalize_path {
+    if [ "$_IS_WINDOWS" -eq "1" ]; then
+        # Apply the followings paths transformations to normalize paths on Windows
+        # -process driver letter
+        # -convert path separator
+        sed -e 's#^\(.\):#/\L\1#' -e 's#\\#/#g' <<< "$1"
+    else
+        echo "$1"
+    fi
     return
 }
 
@@ -54,22 +53,17 @@ function _normalize_windows_path {
 # Case 6a is handled like case 3.
 if [ "${TEST_SRCDIR:-}" ]; then
     # Case 4, bazel has identified runfiles for us.
-    RUNFILES="$TEST_SRCDIR"
+    RUNFILES=$(_normalize_path "$TEST_SRCDIR")
 elif [ "${RUNFILES_MANIFEST_FILE:-}" ]; then
-    if [ "$(_is_windows)" -eq "1" ]; then
-        # If Windows, normalize the path
-        NORMALIZED_RUNFILES_MANIFEST_FILE=$(_normalize_windows_path "$RUNFILES_MANIFEST_FILE")
-    else
-        NORMALIZED_RUNFILES_MANIFEST_FILE="$RUNFILES_MANIFEST_FILE"
-    fi
-    if [[ "${NORMALIZED_RUNFILES_MANIFEST_FILE}" == *.runfiles_manifest ]]; then
+    RUNFILES=$(_normalize_path "$RUNFILES_MANIFEST_FILE")
+    if [[ "${RUNFILES}" == *.runfiles_manifest ]]; then
         # Newer versions of Bazel put the manifest besides the runfiles with the suffix .runfiles_manifest.
         # For example, the runfiles directory is named my_binary.runfiles then the manifest is beside the
         # runfiles directory and named my_binary.runfiles_manifest
-        RUNFILES=${NORMALIZED_RUNFILES_MANIFEST_FILE%_manifest}
-    elif [[ "${NORMALIZED_RUNFILES_MANIFEST_FILE}" == */MANIFEST ]]; then
+        RUNFILES=${RUNFILES%_manifest}
+    elif [[ "${RUNFILES}" == */MANIFEST ]]; then
         # Older versions of Bazel put the manifest file named MANIFEST in the runfiles directory
-        RUNFILES=${NORMALIZED_RUNFILES_MANIFEST_FILE%/MANIFEST}
+        RUNFILES=${RUNFILES%/MANIFEST}
     else
         logf_fatal "Unexpected RUNFILES_MANIFEST_FILE value $RUNFILES_MANIFEST_FILE"
         exit 1
@@ -107,6 +101,8 @@ else
         logf_fatal "RUNFILES environment variable is not set"
         exit 1
     fi
+
+    RUNFILES=$(_normalize_path "$RUNFILES")
 fi
 if [ "${RUNFILES:0:1}" != "/" ]; then
     # Ensure RUNFILES set above is an absolute path. It may be a path relative

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -183,7 +183,7 @@ if [ ! -f "$JS_BINARY__NODE_BINARY" ]; then
     logf_fatal "node binary '%s' not found in runfiles" "$JS_BINARY__NODE_BINARY"
     exit 1
 fi
-if [ ! -x "$JS_BINARY__NODE_BINARY" ]; then
+if [ "$_IS_WINDOWS" -ne "1" ] && [ ! -x "$JS_BINARY__NODE_BINARY" ]; then
     logf_fatal "node binary '%s' is not executable" "$JS_BINARY__NODE_BINARY"
     exit 1
 fi
@@ -195,7 +195,7 @@ if [ "$npm" ]; then
         logf_fatal "npm binary '%s' not found in runfiles" "$JS_BINARY__NPM_BINARY"
         exit 1
     fi
-    if [ ! -x "$JS_BINARY__NPM_BINARY" ]; then
+    if [ "$_IS_WINDOWS" -ne "1" ] && [ ! -x "$JS_BINARY__NPM_BINARY" ]; then
         logf_fatal "npm binary '%s' is not executable" "$JS_BINARY__NPM_BINARY"
         exit 1
     fi
@@ -206,7 +206,7 @@ if [ ! -f "$JS_BINARY__NODE_WRAPPER" ]; then
     logf_fatal "node wrapper '%s' not found in runfiles" "$JS_BINARY__NODE_WRAPPER"
     exit 1
 fi
-if [ ! -x "$JS_BINARY__NODE_WRAPPER" ]; then
+if [ "$_IS_WINDOWS" -ne "1" ] && [ ! -x "$JS_BINARY__NODE_WRAPPER" ]; then
     logf_fatal "node wrapper '%s' is not executable" "$JS_BINARY__NODE_WRAPPER"
     exit 1
 fi


### PR DESCRIPTION
This has been broken for a while on Windows. We don't have Windows CI yet for rules_js so it wasn't caught until the BCR pre-submit failed.