### PR TITLE
perf: cache fs patch fs lookups 

### DIFF
--- a/js/private/node-patches/fs.js
+++ b/js/private/node-patches/fs.js
@@ -160,7 +160,7 @@ const patcher = (fs = _fs, roots) => {
         };
         origLstat(...args);
     };
-    fs.lstatSync = hideStackFrames((...args) => {
+    fs.lstatSync = hideStackFrames(function _lstatSync(...args) {
         const stats = origLstatSync(...args);
         if (!stats.isSymbolicLink()) {
             // the file is not a symbolic link so there is nothing more to do
@@ -229,7 +229,7 @@ const patcher = (fs = _fs, roots) => {
         };
         origRealpathNative(...args);
     };
-    fs.realpathSync = hideStackFrames((...args) => {
+    fs.realpathSync = hideStackFrames(function _realpathSync(...args) {
         const str = origRealpathSync(...args);
         const escapedRoot = isEscape(args[0], str);
         if (escapedRoot) {
@@ -237,7 +237,7 @@ const patcher = (fs = _fs, roots) => {
         }
         return str;
     });
-    fs.realpathSync.native = hideStackFrames((...args) => {
+    fs.realpathSync.native = hideStackFrames(function _native_realpathSync(...args) {
         const str = origRealpathSyncNative(...args);
         const escapedRoot = isEscape(args[0], str);
         if (escapedRoot) {
@@ -294,7 +294,7 @@ const patcher = (fs = _fs, roots) => {
         };
         origReadlink(...args);
     };
-    fs.readlinkSync = hideStackFrames((...args) => {
+    fs.readlinkSync = hideStackFrames(function _readlinkSync(...args) {
         const resolved = path.resolve(args[0]);
         const str = path.resolve(path.dirname(resolved), origReadlinkSync(...args));
         const escapedRoot = isEscape(resolved, str);
@@ -350,7 +350,7 @@ const patcher = (fs = _fs, roots) => {
         };
         origReaddir(...args);
     };
-    fs.readdirSync = hideStackFrames((...args) => {
+    fs.readdirSync = hideStackFrames(function _readdirSync(...args) {
         const res = origReaddirSync(...args);
         const p = path.resolve(args[0]);
         res.forEach((v) => {

--- a/js/private/node-patches/src/fs.ts
+++ b/js/private/node-patches/src/fs.ts
@@ -168,7 +168,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
         origLstat(...args)
     }
 
-    fs.lstatSync = hideStackFrames((...args: any[]) => {
+    fs.lstatSync = hideStackFrames(function _lstatSync(...args: any[]) {
         const stats = origLstatSync(...args)
 
         if (!stats.isSymbolicLink()) {
@@ -258,7 +258,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
         origRealpathNative(...args)
     }
 
-    fs.realpathSync = hideStackFrames((...args: any[]) => {
+    fs.realpathSync = hideStackFrames(function _realpathSync(...args: any[]) {
         const str = origRealpathSync(...args)
         const escapedRoot: string | false = isEscape(args[0], str)
         if (escapedRoot) {
@@ -267,7 +267,9 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
         return str
     })
 
-    fs.realpathSync.native = hideStackFrames((...args: any[]) => {
+    fs.realpathSync.native = hideStackFrames(function _native_realpathSync(
+        ...args: any[]
+    ) {
         const str = origRealpathSyncNative(...args)
         const escapedRoot: string | false = isEscape(args[0], str)
         if (escapedRoot) {
@@ -331,7 +333,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
         origReadlink(...args)
     }
 
-    fs.readlinkSync = hideStackFrames((...args: any[]) => {
+    fs.readlinkSync = hideStackFrames(function _readlinkSync(...args: any[]) {
         const resolved = path.resolve(args[0])
 
         const str = path.resolve(
@@ -399,7 +401,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
         origReaddir(...args)
     }
 
-    fs.readdirSync = hideStackFrames((...args: any[]) => {
+    fs.readdirSync = hideStackFrames(function _readdirSync(...args: any[]) {
         const res = origReaddirSync(...args)
         const p = path.resolve(args[0])
         res.forEach((v: Dirent | any) => {


### PR DESCRIPTION
Caches all fs access operations when reading symlinks, specifically: if a file is a symlink, and what it points.

The underlying `readlinkSync` call throws when called on a non-symlink. Previously calculating the exception stack trace used a significant amount of time. This prevents the exception by doing `lstat` first, the combined result of `lstat` + `readlink` are then cached.