### PR TITLE
chore: remove redunant --experimental_allow_unresolved_symlinks

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -68,8 +68,5 @@ build --nolegacy_external_runfiles
 # See https://github.com/angular/angular/issues/27514.
 build --incompatible_strict_action_env
 
-# TODO: enable once this is supported in Bazel
-build:rbe --experimental_allow_unresolved_symlinks
-
 # Enable with --config=release
 build:release --stamp --workspace_status_command=$(pwd)/workspace_status.sh


### PR DESCRIPTION
`--experimental_allow_unresolved_symlinks` is already on by default in Bazel 6.0.0rc1 which is the version used with RBE