### PR TITLE
Add example showing error when a package relies on node_gyp when installing

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -7,6 +7,7 @@ examples/npm_package/packages/pkg_b/node_modules/
 examples/webpack_cli/node_modules/
 examples/macro/node_modules/
 examples/npm_deps/node_modules/
+examples/build_with_node_gyp/node_modules/
 node_modules/
 npm/private/test/node_modules/
 js/private/coverage/bundle/node_modules

--- a/examples/build_with_node_gyp/BUILD.bazel
+++ b/examples/build_with_node_gyp/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+# Link all direct dependencies in /examples/npm_deps/package.json to
+# bazel-bin/examples/npm_deps/node_modules
+npm_link_all_packages(name = "node_modules")
+
+js_test(
+    name = "test_peer",
+    data = [
+        ":node_modules/ffi-napi"
+    ],
+    entry_point = "peer_test.js",
+)

--- a/examples/build_with_node_gyp/package.json
+++ b/examples/build_with_node_gyp/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "devDependencies": {
+        "ffi-napi": "4.0.3"
+    }
+}

--- a/examples/build_with_node_gyp/peer_test.js
+++ b/examples/build_with_node_gyp/peer_test.js
@@ -1,2 +1,3 @@
 const ffiNapi = require('ffi-napi/package.json')
+const assert = require('assert')
 assert.equal(ffiNapi.version, '4.0.3')

--- a/examples/build_with_node_gyp/peer_test.js
+++ b/examples/build_with_node_gyp/peer_test.js
@@ -1,0 +1,2 @@
+const ffiNapi = require('ffi-napi/package.json')
+assert.equal(ffiNapi.version, '17.0.2')

--- a/examples/build_with_node_gyp/peer_test.js
+++ b/examples/build_with_node_gyp/peer_test.js
@@ -1,2 +1,2 @@
 const ffiNapi = require('ffi-napi/package.json')
-assert.equal(ffiNapi.version, '17.0.2')
+assert.equal(ffiNapi.version, '4.0.3')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       mocha-junit-reporter: 2.0.2_mocha@10.0.0
       mocha-multi-reporters: 1.5.1_ta7lpi5wbajlqvkh4rve5z6nji
 
+  examples/build_with_node_gyp:
+    specifiers:
+      ffi-napi: 4.0.3
+    devDependencies:
+      ffi-napi: 4.0.3
+
   examples/npm_deps:
     specifiers:
       '@aspect-test/a': 5.0.2
@@ -1892,6 +1898,21 @@ packages:
     resolution: {integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==}
     dev: false
 
+  /ffi-napi/4.0.3:
+    resolution: {integrity: sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    dependencies:
+      debug: 4.3.4
+      get-uv-event-loop-napi-h: 1.0.6
+      node-addon-api: 3.2.1
+      node-gyp-build: 4.5.0
+      ref-napi: 3.0.3
+      ref-struct-di: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /fill-range/7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
@@ -2048,6 +2069,16 @@ packages:
   /get-stream/6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+    dev: true
+
+  /get-symbol-from-current-process-h/1.0.2:
+    resolution: {integrity: sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==}
+    dev: true
+
+  /get-uv-event-loop-napi-h/1.0.6:
+    resolution: {integrity: sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==}
+    dependencies:
+      get-symbol-from-current-process-h: 1.0.2
     dev: true
 
   /getpass/0.1.7:
@@ -3137,8 +3168,17 @@ packages:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
     dev: true
 
+  /node-addon-api/3.2.1:
+    resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
+    dev: true
+
   /node-gyp-build/3.7.0:
     resolution: {integrity: sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==}
+    hasBin: true
+    dev: true
+
+  /node-gyp-build/4.5.0:
+    resolution: {integrity: sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==}
     hasBin: true
     dev: true
 
@@ -3649,6 +3689,27 @@ packages:
     dependencies:
       resolve: 1.22.1
     dev: false
+
+  /ref-napi/3.0.3:
+    resolution: {integrity: sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==}
+    engines: {node: '>= 10.0'}
+    requiresBuild: true
+    dependencies:
+      debug: 4.3.4
+      get-symbol-from-current-process-h: 1.0.2
+      node-addon-api: 3.2.1
+      node-gyp-build: 4.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /ref-struct-di/1.1.1:
+    resolution: {integrity: sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==}
+    dependencies:
+      debug: 3.2.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
     - 'examples/js_binary'
     - 'examples/macro'
+    - 'examples/build_with_node_gyp'
     - 'examples/npm_deps'
     - 'examples/npm_package/libs/lib_a'
     - 'examples/npm_package/packages/pkg_a'


### PR DESCRIPTION
Error when building a package that relies on node_gyp (ffi-napi in this example). Same error in https://github.com/aspect-build/rules_js/issues/217#issue-1274142656 . I'm running Ubuntu 20.04.5 LTS (Focal Fossa). 

The error seems to be caused by the minification/bundling of the lifecycle-hooks.js package, as when I have tested it without that it works fine.

Please run "bazel test //examples/build_with_node_gyp:test_peer" to see the error.

```
gitpod /workspace/rules_js (main) $ bazel test //examples/build_with_node_gyp:test_peer
INFO: Analyzed target //examples/build_with_node_gyp:test_peer (1 packages loaded, 23 targets configured).
INFO: Found 1 test target...
ERROR: /workspace/rules_js/BUILD.bazel:10:22: Running lifecycle hooks on npm package ffi-napi@4.0.3 failed: (Exit 1): lifecycle-hooks.sh failed: error executing command bazel-out/k8-opt-exec-2B5CBBC6/bin/npm/private/lifecycle/lifecycle-hooks.sh ffi-napi ../../../external/npm__ffi-napi__4.0.3/package ... (remaining 1 argument skipped)
/home/gitpod/.cache/bazel/_bazel_gitpod/8929c5e70d06b7c2fffe878c4da6441a/execroot/aspect_rules_js/bazel-out/k8-fastbuild/bin/npm/private/lifecycle/min/node-gyp-bin/node-gyp: 5: 1010: not found
Error: ffi-napi@4.0.3 install: `node-gyp-build`
spawn ENOENT
    at ChildProcess.<anonymous> (/home/gitpod/.cache/bazel/_bazel_gitpod/8929c5e70d06b7c2fffe878c4da6441a/execroot/aspect_rules_js/bazel-out/k8-fastbuild/bin/npm/private/lifecycle/min/index.min.js:1:79716)
    at ChildProcess.emit (node:events:394:28)
    at maybeClose (node:internal/child_process:1064:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5) {
  code: 'ELIFECYCLE',
  errno: 'ENOENT',
  syscall: 'spawn',
  file: 'sh',
  pkgid: 'ffi-napi@4.0.3',
  stage: 'install',
  script: 'node-gyp-build',
  pkgname: 'ffi-napi'
}

> ffi-napi@4.0.3 install /home/gitpod/.cache/bazel/_bazel_gitpod/8929c5e70d06b7c2fffe878c4da6441a/execroot/aspect_rules_js/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/ffi-napi@4.0.3/node_modules/ffi-napi
> node-gyp-build

Target //examples/build_with_node_gyp:test_peer failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 1.204s, Critical Path: 0.78s
INFO: 8 processes: 7 internal, 1 local.
FAILED: Build did NOT complete successfully
//examples/build_with_node_gyp:test_peer                        FAILED TO BUILD

FAILED: Build did NOT complete successfully
```