### PR TITLE
fix: always set JsInfo.declarations on npm_link_package_store targets

### DIFF
--- a/js/private/test/js_library_test.bzl
+++ b/js/private/test/js_library_test.bzl
@@ -37,11 +37,17 @@ def _declarations_test_impl(ctx):
     asserts.true(env, declarations[0].path.find("/importing.d.ts") != -1)
     asserts.true(env, declarations[1].path.find("/data.json") != -1)
 
-    # declarations should only have the source declarations
+    # transitive_declarations should have the source declarations and transitive declarations
     transitive_declarations = target_under_test[JsInfo].transitive_declarations.to_list()
-    asserts.equals(env, 2, len(transitive_declarations))
+
+    # the transitive count might be 3 or 4 depending on the type of symlink created.
+    # See utils.make_symlink()
+    asserts.true(env, len(transitive_declarations) == 3 or len(transitive_declarations) == 4)
     asserts.true(env, transitive_declarations[0].path.find("/importing.d.ts") != -1)
     asserts.true(env, transitive_declarations[1].path.find("/data.json") != -1)
+    asserts.true(env, transitive_declarations[2].path.find("/@types/node") != -1)
+    if len(transitive_declarations) == 4:
+        asserts.true(env, transitive_declarations[3].path.find("/@types/node") != -1)
 
     # types OutputGroupInfo should be the same as direct declarations
     asserts.equals(env, declarations, target_under_test[OutputGroupInfo].types.to_list())

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -126,6 +126,9 @@ def _impl(ctx):
             runfiles = ctx.runfiles(transitive_files = transitive_files_depset),
         ),
         js_info(
+            # assume a directory contains declarations since we can't know that it doesn't
+            declarations = files_depset,
+            transitive_declarations = transitive_files_depset,
             npm_linked_package_files = files_depset,
             npm_linked_packages = depset([npm_linked_package_info]),
             npm_package_store_deps = depset([store_info]),


### PR DESCRIPTION
This way it will be a valid `ts_project` dep like we were discussing.

This PR currently does the same as what `js_library` does for directories but 100% of the time. Here `js_library` does this only when finding a directory with unknown content: https://github.com/aspect-build/rules_js/blob/2bc5e8622b9509b370fbbd44e9022900d15b5244/js/private/js_library.bzl#L126-L129