### PR TITLE
chore: unrelease

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "aspect_rules_js",
-    version = "1.6.8",
+    version = "0.0.0",
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
Version no longer needed in the MODULE.bazel file thanks to @kormide's wizardry in the bzlmod bot