### PR TITLE
perf: remove unnecessary additiona_files.to_list() in npm_package

### DIFF
--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -168,7 +168,7 @@ def _impl(ctx):
         ctx,
         srcs = ctx.attr.srcs,
         dst = dst,
-        additional_files = additional_files.to_list(),
+        additional_files = additional_files,
         root_paths = ctx.attr.root_paths,
         include_external_repositories = ctx.attr.include_external_repositories,
         include_srcs_packages = ctx.attr.include_srcs_packages,


### PR DESCRIPTION
The copy_to_direction action accepts a depset https://github.com/aspect-build/bazel-lib/blob/main/lib/private/copy_to_directory.bzl#L744