### PR TITLE
fix: sync fs esm library after patching cjs version

### DIFF
--- a/js/private/node-patches/register.js
+++ b/js/private/node-patches/register.js
@@ -35,7 +35,8 @@ if (
     JS_BINARY__PATCH_NODE_FS != '0' &&
     JS_BINARY__FS_PATCH_ROOTS
 ) {
-    const fs = require('fs')
+    const fs = require('node:fs')
+    const module = require('node:module')
     const roots = JS_BINARY__FS_PATCH_ROOTS.split(':')
     if (JS_BINARY__LOG_DEBUG) {
         console.error(
@@ -43,4 +44,8 @@ if (
         )
     }
     patchfs(fs, roots)
+
+    // Sync the esm modules to use the now patched fs cjs module.
+    // See: https://nodejs.org/api/esm.html#builtin-modules
+    module.syncBuiltinESMExports()
 }


### PR DESCRIPTION
For example as a test... without the `syncBuiltinESMExports` the last log (5) is false:
```
    import('fs').then(importFS => {
        console.log(1, origReaddirSync === fs.readdirSync)          // pre patched
        console.log(2, origReaddirSync === importFS.readdirSync)    // pre patch
        patchfs(fs, roots)
        console.log(3, origReaddirSync !== fs.readdirSync)          // post patched
        console.log(4, origReaddirSync === importFS.readdirSync)    // pre synced
        module.syncBuiltinESMExports()
        console.log(5, origReaddirSync !== importFS.readdirSync)    // post sync
    });
```