### PR TITLE
fix: update fixed releaser format

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,1 +1,3 @@
-fixedReleaser: jbedard
+fixedReleaser:
+    login: jbedard
+    email: jason@aspect.dev


### PR DESCRIPTION
Made a breaking change to the BCR app API. `fixedReleaser` now needs an email because the app can't reliably get a user's email to use in the bcr commit unless they make their email public.