### PR TITLE
fix: treat npmrc keys as case-sensitive

### DIFF
--- a/npm/private/BUILD.bazel
+++ b/npm/private/BUILD.bazel
@@ -88,7 +88,7 @@ bzl_library(
     srcs = ["npm_translate_lock.bzl"],
     visibility = ["//npm:__subpackages__"],
     deps = [
-        ":ini",
+        ":npmrc",
         ":starlark_codegen_utils",
         ":transitive_closure",
         ":utils",
@@ -105,8 +105,8 @@ bzl_library(
 )
 
 bzl_library(
-    name = "ini",
-    srcs = ["ini.bzl"],
+    name = "npmrc",
+    srcs = ["npmrc.bzl"],
     visibility = ["//npm:__subpackages__"],
 )
 

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -3,7 +3,7 @@
 load("@aspect_bazel_lib//lib:utils.bzl", "is_bazel_6_or_greater")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load(":ini.bzl", "parse_ini")
+load(":npmrc.bzl", "parse_npmrc")
 load(":utils.bzl", "utils")
 load(":transitive_closure.bzl", "translate_to_transitive_closure")
 load(":starlark_codegen_utils.bzl", "starlark_codegen_utils")
@@ -526,7 +526,7 @@ def _impl(rctx):
     # Read tokens from npmrc label
     if rctx.attr.npmrc:
         npmrc_path = rctx.path(rctx.attr.npmrc)
-        npmrc = parse_ini(rctx.read(npmrc_path))
+        npmrc = parse_npmrc(rctx.read(npmrc_path))
         (npm_tokens, npm_registries) = get_npm_auth(npmrc, npmrc_path, rctx.os.environ)
 
         if "registry" in npmrc:

--- a/npm/private/npmrc.bzl
+++ b/npm/private/npmrc.bzl
@@ -1,14 +1,13 @@
-"""
-INI utils
+"""npmrc utils"""
 
-See https://en.wikipedia.org/wiki/INI_file
-"""
+def parse_npmrc(npmrc_content):
+    """Parse an `.npmrc` file in into key/value map.
 
-def parse_ini(init_content):
-    """Parse standard INI string into key/value map.
+    `.npmrc` files are in [INI](https://en.wikipedia.org/wiki/INI_file#Format) format but we don't
+    treat keys as [case insensitive](https://en.wikipedia.org/wiki/INI_file#Case_sensitivity) due
+    to https://github.com/aspect-build/rules_js/issues/622.
 
-    Duplicate keys override previous values.
-    Keys are converted to lowercase.
+    Duplicate case-sensitive keys override previous values.
 
     Supports:
     * basic key/value
@@ -20,18 +19,16 @@ def parse_ini(init_content):
     * number or boolean types (all values are strings)
     * comment characters (#, ;) within a value
 
-    https://en.wikipedia.org/wiki/INI_file#Format
-
     Args:
-        init_content: the INI content string
+        npmrc_content: the `.npmrc` content string
 
     Returns:
-        A dict() of key/value pairs of the INI properties
+        A dict() of key/value pairs of the `.npmrc` properties
     """
 
     props = []
 
-    for line in init_content.splitlines():
+    for line in npmrc_content.splitlines():
         line = line.strip()
 
         # Ignore sections
@@ -48,6 +45,6 @@ def parse_ini(init_content):
 
         [name, _, value] = line.strip().partition("=")
 
-        props.append([name.strip().lower(), value.strip()])
+        props.append([name.strip(), value.strip()])
 
     return dict(props)

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -4,7 +4,7 @@ load(":transitive_closure_tests.bzl", "transitive_closure_tests")
 load(":translate_lock_tests.bzl", "translate_lock_tests")
 load(":yaml_tests.bzl", "yaml_tests")
 load(":utils_tests.bzl", "utils_tests")
-load(":ini_test.bzl", "ini_tests")
+load(":npmrc_test.bzl", "npmrc_tests")
 load(":pkg_glob_tests.bzl", "pkg_glob_tests")
 load(":generated_pkg_json_test.bzl", "generated_pkg_json_test")
 load(":npm_auth_test.bzl", "npm_auth_test_suite")
@@ -16,7 +16,7 @@ npm_link_all_packages(name = "node_modules")
 # Unit tests
 utils_tests(name = "test_utils")
 
-ini_tests(name = "test_ini")
+npmrc_tests(name = "test_npmrc")
 
 pkg_glob_tests(name = "test_pkg_glob")
 

--- a/npm/private/test/npmrc_test.bzl
+++ b/npm/private/test/npmrc_test.bzl
@@ -1,18 +1,20 @@
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//npm/private:ini.bzl", "parse_ini")
+"""Tests for parse_npmrc utility function"""
 
-def _ini_test(ctx, expected, content):
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//npm/private:npmrc.bzl", "parse_npmrc")
+
+def _npmrc_test(ctx, expected, content):
     env = unittest.begin(ctx)
-    asserts.equals(env, dict(expected), parse_ini(content))
+    asserts.equals(env, dict(expected), parse_npmrc(content))
     return unittest.end(env)
 
 def _basic(ctx):
-    return _ini_test(ctx, [["a", "b"]], """
+    return _npmrc_test(ctx, [["a", "b"]], """
         a=b
     """)
 
 def _comments(ctx):
-    return _ini_test(ctx, [["a", "1"], ["b", "2"]], """
+    return _npmrc_test(ctx, [["a", "1"], ["b", "2"]], """
         ; foo
         a=1 ;bar ; baz
         # baz
@@ -22,7 +24,7 @@ def _comments(ctx):
     """)
 
 def _whitespace(ctx):
-    return _ini_test(ctx, [["a", "b"], ["c", "3"]], """
+    return _npmrc_test(ctx, [["a", "b"], ["c", "3"]], """
         ; foo
 
         a = b ; 
@@ -33,14 +35,14 @@ def _whitespace(ctx):
     """)
 
 def _dupe(ctx):
-    return _ini_test(ctx, [["a", "3"]], """
+    return _npmrc_test(ctx, [["a", "3"]], """
         a=1 ;
         a =2
         a = 3
     """)
 
 def _sections(ctx):
-    return _ini_test(ctx, [["a", "1"], ["b", "2"]], """
+    return _npmrc_test(ctx, [["a", "1"], ["b", "2"]], """
         [a]
         a=1
         [b]
@@ -50,15 +52,16 @@ def _sections(ctx):
     """)
 
 def _case_sensitivity(ctx):
-    return _ini_test(ctx, [["a", "MixeD"], ["b", "UPPER"]], """
-        a=overriden
+    return _npmrc_test(ctx, [["a", "not_overriden"], ["A", "MixeD"], ["B", "UPPER"]], """
+        a=not_overriden
+        A=overriden
         A=MixeD
         B=UPPER
     """)
 
 def _glob_characters(ctx):
-    return _ini_test(ctx, [["stars", "*/*.ini"], ["dstar", "**/*/*.foo"], ["exts", "*.{foo,bar}"], ["protocol", "file://path/to/file.ext"]], """
-        stars=*/*.ini
+    return _npmrc_test(ctx, [["stars", "*/*.npmrc"], ["dstar", "**/*/*.foo"], ["exts", "*.{foo,bar}"], ["protocol", "file://path/to/file.ext"]], """
+        stars=*/*.npmrc
         dstar= **/*/*.foo
         exts =*.{foo,bar}
         protocol=file://path/to/file.ext
@@ -72,7 +75,7 @@ sections_test = unittest.make(_sections)
 case_sensitivity_test = unittest.make(_case_sensitivity)
 glob_characters_test = unittest.make(_glob_characters)
 
-def ini_tests(name):
+def npmrc_tests(name):
     unittest.suite(
         name,
         basic_test,


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_js/issues/622

We're diverging from the INI format by not treating keys as case-insensitive to resolve #622 