### PR TITLE
fix: include transitive source in js_run_devserver sandbox

### DIFF
--- a/docs/js_run_devserver.md
+++ b/docs/js_run_devserver.md
@@ -77,11 +77,14 @@ The devserver specified by either `tool` or `command` is run in a custom sandbox
 compatible with devserver watch modes in Node.js tools such as Webpack and Next.js.
 
 The custom sandbox is populated with the default outputs of all targets in `data`
-as well as transitive npm links.
+as well as transitive sources & npm links.
 
-rules_js npm package link targets such as `//:node_modules/next` are handled efficiently.
-Since these targets are symlinks in the output tree, they are recreated as symlinks
-in the custom sandbox and do not incur a fully copy of the underlying npm packages.
+An an optimization, virtual store files are explicitly excluded from the sandbox since the npm
+links will point to the virtual store in the execroot and Node.js will follow those links as it
+does within the execroot. As a result, rules_js npm package link targets such as
+`//:node_modules/next` are handled efficiently. Since these targets are symlinks in the output
+tree, they are recreated as symlinks in the custom sandbox and do not incur a fully copy of the
+underlying npm packages.
 
 Supports running with [ibazel](https://github.com/bazelbuild/bazel-watcher).
 Only `data` files that change on incremental builds are synchronized when running with ibazel.

--- a/e2e/js_run_devserver/multirun_test.sh
+++ b/e2e/js_run_devserver/multirun_test.sh
@@ -93,7 +93,7 @@ if ! curl http://localhost:8081/index.html --fail 2>/dev/null | grep "A second l
 fi
 
 echo "<div>A new file</div>" > src/new.html
-_sedi 's#"other.html",#"other.html", "new.html",#' src/BUILD.bazel
+_sedi 's#"other.html"#"other.html", "new.html"#' src/BUILD.bazel
 
 echo "Waiting 10 seconds for ibazel rebuild after change to src/BUILD.bazel..."
 sleep 10

--- a/e2e/js_run_devserver/serve_test.sh
+++ b/e2e/js_run_devserver/serve_test.sh
@@ -63,7 +63,7 @@ if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "A second l
 fi
 
 echo "<div>A new file</div>" > src/new.html
-_sedi 's#"other.html",#"other.html", "new.html",#' src/BUILD.bazel
+_sedi 's#"other.html"#"other.html", "new.html"#' src/BUILD.bazel
 
 echo "Waiting 10 seconds for ibazel rebuild after change to src/BUILD.bazel..."
 sleep 10

--- a/e2e/js_run_devserver/src/BUILD.bazel
+++ b/e2e/js_run_devserver/src/BUILD.bazel
@@ -7,15 +7,25 @@ http_server_bin.http_server_binary(
     name = "http_server",
 )
 
+# A trivial graph of sources to include in js_run_devserver data to test
+# that transitive sources are include
+js_library(
+    name = "transitive_web_files",
+    srcs = ["other.html"],
+)
+
+js_library(
+    name = "web_files",
+    srcs = ["index.html"],
+    deps = [":transitive_web_files"],
+)
+
 # Simple js_run_devserver rule that syncs two html files and takes an http-server js_binary
 # as the tool
 js_run_devserver(
     name = "devserver",
     chdir = package_name(),
-    data = [
-        "index.html",
-        "other.html",
-    ],
+    data = [":web_files"],
     log_level = "debug",
     tool = ":http_server",
 )
@@ -47,6 +57,7 @@ js_run_devserver(
         ":http_root",
         "//:node_modules/http-server",
     ],
+    log_level = "debug",
 )
 
 # Use command to bake-in the arguments into the runnable binary so that the target
@@ -87,8 +98,8 @@ js_run_devserver(
     chdir = package_name(),
     command = "./simple.js",
     data = [
-        "index.html",
-        "other.html",
         ":simple",
+        ":web_files",
     ],
+    log_level = "debug",
 )

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -127,7 +127,6 @@ bzl_library(
     deps = [
         ":js_binary",
         ":js_binary_helpers",
-        ":js_library_helpers",
         "@bazel_skylib//lib:dicts",
     ],
 )


### PR DESCRIPTION
Resolves issue reported on Bazel Slack https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1667931292061319?thread_ts=1667857230.697759&cid=CEZUUKQ6P