### PR TITLE
fix: include transitive linked npm deps in js_run_devserver sandbox

### DIFF
--- a/docs/js_run_devserver.md
+++ b/docs/js_run_devserver.md
@@ -76,8 +76,10 @@ and run in watch mode using [ibazel](https://github.com/bazelbuild/bazel-watcher
 The devserver specified by either `tool` or `command` is run in a custom sandbox that is more
 compatible with devserver watch modes in Node.js tools such as Webpack and Next.js.
 
-The custom sandbox is populated with the default outputs of all targets in `data`.
-rules_js npm package link targets such as `//:node_modules/next` are supported.
+The custom sandbox is populated with the default outputs of all targets in `data`
+as well as transitive npm links.
+
+rules_js npm package link targets such as `//:node_modules/next` are handled efficiently.
 Since these targets are symlinks in the output tree, they are recreated as symlinks
 in the custom sandbox and do not incur a fully copy of the underlying npm packages.
 

--- a/e2e/js_run_devserver/package.json
+++ b/e2e/js_run_devserver/package.json
@@ -1,5 +1,6 @@
 {
     "devDependencies": {
+        "chalk": "4.1.2",
         "http-server": "14.1.1",
         "@bazel/ibazel": "0.16.2"
     }

--- a/e2e/js_run_devserver/pnpm-lock.yaml
+++ b/e2e/js_run_devserver/pnpm-lock.yaml
@@ -5,9 +5,11 @@ importers:
   .:
     specifiers:
       '@bazel/ibazel': 0.16.2
+      chalk: 4.1.2
       http-server: 14.1.1
     devDependencies:
       '@bazel/ibazel': 0.16.2
+      chalk: 4.1.2
       http-server: 14.1.1
 
 packages:

--- a/e2e/js_run_devserver/src/BUILD.bazel
+++ b/e2e/js_run_devserver/src/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_rules_js//js:defs.bzl", "js_run_devserver")
+load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_devserver")
 load("@com_github_ash2k_bazel_tools//multirun:def.bzl", "command", "multirun")
 load("@npm//:http-server/package_json.bzl", http_server_bin = "bin")
 
@@ -61,10 +61,34 @@ command(
 # See https://github.com/ash2k/bazel-tools/tree/master/multirun.
 # This can be used with ibazel: ibazel run //src:serve_all
 multirun(
-    name = "serve_all",
+    name = "serve_multi",
     commands = [
         ":serve",
         ":serve_alt",
     ],
     jobs = 0,
+)
+
+# Intentionally a js_library and not a js_binary to test that transitive npm are
+# include in js_run_devserver. See https://github.com/aspect-build/rules_webpack/issues/66.
+js_library(
+    name = "simple",
+    srcs = [
+        "simple.js",
+    ],
+    deps = [
+        "//:node_modules/chalk",
+    ],
+)
+
+# Another example but this time using a simple custom http-server js_binary
+js_run_devserver(
+    name = "serve_simple",
+    chdir = package_name(),
+    command = "./simple.js",
+    data = [
+        "index.html",
+        "other.html",
+        ":simple",
+    ],
 )

--- a/e2e/js_run_devserver/src/simple.js
+++ b/e2e/js_run_devserver/src/simple.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const http = require('http')
+const url = require('url')
+const fs = require('fs')
+const chalk = require('chalk')
+
+http.createServer(function (req, res) {
+    const q = url.parse(req.url, true)
+    const filename = q.pathname == '/' ? './index.html' : '.' + q.pathname
+    console.log(`Serving ${chalk.italic.bgBlue(filename)}`)
+    fs.readFile(filename, function (err, data) {
+        if (err) {
+            res.writeHead(404, { 'Content-Type': 'text/html' })
+            return res.end('404 Not Found')
+        }
+        res.writeHead(200, { 'Content-Type': 'text/html' })
+        res.write(data)
+        console.log(require.resolve('chalk'))
+        return res.end()
+    })
+}).listen(8080)

--- a/e2e/js_run_devserver/test.sh
+++ b/e2e/js_run_devserver/test.sh
@@ -7,4 +7,5 @@ bazel run -- @pnpm//:pnpm --dir "$PWD" install
 
 ./serve_test.sh //src:serve
 ./serve_test.sh //src:serve_alt
-./multirun_test.sh //src:serve_all
+./serve_test.sh //src:serve_simple
+./multirun_test.sh //src:serve_multi

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -127,6 +127,7 @@ bzl_library(
     deps = [
         ":js_binary",
         ":js_binary_helpers",
+        ":js_library_helpers",
         "@bazel_skylib//lib:dicts",
     ],
 )

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -2,6 +2,7 @@
 
 load(":js_binary.bzl", "js_binary_lib")
 load(":js_binary_helpers.bzl", _gather_files_from_js_providers = "gather_files_from_js_providers")
+load(":js_library_helpers.bzl", _gather_npm_linked_packages = "gather_npm_linked_packages")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 _DOC = """Runs a devserver via binary target or command.
@@ -67,8 +68,10 @@ and run in watch mode using [ibazel](https://github.com/bazelbuild/bazel-watcher
 The devserver specified by either `tool` or `command` is run in a custom sandbox that is more
 compatible with devserver watch modes in Node.js tools such as Webpack and Next.js.
 
-The custom sandbox is populated with the default outputs of all targets in `data`.
-rules_js npm package link targets such as `//:node_modules/next` are supported.
+The custom sandbox is populated with the default outputs of all targets in `data`
+as well as transitive npm links.
+
+rules_js npm package link targets such as `//:node_modules/next` are handled efficiently.
 Since these targets are symlinks in the output tree, they are recreated as symlinks
 in the custom sandbox and do not incur a fully copy of the underlying npm packages.
 
@@ -113,8 +116,18 @@ def _impl(ctx):
     if ctx.attr.tool and ctx.attr.command:
         fail("Only one of tool or command may be specified")
 
+    # The .to_list() calls here are intentional and cannot be avoided; they should be small sets of
+    # files as they only include direct npm links (node_modules/foo) and the virtual store tree
+    # artifacts those symlinks point to (node_modules/.aspect_rules_js/foo@1.2.3/node_modules/foo)
+    transitive_npm_links_files = []
+    transitive_npm_links = depset(transitive = [p.files for p in _gather_npm_linked_packages(srcs = [], deps = ctx.attr.data).transitive.to_list()])
+    for f in transitive_npm_links.to_list():
+        # don't include the virtual store tree artifact; only the node_module link is needed
+        if not "/.aspect_rules_js/" in f.path:
+            transitive_npm_links_files.append(f)
+
     config = {
-        "data_files": [f.short_path for f in ctx.files.data],
+        "data_files": [f.short_path for f in ctx.files.data + transitive_npm_links_files],
     }
     if ctx.attr.tool:
         config["tool"] = ctx.executable.tool.short_path


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_webpack/issues/66

Also address Bazel Slack question https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1667857230697759