### PR TITLE
fix: fix regression in .npmrc _authToken parsing

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -186,7 +186,9 @@ def get_npm_auth(npmrc, npmrc_path, environ):
         A tuple with a tokens dict and a registries dict.
     """
 
-    _NPM_TOKEN_KEY = ":_authtoken"
+    # _NPM_TOKEN_KEY is case-sensitive. Should be the same as pnpm's
+    # https://github.com/pnpm/pnpm/blob/4097af6b5c09d9de1a3570d531bb4bb89c093a04/network/auth-header/src/getAuthHeadersFromConfig.ts#L17
+    _NPM_TOKEN_KEY = ":_authToken"
     _NPM_PKG_SCOPE_KEY = ":registry"
     tokens = {}
     registries = {}


### PR DESCRIPTION
This regressed in rules_js 1.8.0 with https://github.com/aspect-build/rules_js/pull/642 but the problem was masked on CI by the external repository cache. Didn't see it failing until that cache was busted on GH actions: https://github.com/aspect-build/rules_js/actions/runs/3568511414/jobs/5997665772#step:8:62