### PR TITLE
chore: enable vendored_node e2e test on CI

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,54 +1,59 @@
 ---
 workspaces:
-  - .:
-      group:
-        icon: js
-        label: rules_js
-  - e2e/bzlmod:
-      group:
-        icon: bazel
-  - e2e/js_image:
-      group:
-        icon: docker
-  - e2e/js_image:
-      group:
-        icon: docker
-  - e2e/js_run_devserver:
-      group:
-        icon: js
-  - e2e/npm_link_package:
-      group:
-        icon: npm
-  - e2e/npm_link_package-esm:
-      group:
-        icon: npm
-  - e2e/npm_translate_lock:
-      group:
-        icon: npm
-  # Requires an auth token?
-  # - e2e/npm_translate_lock_auth:
-  #     group:
-  #       icon: npm
-  - e2e/npm_translate_package_lock:
-      group:
-        icon: npm
-  - e2e/npm_translate_yarn_lock:
-      group:
-        icon: yarn
-  - e2e/package_json_module:
-      group:
-        icon: npm
-  - e2e/pnpm_workspace:
-      group:
-        icon: pnpm
-  - e2e/pnpm_workspace_rerooted:
-      group:
-        icon: pnpm
-  - e2e/rules_foo
+    - .:
+          group:
+              icon: js
+              label: rules_js
+    - e2e/bzlmod:
+          group:
+              icon: bazel
+    - e2e/js_image:
+          group:
+              icon: docker
+    - e2e/js_image:
+          group:
+              icon: docker
+    - e2e/js_run_devserver:
+          group:
+              icon: js
+    - e2e/npm_link_package:
+          group:
+              icon: npm
+    - e2e/npm_link_package-esm:
+          group:
+              icon: npm
+    - e2e/npm_translate_lock:
+          group:
+              icon: npm
+    # Requires an auth token?
+    # - e2e/npm_translate_lock_auth:
+    #     group:
+    #       icon: npm
+    - e2e/npm_translate_package_lock:
+          group:
+              icon: npm
+    - e2e/npm_translate_yarn_lock:
+          group:
+              icon: yarn
+    - e2e/package_json_module:
+          group:
+              icon: npm
+    - e2e/pnpm_workspace:
+          group:
+              icon: pnpm
+    - e2e/pnpm_workspace_rerooted:
+          group:
+              icon: pnpm
+    - e2e/rules_foo:
+          group:
+              icon: js
+    - e2e/vendored_node:
+          group:
+              icon: js
 
 tasks:
-  test:
-    flags:
-      - --remote_default_exec_properties=cache-silo-key="74aed5f7"
-      - --remote_cache=grpc://remote-cache-9e85d2169ed596f9.elb.us-east-2.amazonaws.com:8980
-    archive_execution_log: false
+    test:
+        flags:
+            - --remote_default_exec_properties=cache-silo-key="74aed5f7"
+            - --remote_cache=grpc://remote-cache-9e85d2169ed596f9.elb.us-east-2.amazonaws.com:8980
+        archive_execution_log: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,8 @@ jobs:
               run: echo "folder=e2e/pnpm_workspace" >> $GITHUB_OUTPUT
             - id: rules_foo
               run: echo "folder=e2e/rules_foo" >> $GITHUB_OUTPUT
+            - id: vendored_node
+              run: echo "folder=e2e/vendored_node" >> $GITHUB_OUTPUT
         outputs:
             # Will look like [".", "e2e/bzlmod", ...]
             folders: ${{ toJSON(steps.*.outputs.folder) }}

--- a/e2e/vendored_node/WORKSPACE
+++ b/e2e/vendored_node/WORKSPACE
@@ -9,29 +9,28 @@ rules_js_dependencies()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# See comment in README about these fetches
 http_archive(
     name = "vendored_node_linux_amd64",
     build_file_content = """exports_files(["bin/node"])""",
-    sha256 = "cc9c3eed21755b490e5333ccab208ce15b539c35f64a764eeeae77c58746a7ff",
-    strip_prefix = "node-v15.0.1-linux-x64",
-    urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-x64.tar.xz"],
+    sha256 = "de2c694e7081c37022817d27a65b02f69ecf4c49699d65585e8e24431b7bc920",
+    strip_prefix = "node-v16.18.1-linux-x64",
+    urls = ["https://nodejs.org/download/release/v16.18.1/node-v16.18.1-linux-x64.tar.xz"],
 )
 
 http_archive(
     name = "vendored_node_darwin_amd64",
     build_file_content = """exports_files(["bin/node"])""",
-    sha256 = "78571df5b35d3ec73d7543332776bcb8cab3bc0e3abd12b1440fbcd01c74c055",
-    strip_prefix = "node-v15.0.1-darwin-x64",
-    urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-darwin-x64.tar.xz"],
+    sha256 = "79ff9ca43ae882051b2d607696cb3e70bfdef8c7b24f8d3effa3d41ff16368ff",
+    strip_prefix = "node-v16.18.1-darwin-x64",
+    urls = ["https://nodejs.org/download/release/v16.18.1/node-v16.18.1-darwin-x64.tar.xz"],
 )
 
 http_archive(
     name = "vendored_node_windows_amd64",
     build_file_content = """exports_files(["node.exe"])""",
-    sha256 = "efa7a74d91789a6e9f068f375e49f108ff87578fd88ff4b4e7fefd930c04db6c",
-    strip_prefix = "node-v15.0.1-win-x64",
-    urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-win-x64.zip"],
+    sha256 = "db6a81de8e8ca3444495f1bcf04a883c076b4325d0fbaa032a190f88b38b30c5",
+    strip_prefix = "node-v16.18.1-win-x64",
+    urls = ["https://nodejs.org/download/release/v16.18.1/node-v16.18.1-win-x64.zip"],
 )
 
 register_toolchains("//toolchains:all")

--- a/e2e/vendored_node/test.js
+++ b/e2e/vendored_node/test.js
@@ -1,6 +1,6 @@
 console.log(process.version)
 
-if (process.version != 'v15.0.1') {
+if (process.version != 'v16.18.1') {
     console.error('Expected node version to be the one we vendored')
     process.exit(1)
 }


### PR DESCRIPTION
Also bump vendored version to node 16 since node 15 doesn't support the `node:fs` style imports. Those were added in 16 and then back-ported to 14 but not 15.