### PR TITLE
test: explicitly set devserver test ports

### DIFF
--- a/e2e/js_run_devserver/multirun_test.sh
+++ b/e2e/js_run_devserver/multirun_test.sh
@@ -12,6 +12,8 @@ _sedi () {
   sed "${sedi[@]}" "$@"
 }
 
+echo "TEST - $0: $1"
+
 ./node_modules/.bin/ibazel run "$1" >/dev/null 2>&1 &
 ibazel_pid="$!"
 
@@ -23,15 +25,17 @@ function _exit {
 }
 trap _exit EXIT
 
-echo "Waiting for $1 devservers to launch on 8080 and 8081..."
+echo "Waiting for $1 devservers to launch on 8080..."
 
 while ! nc -z localhost 8080; do
-  echo "."
+  echo "... waiting (8080)"
   sleep 0.5 # wait before check again
 done
 
+echo "Waiting for $1 devservers to launch on 8081..."
+
 while ! nc -z localhost 8081; do
-  echo "."
+  echo "... waiting (8081)"
   sleep 0.5 # wait before check again
 done
 

--- a/e2e/js_run_devserver/serve_test.sh
+++ b/e2e/js_run_devserver/serve_test.sh
@@ -12,6 +12,8 @@ _sedi () {
   sed "${sedi[@]}" "$@"
 }
 
+echo "TEST - $0: $1"
+
 ./node_modules/.bin/ibazel run "$1" >/dev/null 2>&1 &
 ibazel_pid="$!"
 

--- a/e2e/js_run_devserver/src/BUILD.bazel
+++ b/e2e/js_run_devserver/src/BUILD.bazel
@@ -11,6 +11,10 @@ http_server_bin.http_server_binary(
 # as the tool
 js_run_devserver(
     name = "devserver",
+    args = [
+        "-p",
+        "8080",
+    ],
     chdir = package_name(),
     data = [
         "index.html",
@@ -41,6 +45,10 @@ copy_to_directory(
 # entry point
 js_run_devserver(
     name = "devserver_alt",
+    args = [
+        "-p",
+        "8081",
+    ],
     chdir = package_name(),
     command = "../node_modules/.bin/http-server",
     data = [


### PR DESCRIPTION
I've seen this randomly failing, specifically timing out I think due to a port conflict?

If I'm understanding this correctly the multirun test was assuming the first run would take port 8080 and the second would take 8081 because 8080 was in use? This is a race condition and I'm finding the second one often also tries 8080 and then fails, the "waiting (8081)" loop then loops forever.

I found the logging info useful when trying to debug so leaving it in.