### PR TITLE
DNL: Testing --remote_download_outputs=toplevel issue with Bazel 6.0.0rc1 & rc2

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -10,7 +10,7 @@ build:local --disk_cache=~/.cache/bazel
 
 # Generic remote cache
 build --remote_local_fallback
-# build --remote_download_toplevel # BREAKS BUILD in Bazel 6.0.0rc1
+build --remote_download_toplevel
 build --remote_timeout=3600
 build --remote_upload_local_results
 ## Fixes builds hanging on CI that get the TCP connection closed without sending RST packets.


### PR DESCRIPTION
Based on testing it looks like the issue happens with `--remote_download_outputs=toplevel` or `--remote_download_outputs=minimal` but only with sandboxed execution and when there is a `--disk_cache` or a `--remote_cache` configured.

The symptom seems to be that tree artifacts are just not present in the sandbox under these conditions. npm deps fail to resolve since the virtual store tree artifacts are not present.