### PR TITLE
chore: tidy up error messages for string substitutions so they show up cleaner when they are hit

### DIFF
--- a/e2e/js_image/js_image_layer.bzl
+++ b/e2e/js_image/js_image_layer.bzl
@@ -193,7 +193,8 @@ def js_image_layer(name, binary, root = None, **kwargs):
         **kwargs: Passed to pkg_tar. See: https://github.com/bazelbuild/rules_pkg/blob/main/docs/0.7.0/reference.md#pkg_tar
     """
     if root != None and not root.startswith("/"):
-        fail("root path must start with '/' but got '{root}', expected '/{root}'".format(root = root))
+        msg = "root path must start with '/' but got '{root}', expected '/{root}'".format(root = root)
+        fail(msg)
 
     if kwargs.pop("package_dir", None):
         fail("use 'root' attribute instead of 'package_dir'.")

--- a/js/private/js_binary_helpers.bzl
+++ b/js/private/js_binary_helpers.bzl
@@ -23,7 +23,8 @@ def envs_for_log_level(log_level):
         logs for the given log level. Typically, they are each set to "1".
     """
     if log_level not in LOG_LEVELS.keys():
-        fail("log_level must be one of {} but got {}".format(LOG_LEVELS.keys(), log_level))
+        msg = "log_level must be one of {} but got {}".format(LOG_LEVELS.keys(), log_level)
+        fail(msg)
     envs = []
     log_level_numeric = LOG_LEVELS[log_level]
     if log_level_numeric >= LOG_LEVELS["fatal"]:

--- a/npm/npm_import.bzl
+++ b/npm/npm_import.bzl
@@ -328,7 +328,8 @@ def npm_translate_lock(
     generate_bzl_library_targets = kwargs.pop("generate_bzl_library_targets", None)
 
     if len(kwargs):
-        fail("Invalid npm_translate_lock parameter '{}'".format(kwargs.keys()[0]))
+        msg = "Invalid npm_translate_lock parameter '{}'".format(kwargs.keys()[0])
+        fail(msg)
 
     if pnpm_version != None and not native.existing_rule("pnpm"):
         npm_import(
@@ -615,7 +616,8 @@ def npm_import(
     npm_translate_lock_repo = kwargs.pop("npm_translate_lock_repo", None)
     generate_bzl_library_targets = kwargs.pop("generate_bzl_library_targets", None)
     if len(kwargs):
-        fail("Invalid npm_import parameter '{}'".format(kwargs.keys()[0]))
+        msg = "Invalid npm_import parameter '{}'".format(kwargs.keys()[0])
+        fail(msg)
 
     # By convention, the `{name}` repository contains the actual npm
     # package sources downloaded from the registry and extracted

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -124,7 +124,8 @@ _PACKAGE_JSON_BZL_FILENAME = "package_json.bzl"
 def _link_package(root_package, import_path, rel_path = "."):
     link_package = paths.normalize(paths.join(root_package, import_path, rel_path))
     if link_package.startswith("../"):
-        fail("Invalid link_package outside of the WORKSPACE: {}".format(link_package))
+        msg = "Invalid link_package outside of the WORKSPACE: {}".format(link_package)
+        fail(msg)
     if link_package == ".":
         link_package = ""
     return link_package
@@ -246,7 +247,8 @@ def _gen_npm_imports(lockfile, root_package, attr, registries, default_registry)
     for import_path, importer in importers.items():
         dependencies = importer.get("dependencies")
         if type(dependencies) != "dict":
-            fail("expected dict of dependencies in processed importer '%s'" % import_path)
+            msg = "expected dict of dependencies in processed importer '{}'".format(import_path)
+            fail(msg)
         links = {
             "link_package": _link_package(root_package, import_path),
         }
@@ -476,7 +478,8 @@ def _validate_attrs(rctx):
         if rctx.attr.package_json:
             fail("The package_json attribute should not be used with pnpm_lock.")
     if count != 1:
-        fail("npm_translate_lock requires exactly one of [pnpm_lock, npm_package_lock, yarn_lock] attributes, but {} were set.".format(count))
+        msg = "npm_translate_lock requires exactly one of [pnpm_lock, npm_package_lock, yarn_lock] attributes, but {} were set.".format(count)
+        fail(msg)
 
 def _label_str(label):
     return "//{}:{}".format(
@@ -688,7 +691,8 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")"""]
     for import_path, importer in importers.items():
         dependencies = importer.get("dependencies")
         if type(dependencies) != "dict":
-            fail("expected dict of dependencies in processed importer '%s'" % import_path)
+            msg = "expected dict of dependencies in processed importer '{}'".format(import_path)
+            fail(msg)
         link_package = _link_package(root_package, import_path)
         for dep_package, dep_version in dependencies.items():
             if dep_version.startswith("file:"):
@@ -698,7 +702,8 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")"""]
                     dep_path = _link_package(root_package, dep_version[len("file:"):])
                 dep_key = "{}+{}".format(dep_package, dep_version)
                 if not dep_key in fp_links.keys():
-                    fail("Expected to file: referenced package {} in first-party links".format(dep_key))
+                    msg = "Expected to file: referenced package {} in first-party links".format(dep_key)
+                    fail(msg)
                 fp_links[dep_key]["link_packages"][link_package] = []
             elif dep_version.startswith("link:"):
                 dep_importer = paths.normalize(paths.join(import_path, dep_version[len("link:"):]))

--- a/npm/private/transitive_closure.bzl
+++ b/npm/private/transitive_closure.bzl
@@ -23,7 +23,8 @@ def gather_transitive_closure(packages, no_optional, direct_deps, transitive_clo
         if not len(stack):
             break
         if i == iteration_max:
-            fail("gather_transitive_closure exhausted the iteration limit of %s - please report this issue" % iteration_max)
+            msg = "gather_transitive_closure exhausted the iteration limit of {} - please report this issue".format(iteration_max)
+            fail(msg)
         deps = stack.pop()
         for name in deps.keys():
             version = deps[name]
@@ -58,7 +59,8 @@ def _gather_package_info(package_path, package_snapshot):
     elif package_path.startswith("file:"):
         package = package_path
         if "name" not in package_snapshot:
-            fail("expected package %s to have a name field" % package_path)
+            msg = "expected package {} to have a name field".format(package_path)
+            fail(msg)
         name = package_snapshot["name"]
         version = package_path
         friendly_version = package_snapshot["version"] if "version" in package_snapshot else version
@@ -66,23 +68,27 @@ def _gather_package_info(package_path, package_snapshot):
     else:
         package = package_path
         if "name" not in package_snapshot:
-            fail("expected package %s to have a name field" % package_path)
+            msg = "expected package {} to have a name field".format(package_path)
+            fail(msg)
         if "version" not in package_snapshot:
-            fail("expected package %s to have a version field" % package_path)
+            msg = "expected package {} to have a version field".format(package_path)
+            fail(msg)
         name = package_snapshot["name"]
         version = package_path
         friendly_version = package_snapshot["version"]
         package_key = package
 
     if "resolution" not in package_snapshot:
-        fail("package %s has no resolution field" % package_path)
+        msg = "package {} has no resolution field".format(package_path)
+        fail(msg)
     id = package_snapshot["id"] if "id" in package_snapshot else None
     resolution = package_snapshot["resolution"]
     integrity = resolution["integrity"] if "integrity" in resolution else None
     tarball = resolution["tarball"] if "tarball" in resolution else None
     directory = resolution["directory"] if "directory" in resolution else None
     if not integrity and not tarball and not directory:
-        fail("expected package %s to have an integrity, tarball or directory fields but found none" % package_path)
+        msg = "expected package {} to have an integrity, tarball or directory fields but found none".format(package_path)
+        fail(msg)
     registry = resolution["registry"] if "registry" in resolution else None
 
     return package_key, {

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -45,7 +45,8 @@ def _parse_pnpm_name(pnpmName):
     # a (name, version) tuple
     segments = pnpmName.rsplit("/", 1)
     if len(segments) != 2:
-        fail("unexpected pnpm versioned name " + pnpmName)
+        msg = "unexpected pnpm versioned name {}".format(pnpmName)
+        fail(msg)
     return (segments[0], segments[1])
 
 def _parse_pnpm_lock(lockfile_content):


### PR DESCRIPTION
Looks like some formatting got tripped on yaml.bzl as well