### PR TITLE
fix: allow for absolute path to node specified in target_tool_path in node_toolchain

### DIFF
--- a/e2e/vendored_node/.bazelignore
+++ b/e2e/vendored_node/.bazelignore
@@ -1,0 +1,1 @@
+node_modules

--- a/e2e/vendored_node/.bazelrc
+++ b/e2e/vendored_node/.bazelrc
@@ -1,0 +1,2 @@
+# import common bazelrc shared with e2e workspaces
+import %workspace%/../../.bazelrc.common

--- a/e2e/vendored_node/.bazelversion
+++ b/e2e/vendored_node/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/vendored_node/BUILD.bazel
+++ b/e2e/vendored_node/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+
+js_test(
+    name = "test",
+    entry_point = "test.js",
+)

--- a/e2e/vendored_node/WORKSPACE
+++ b/e2e/vendored_node/WORKSPACE
@@ -1,0 +1,37 @@
+local_repository(
+    name = "aspect_rules_js",
+    path = "../..",
+)
+
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# See comment in README about these fetches
+http_archive(
+    name = "vendored_node_linux_amd64",
+    build_file_content = """exports_files(["bin/node"])""",
+    sha256 = "cc9c3eed21755b490e5333ccab208ce15b539c35f64a764eeeae77c58746a7ff",
+    strip_prefix = "node-v15.0.1-linux-x64",
+    urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-x64.tar.xz"],
+)
+
+http_archive(
+    name = "vendored_node_darwin_amd64",
+    build_file_content = """exports_files(["bin/node"])""",
+    sha256 = "78571df5b35d3ec73d7543332776bcb8cab3bc0e3abd12b1440fbcd01c74c055",
+    strip_prefix = "node-v15.0.1-darwin-x64",
+    urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-darwin-x64.tar.xz"],
+)
+
+http_archive(
+    name = "vendored_node_windows_amd64",
+    build_file_content = """exports_files(["node.exe"])""",
+    sha256 = "efa7a74d91789a6e9f068f375e49f108ff87578fd88ff4b4e7fefd930c04db6c",
+    strip_prefix = "node-v15.0.1-win-x64",
+    urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-win-x64.zip"],
+)
+
+register_toolchains("//toolchains:all")

--- a/e2e/vendored_node/test.js
+++ b/e2e/vendored_node/test.js
@@ -1,0 +1,8 @@
+console.log(process.version)
+
+if (process.version != 'v15.0.1') {
+    console.error('Expected node version to be the one we vendored')
+    process.exit(1)
+}
+
+console.log('All checked passed')

--- a/e2e/vendored_node/toolchains/BUILD.bazel
+++ b/e2e/vendored_node/toolchains/BUILD.bazel
@@ -1,0 +1,42 @@
+"""Define toolchains for nodejs
+
+Note that this file causes eager fetches of node for all platforms
+because the Bazel analysis phase follows the labels below.
+
+In a real project you would vendor the binaries you need, or
+build them from source, so there shouldn't be any fetches required.
+"""
+
+load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
+
+[
+    toolchain(
+        name = "node15_%s_toolchain" % os,
+        exec_compatible_with = [
+            "@platforms//os:" + os,
+            "@platforms//cpu:x86_64",
+        ],
+        toolchain = ":node_" + os,
+        toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+    )
+    for os in [
+        "linux",
+        "macos",
+        "windows",
+    ]
+]
+
+node_toolchain(
+    name = "node_linux",
+    target_tool = "@vendored_node_linux_amd64//:bin/node",
+)
+
+node_toolchain(
+    name = "node_macos",
+    target_tool = "@vendored_node_darwin_amd64//:bin/node",
+)
+
+node_toolchain(
+    name = "node_windows",
+    target_tool = "@vendored_node_windows_amd64//:node.exe",
+)

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -195,22 +195,42 @@ if [ ! -f "$entry_point" ]; then
     exit 1
 fi
 
-export JS_BINARY__NODE_BINARY="$JS_BINARY__RUNFILES/{{workspace_name}}/{{node}}"
-if [ ! -f "$JS_BINARY__NODE_BINARY" ]; then
-    logf_fatal "node binary '%s' not found in runfiles" "$JS_BINARY__NODE_BINARY"
-    exit 1
+node="$(_normalize_path "{{node}}")"
+if [ "${node:0:1}" = "/" ]; then
+    # A user may specify an absolute path to node using target_tool_path in node_toolchain
+    export JS_BINARY__NODE_BINARY="$node"
+    if [ ! -f "$JS_BINARY__NODE_BINARY" ]; then
+        logf_fatal "node binary '%s' not found" "$JS_BINARY__NODE_BINARY"
+        exit 1
+    fi
+else
+    export JS_BINARY__NODE_BINARY="$JS_BINARY__RUNFILES/{{workspace_name}}/{{node}}"
+    if [ ! -f "$JS_BINARY__NODE_BINARY" ]; then
+        logf_fatal "node binary '%s' not found in runfiles" "$JS_BINARY__NODE_BINARY"
+        exit 1
+    fi
 fi
 if [ "$_IS_WINDOWS" -ne "1" ] && [ ! -x "$JS_BINARY__NODE_BINARY" ]; then
     logf_fatal "node binary '%s' is not executable" "$JS_BINARY__NODE_BINARY"
     exit 1
 fi
 
-npm={{npm}}
+npm="{{npm}}"
 if [ "$npm" ]; then
-    export JS_BINARY__NPM_BINARY="$JS_BINARY__RUNFILES/{{workspace_name}}/{{npm}}"
-    if [ ! -f "$JS_BINARY__NPM_BINARY" ]; then
-        logf_fatal "npm binary '%s' not found in runfiles" "$JS_BINARY__NPM_BINARY"
-        exit 1
+    npm="$(_normalize_path "$npm")"
+    if [ "${npm:0:1}" = "/" ]; then
+        # A user may specify an absolute path to npm using npm_path in node_toolchain
+        export JS_BINARY__NPM_BINARY="$npm"
+        if [ ! -f "$JS_BINARY__NPM_BINARY" ]; then
+            logf_fatal "npm binary '%s' not found" "$JS_BINARY__NPM_BINARY"
+            exit 1
+        fi
+    else
+        export JS_BINARY__NPM_BINARY="$JS_BINARY__RUNFILES/{{workspace_name}}/{{npm}}"
+        if [ ! -f "$JS_BINARY__NPM_BINARY" ]; then
+            logf_fatal "npm binary '%s' not found in runfiles" "$JS_BINARY__NPM_BINARY"
+            exit 1
+        fi
     fi
     if [ "$_IS_WINDOWS" -ne "1" ] && [ ! -x "$JS_BINARY__NPM_BINARY" ]; then
         logf_fatal "npm binary '%s' is not executable" "$JS_BINARY__NPM_BINARY"

--- a/js/private/test/shellcheck_launcher.sh
+++ b/js/private/test/shellcheck_launcher.sh
@@ -311,22 +311,42 @@ if [ ! -f "$entry_point" ]; then
     exit 1
 fi
 
-export JS_BINARY__NODE_BINARY="$JS_BINARY__RUNFILES/aspect_rules_js/../nodejs_linux_amd64/bin/nodejs/bin/node"
-if [ ! -f "$JS_BINARY__NODE_BINARY" ]; then
-    logf_fatal "node binary '%s' not found in runfiles" "$JS_BINARY__NODE_BINARY"
-    exit 1
+node="$(_normalize_path "../nodejs_linux_amd64/bin/nodejs/bin/node")"
+if [ "${node:0:1}" = "/" ]; then
+    # A user may specify an absolute path to node using target_tool_path in node_toolchain
+    export JS_BINARY__NODE_BINARY="$node"
+    if [ ! -f "$JS_BINARY__NODE_BINARY" ]; then
+        logf_fatal "node binary '%s' not found" "$JS_BINARY__NODE_BINARY"
+        exit 1
+    fi
+else
+    export JS_BINARY__NODE_BINARY="$JS_BINARY__RUNFILES/aspect_rules_js/../nodejs_linux_amd64/bin/nodejs/bin/node"
+    if [ ! -f "$JS_BINARY__NODE_BINARY" ]; then
+        logf_fatal "node binary '%s' not found in runfiles" "$JS_BINARY__NODE_BINARY"
+        exit 1
+    fi
 fi
 if [ "$_IS_WINDOWS" -ne "1" ] && [ ! -x "$JS_BINARY__NODE_BINARY" ]; then
     logf_fatal "node binary '%s' is not executable" "$JS_BINARY__NODE_BINARY"
     exit 1
 fi
 
-npm=
+npm=""
 if [ "$npm" ]; then
-    export JS_BINARY__NPM_BINARY="$JS_BINARY__RUNFILES/aspect_rules_js/"
-    if [ ! -f "$JS_BINARY__NPM_BINARY" ]; then
-        logf_fatal "npm binary '%s' not found in runfiles" "$JS_BINARY__NPM_BINARY"
-        exit 1
+    npm="$(_normalize_path "$npm")"
+    if [ "${npm:0:1}" = "/" ]; then
+        # A user may specify an absolute path to npm using npm_path in node_toolchain
+        export JS_BINARY__NPM_BINARY="$npm"
+        if [ ! -f "$JS_BINARY__NPM_BINARY" ]; then
+            logf_fatal "npm binary '%s' not found" "$JS_BINARY__NPM_BINARY"
+            exit 1
+        fi
+    else
+        export JS_BINARY__NPM_BINARY="$JS_BINARY__RUNFILES/aspect_rules_js/"
+        if [ ! -f "$JS_BINARY__NPM_BINARY" ]; then
+            logf_fatal "npm binary '%s' not found in runfiles" "$JS_BINARY__NPM_BINARY"
+            exit 1
+        fi
     fi
     if [ "$_IS_WINDOWS" -ne "1" ] && [ ! -x "$JS_BINARY__NPM_BINARY" ]; then
         logf_fatal "npm binary '%s' is not executable" "$JS_BINARY__NPM_BINARY"


### PR DESCRIPTION
I also ported over the e2e test from rules_nodejs for a vendored node but there still is no test coverage for the absolute path to node & npm as that test would depend on having a node on the local machine. Could be added to a CI only test at some point but not that important atm. I had a need for this change when testing against a locally built node from source which is how this came up. Tested locally that the absolute path to node works:

```
load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")

toolchain(
    name = "node_macos_toolchain",
    exec_compatible_with = [
        "@platforms//os:macos",
        "@platforms//cpu:x86_64",
    ],
    toolchain = ":node_macos",
    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
)

node_toolchain(
    name = "node_macos",
    target_tool_path = "/Users/greg/aspect/oss/node/out/Release/node",
)
```

```
register_toolchains("//:node_macos_toolchain")
```