### PR TITLE
renovate: upgrade aspect deps asap, reduce spam of various dep types/names

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,38 +16,42 @@
 
     "packageRules": [
         {
-            "matchPackagePatterns": ["*"],
+            "matchPackagePatterns": ["npm"],
             "stabilityDays": 3
         },
         {
-            "matchPackagePatterns": ["*"],
-            "matchUpdateTypes": ["patch"],
             "groupName": "all patch updates",
-            "groupSlug": "all-patch"
+            "matchPackagePatterns": ["*"],
+            "matchUpdateTypes": ["patch"]
+        },
+        {
+            "groupName": "Bazel",
+            "matchManagers": ["bazel"],
+            "matchUpdateTypes": ["patch", "minor"]
+        },
+        {
+            "groupName": "Aspect",
+            "matchSourceUrlPrefixes": ["https://github.com/aspect-build/"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "schedule": null
+        },
+        {
+            "groupName": "@types",
+            "matchUpdateTypes": ["major"],
+            "matchPackagePatterns": ["^@types/"],
+            "extends": ["schedule:monthly"]
         },
         {
             "groupName": "rollup",
-            "groupSlug": "rollup",
-            "matchPackageNames": ["rollup"],
-            "matchPackagePatterns": ["^rollup-", "^@rollup/", "-rollup-"]
+            "matchUpdateTypes": ["major"],
+            "matchPackagePatterns": ["rollup"],
+            "extends": ["schedule:monthly"]
         },
         {
             "groupName": "Webpack",
-            "groupSlug": "webpack",
-            "matchPackagePatterns": ["^webpack-", "^@webpack-cli/", "-webpack-"]
-        },
-        {
-            "groupName": "Bazel rules",
-            "groupSlug": "bazel_rules",
-            "matchManagers": ["bazel"],
-            "matchUpdateTypes": ["patch", "minor"]
-        },
-        {
-            "groupName": "Aspect rules",
-            "groupSlug": "aspect_rules",
-            "matchManagers": ["bazel"],
-            "matchPackagePatterns": ["^aspect_"],
-            "matchUpdateTypes": ["patch", "minor"]
+            "matchUpdateTypes": ["major"],
+            "matchPackagePatterns": ["webpack"],
+            "extends": ["schedule:monthly"]
         }
     ]
 }


### PR DESCRIPTION
Still playing around with this config in rules_js before we put it into each of our repos and enable it everywhere. Main goal is the reduce spam while still automating things. Can hopefully enable automerge as well.

The summary:
* use standard/recommended config, group by monorepo etc, send PRs weekly by default
* group all patches (unless one of the below matches)
* group all bazel minor/patch
* group all in the aspect github org, open PRs instantly
* group a few spamy npm packages (types/rollup/webpack) and do them monthly
* otherwise it will open individual PRs weekly