### PR TITLE
fix: fix .npmrc default registry logic

### DIFF
--- a/e2e/npm_translate_lock/.npmrc
+++ b/e2e/npm_translate_lock/.npmrc
@@ -7,4 +7,4 @@ hoist=false
 registry=https://registry.yarnpkg.com
 
 # Override the registry of a scope
-@types:registry=https://registry.npmjs.org/
+@rollup:registry=https://registry.npmjs.org/

--- a/e2e/npm_translate_lock/package.json
+++ b/e2e/npm_translate_lock/package.json
@@ -1,12 +1,15 @@
 {
     "private": true,
     "dependencies": {
-        "debug": "^4.3.4",
-        "is-odd": "^3.0.1",
-        "semver": "^7.3.8"
+        "debug": "4.3.4",
+        "is-odd": "3.0.1",
+        "semver": "7.3.8"
     },
     "devDependencies": {
-        "@types/node": "^18.11.0",
-        "@types/semver": "^7.3.12"
+        "@types/node": "18.11.11",
+        "@types/semver": "7.3.13",
+        "@rollup/plugin-commonjs": "23.0.4",
+        "@rollup/plugin-json": "5.0.2",
+        "@rollup/plugin-node-resolve": "15.0.1"
     }
 }

--- a/e2e/npm_translate_lock/pnpm-lock.yaml
+++ b/e2e/npm_translate_lock/pnpm-lock.yaml
@@ -4,27 +4,136 @@ importers:
 
   .:
     specifiers:
-      '@types/node': ^18.11.0
-      '@types/semver': ^7.3.12
-      debug: ^4.3.4
-      is-odd: ^3.0.1
-      semver: ^7.3.8
+      '@rollup/plugin-commonjs': 23.0.4
+      '@rollup/plugin-json': 5.0.2
+      '@rollup/plugin-node-resolve': 15.0.1
+      '@types/node': 18.11.11
+      '@types/semver': 7.3.13
+      debug: 4.3.4
+      is-odd: 3.0.1
+      semver: 7.3.8
     dependencies:
       debug: registry.npmjs.org/debug/4.3.4
       is-odd: registry.npmjs.org/is-odd/3.0.1
       semver: registry.npmjs.org/semver/7.3.8
     devDependencies:
-      '@types/node': 18.11.0
-      '@types/semver': 7.3.12
+      '@rollup/plugin-commonjs': 23.0.4
+      '@rollup/plugin-json': 5.0.2
+      '@rollup/plugin-node-resolve': 15.0.1
+      '@types/node': registry.npmjs.org/@types/node/18.11.11
+      '@types/semver': registry.npmjs.org/@types/semver/7.3.13
 
 packages:
 
-  /@types/node/18.11.0:
-    resolution: {integrity: sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==}
+  /@rollup/plugin-commonjs/23.0.4:
+    resolution: {integrity: sha512-bOPJeTZg56D2MCm+TT4psP8e8Jmf1Jsi7pFUMl8BN5kOADNzofNHe47+84WVCt7D095xPghC235/YKuNDEhczg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2
+      commondir: registry.npmjs.org/commondir/1.0.1
+      estree-walker: registry.npmjs.org/estree-walker/2.0.2
+      glob: registry.npmjs.org/glob/8.0.3
+      is-reference: registry.npmjs.org/is-reference/1.2.1
+      magic-string: registry.npmjs.org/magic-string/0.26.7
     dev: true
 
-  /@types/semver/7.3.12:
-    resolution: {integrity: sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==}
+  /@rollup/plugin-json/5.0.2:
+    resolution: {integrity: sha512-D1CoOT2wPvadWLhVcmpkDnesTzjhNIQRWLsc3fA49IFOP2Y84cFOOJ+nKGYedvXHKUsPeq07HR4hXpBBr+CHlA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2
+    dev: true
+
+  /@rollup/plugin-node-resolve/15.0.1:
+    resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2
+      '@types/resolve': registry.npmjs.org/@types/resolve/1.20.2
+      deepmerge: registry.npmjs.org/deepmerge/4.2.2
+      is-builtin-module: registry.npmjs.org/is-builtin-module/3.2.0
+      is-module: registry.npmjs.org/is-module/1.0.0
+      resolve: registry.npmjs.org/resolve/1.22.1
+    dev: true
+
+  /@rollup/pluginutils/5.0.2:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': registry.npmjs.org/@types/estree/1.0.0
+      estree-walker: registry.npmjs.org/estree-walker/2.0.2
+      picomatch: registry.npmjs.org/picomatch/2.3.1
+    dev: true
+
+  registry.npmjs.org/@types/estree/1.0.0:
+    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz}
+    name: '@types/estree'
+    version: 1.0.0
+    dev: true
+
+  registry.npmjs.org/@types/node/18.11.11:
+    resolution: {integrity: sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz}
+    name: '@types/node'
+    version: 18.11.11
+    dev: true
+
+  registry.npmjs.org/@types/resolve/1.20.2:
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz}
+    name: '@types/resolve'
+    version: 1.20.2
+    dev: true
+
+  registry.npmjs.org/@types/semver/7.3.13:
+    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz}
+    name: '@types/semver'
+    version: 7.3.13
+    dev: true
+
+  registry.npmjs.org/balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz}
+    name: balanced-match
+    version: 1.0.2
+    dev: true
+
+  registry.npmjs.org/brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz}
+    name: brace-expansion
+    version: 2.0.1
+    dependencies:
+      balanced-match: registry.npmjs.org/balanced-match/1.0.2
+    dev: true
+
+  registry.npmjs.org/builtin-modules/3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz}
+    name: builtin-modules
+    version: 3.3.0
+    engines: {node: '>=6'}
+    dev: true
+
+  registry.npmjs.org/commondir/1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz}
+    name: commondir
+    version: 1.0.1
     dev: true
 
   registry.npmjs.org/debug/4.3.4:
@@ -40,6 +149,91 @@ packages:
     dependencies:
       ms: registry.npmjs.org/ms/2.1.2
     dev: false
+
+  registry.npmjs.org/deepmerge/4.2.2:
+    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz}
+    name: deepmerge
+    version: 4.2.2
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  registry.npmjs.org/estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz}
+    name: estree-walker
+    version: 2.0.2
+    dev: true
+
+  registry.npmjs.org/fs.realpath/1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz}
+    name: fs.realpath
+    version: 1.0.0
+    dev: true
+
+  registry.npmjs.org/function-bind/1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz}
+    name: function-bind
+    version: 1.1.1
+    dev: true
+
+  registry.npmjs.org/glob/8.0.3:
+    resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/glob/-/glob-8.0.3.tgz}
+    name: glob
+    version: 8.0.3
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: registry.npmjs.org/fs.realpath/1.0.0
+      inflight: registry.npmjs.org/inflight/1.0.6
+      inherits: registry.npmjs.org/inherits/2.0.4
+      minimatch: registry.npmjs.org/minimatch/5.1.1
+      once: registry.npmjs.org/once/1.4.0
+    dev: true
+
+  registry.npmjs.org/has/1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/has/-/has-1.0.3.tgz}
+    name: has
+    version: 1.0.3
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: registry.npmjs.org/function-bind/1.1.1
+    dev: true
+
+  registry.npmjs.org/inflight/1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz}
+    name: inflight
+    version: 1.0.6
+    dependencies:
+      once: registry.npmjs.org/once/1.4.0
+      wrappy: registry.npmjs.org/wrappy/1.0.2
+    dev: true
+
+  registry.npmjs.org/inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz}
+    name: inherits
+    version: 2.0.4
+    dev: true
+
+  registry.npmjs.org/is-builtin-module/3.2.0:
+    resolution: {integrity: sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz}
+    name: is-builtin-module
+    version: 3.2.0
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: registry.npmjs.org/builtin-modules/3.3.0
+    dev: true
+
+  registry.npmjs.org/is-core-module/2.11.0:
+    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz}
+    name: is-core-module
+    version: 2.11.0
+    dependencies:
+      has: registry.npmjs.org/has/1.0.3
+    dev: true
+
+  registry.npmjs.org/is-module/1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz}
+    name: is-module
+    version: 1.0.0
+    dev: true
 
   registry.npmjs.org/is-number/6.0.0:
     resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz}
@@ -57,6 +251,14 @@ packages:
       is-number: registry.npmjs.org/is-number/6.0.0
     dev: false
 
+  registry.npmjs.org/is-reference/1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz}
+    name: is-reference
+    version: 1.2.1
+    dependencies:
+      '@types/estree': registry.npmjs.org/@types/estree/1.0.0
+    dev: true
+
   registry.npmjs.org/lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz}
     name: lru-cache
@@ -66,11 +268,61 @@ packages:
       yallist: registry.npmjs.org/yallist/4.0.0
     dev: false
 
+  registry.npmjs.org/magic-string/0.26.7:
+    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz}
+    name: magic-string
+    version: 0.26.7
+    engines: {node: '>=12'}
+    dependencies:
+      sourcemap-codec: registry.npmjs.org/sourcemap-codec/1.4.8
+    dev: true
+
+  registry.npmjs.org/minimatch/5.1.1:
+    resolution: {integrity: sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz}
+    name: minimatch
+    version: 5.1.1
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: registry.npmjs.org/brace-expansion/2.0.1
+    dev: true
+
   registry.npmjs.org/ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/ms/-/ms-2.1.2.tgz}
     name: ms
     version: 2.1.2
     dev: false
+
+  registry.npmjs.org/once/1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/once/-/once-1.4.0.tgz}
+    name: once
+    version: 1.4.0
+    dependencies:
+      wrappy: registry.npmjs.org/wrappy/1.0.2
+    dev: true
+
+  registry.npmjs.org/path-parse/1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz}
+    name: path-parse
+    version: 1.0.7
+    dev: true
+
+  registry.npmjs.org/picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz}
+    name: picomatch
+    version: 2.3.1
+    engines: {node: '>=8.6'}
+    dev: true
+
+  registry.npmjs.org/resolve/1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz}
+    name: resolve
+    version: 1.22.1
+    hasBin: true
+    dependencies:
+      is-core-module: registry.npmjs.org/is-core-module/2.11.0
+      path-parse: registry.npmjs.org/path-parse/1.0.7
+      supports-preserve-symlinks-flag: registry.npmjs.org/supports-preserve-symlinks-flag/1.0.0
+    dev: true
 
   registry.npmjs.org/semver/7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/semver/-/semver-7.3.8.tgz}
@@ -81,6 +333,26 @@ packages:
     dependencies:
       lru-cache: registry.npmjs.org/lru-cache/6.0.0
     dev: false
+
+  registry.npmjs.org/sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz}
+    name: sourcemap-codec
+    version: 1.4.8
+    deprecated: Please use @jridgewell/sourcemap-codec instead
+    dev: true
+
+  registry.npmjs.org/supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz}
+    name: supports-preserve-symlinks-flag
+    version: 1.0.0
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  registry.npmjs.org/wrappy/1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz}
+    name: wrappy
+    version: 1.0.2
+    dev: true
 
   registry.npmjs.org/yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz}

--- a/e2e/npm_translate_lock/repositories_checked.bzl
+++ b/e2e/npm_translate_lock/repositories_checked.bzl
@@ -5,38 +5,271 @@ load("@aspect_rules_js//npm:npm_import.bzl", "npm_import")
 def npm_repositories():
     "Generated npm_import repository rules corresponding to npm packages in //:pnpm-lock.yaml"
     npm_import(
-        name = "npm__at_types_node__18.11.0",
+        name = "npm__at_rollup_plugin-commonjs__23.0.4",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {
+            "": ["@rollup/plugin-commonjs"],
+        },
+        package = "@rollup/plugin-commonjs",
+        version = "23.0.4",
+        url = "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-23.0.4.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-bOPJeTZg56D2MCm+TT4psP8e8Jmf1Jsi7pFUMl8BN5kOADNzofNHe47+84WVCt7D095xPghC235/YKuNDEhczg==",
+        deps = {
+            "@rollup/pluginutils": "5.0.2",
+            "commondir": "registry.npmjs.org/commondir/1.0.1",
+            "estree-walker": "registry.npmjs.org/estree-walker/2.0.2",
+            "glob": "registry.npmjs.org/glob/8.0.3",
+            "is-reference": "registry.npmjs.org/is-reference/1.2.1",
+            "magic-string": "registry.npmjs.org/magic-string/0.26.7",
+        },
+        transitive_closure = {
+            "@rollup/plugin-commonjs": ["23.0.4"],
+            "@rollup/pluginutils": ["5.0.2"],
+            "commondir": ["registry.npmjs.org/commondir/1.0.1"],
+            "estree-walker": ["registry.npmjs.org/estree-walker/2.0.2"],
+            "glob": ["registry.npmjs.org/glob/8.0.3"],
+            "is-reference": ["registry.npmjs.org/is-reference/1.2.1"],
+            "magic-string": ["registry.npmjs.org/magic-string/0.26.7"],
+            "sourcemap-codec": ["registry.npmjs.org/sourcemap-codec/1.4.8"],
+            "@types/estree": ["registry.npmjs.org/@types/estree/1.0.0"],
+            "fs.realpath": ["registry.npmjs.org/fs.realpath/1.0.0"],
+            "inflight": ["registry.npmjs.org/inflight/1.0.6"],
+            "inherits": ["registry.npmjs.org/inherits/2.0.4"],
+            "minimatch": ["registry.npmjs.org/minimatch/5.1.1"],
+            "once": ["registry.npmjs.org/once/1.4.0"],
+            "wrappy": ["registry.npmjs.org/wrappy/1.0.2"],
+            "brace-expansion": ["registry.npmjs.org/brace-expansion/2.0.1"],
+            "balanced-match": ["registry.npmjs.org/balanced-match/1.0.2"],
+            "picomatch": ["registry.npmjs.org/picomatch/2.3.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__at_rollup_plugin-json__5.0.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {
+            "": ["@rollup/plugin-json"],
+        },
+        package = "@rollup/plugin-json",
+        version = "5.0.2",
+        url = "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-5.0.2.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-D1CoOT2wPvadWLhVcmpkDnesTzjhNIQRWLsc3fA49IFOP2Y84cFOOJ+nKGYedvXHKUsPeq07HR4hXpBBr+CHlA==",
+        deps = {
+            "@rollup/pluginutils": "5.0.2",
+        },
+        transitive_closure = {
+            "@rollup/plugin-json": ["5.0.2"],
+            "@rollup/pluginutils": ["5.0.2"],
+            "@types/estree": ["registry.npmjs.org/@types/estree/1.0.0"],
+            "estree-walker": ["registry.npmjs.org/estree-walker/2.0.2"],
+            "picomatch": ["registry.npmjs.org/picomatch/2.3.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__at_rollup_plugin-node-resolve__15.0.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {
+            "": ["@rollup/plugin-node-resolve"],
+        },
+        package = "@rollup/plugin-node-resolve",
+        version = "15.0.1",
+        url = "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==",
+        deps = {
+            "@rollup/pluginutils": "5.0.2",
+            "@types/resolve": "registry.npmjs.org/@types/resolve/1.20.2",
+            "deepmerge": "registry.npmjs.org/deepmerge/4.2.2",
+            "is-builtin-module": "registry.npmjs.org/is-builtin-module/3.2.0",
+            "is-module": "registry.npmjs.org/is-module/1.0.0",
+            "resolve": "registry.npmjs.org/resolve/1.22.1",
+        },
+        transitive_closure = {
+            "@rollup/plugin-node-resolve": ["15.0.1"],
+            "@rollup/pluginutils": ["5.0.2"],
+            "@types/resolve": ["registry.npmjs.org/@types/resolve/1.20.2"],
+            "deepmerge": ["registry.npmjs.org/deepmerge/4.2.2"],
+            "is-builtin-module": ["registry.npmjs.org/is-builtin-module/3.2.0"],
+            "is-module": ["registry.npmjs.org/is-module/1.0.0"],
+            "resolve": ["registry.npmjs.org/resolve/1.22.1"],
+            "is-core-module": ["registry.npmjs.org/is-core-module/2.11.0"],
+            "path-parse": ["registry.npmjs.org/path-parse/1.0.7"],
+            "supports-preserve-symlinks-flag": ["registry.npmjs.org/supports-preserve-symlinks-flag/1.0.0"],
+            "has": ["registry.npmjs.org/has/1.0.3"],
+            "function-bind": ["registry.npmjs.org/function-bind/1.1.1"],
+            "builtin-modules": ["registry.npmjs.org/builtin-modules/3.3.0"],
+            "@types/estree": ["registry.npmjs.org/@types/estree/1.0.0"],
+            "estree-walker": ["registry.npmjs.org/estree-walker/2.0.2"],
+            "picomatch": ["registry.npmjs.org/picomatch/2.3.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__at_rollup_pluginutils__5.0.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "@rollup/pluginutils",
+        version = "5.0.2",
+        url = "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+        deps = {
+            "@types/estree": "registry.npmjs.org/@types/estree/1.0.0",
+            "estree-walker": "registry.npmjs.org/estree-walker/2.0.2",
+            "picomatch": "registry.npmjs.org/picomatch/2.3.1",
+        },
+        transitive_closure = {
+            "@rollup/pluginutils": ["5.0.2"],
+            "@types/estree": ["registry.npmjs.org/@types/estree/1.0.0"],
+            "estree-walker": ["registry.npmjs.org/estree-walker/2.0.2"],
+            "picomatch": ["registry.npmjs.org/picomatch/2.3.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__at_types_estree__registry.npmjs.org_at_types_estree_1.0.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "@types/estree",
+        version = "registry.npmjs.org/@types/estree/1.0.0",
+        url = "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+        transitive_closure = {
+            "@types/estree": ["registry.npmjs.org/@types/estree/1.0.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__at_types_node__registry.npmjs.org_at_types_node_18.11.11",
         root_package = "",
         link_workspace = "",
         link_packages = {
             "": ["@types/node"],
         },
         package = "@types/node",
-        version = "18.11.0",
-        url = "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+        version = "registry.npmjs.org/@types/node/18.11.11",
+        url = "https://registry.yarnpkg.com/@types/node/-/node-18.11.11.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
-        integrity = "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
+        integrity = "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
         transitive_closure = {
-            "@types/node": ["18.11.0"],
+            "@types/node": ["registry.npmjs.org/@types/node/18.11.11"],
         },
     )
 
     npm_import(
-        name = "npm__at_types_semver__7.3.12",
+        name = "npm__at_types_resolve__registry.npmjs.org_at_types_resolve_1.20.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "@types/resolve",
+        version = "registry.npmjs.org/@types/resolve/1.20.2",
+        url = "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+        transitive_closure = {
+            "@types/resolve": ["registry.npmjs.org/@types/resolve/1.20.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__at_types_semver__registry.npmjs.org_at_types_semver_7.3.13",
         root_package = "",
         link_workspace = "",
         link_packages = {
             "": ["@types/semver"],
         },
         package = "@types/semver",
-        version = "7.3.12",
-        url = "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+        version = "registry.npmjs.org/@types/semver/7.3.13",
+        url = "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
-        integrity = "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+        integrity = "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
         transitive_closure = {
-            "@types/semver": ["7.3.12"],
+            "@types/semver": ["registry.npmjs.org/@types/semver/7.3.13"],
+        },
+    )
+
+    npm_import(
+        name = "npm__balanced-match__registry.npmjs.org_balanced-match_1.0.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "balanced-match",
+        version = "registry.npmjs.org/balanced-match/1.0.2",
+        url = "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+        transitive_closure = {
+            "balanced-match": ["registry.npmjs.org/balanced-match/1.0.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__brace-expansion__registry.npmjs.org_brace-expansion_2.0.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "brace-expansion",
+        version = "registry.npmjs.org/brace-expansion/2.0.1",
+        url = "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+        deps = {
+            "balanced-match": "registry.npmjs.org/balanced-match/1.0.2",
+        },
+        transitive_closure = {
+            "brace-expansion": ["registry.npmjs.org/brace-expansion/2.0.1"],
+            "balanced-match": ["registry.npmjs.org/balanced-match/1.0.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__builtin-modules__registry.npmjs.org_builtin-modules_3.3.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "builtin-modules",
+        version = "registry.npmjs.org/builtin-modules/3.3.0",
+        url = "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+        transitive_closure = {
+            "builtin-modules": ["registry.npmjs.org/builtin-modules/3.3.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__commondir__registry.npmjs.org_commondir_1.0.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "commondir",
+        version = "registry.npmjs.org/commondir/1.0.1",
+        url = "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+        transitive_closure = {
+            "commondir": ["registry.npmjs.org/commondir/1.0.1"],
         },
     )
 
@@ -49,7 +282,7 @@ def npm_repositories():
         },
         package = "debug",
         version = "registry.npmjs.org/debug/4.3.4",
-        url = "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+        url = "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
         integrity = "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
@@ -63,13 +296,223 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__deepmerge__registry.npmjs.org_deepmerge_4.2.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "deepmerge",
+        version = "registry.npmjs.org/deepmerge/4.2.2",
+        url = "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+        transitive_closure = {
+            "deepmerge": ["registry.npmjs.org/deepmerge/4.2.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__estree-walker__registry.npmjs.org_estree-walker_2.0.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "estree-walker",
+        version = "registry.npmjs.org/estree-walker/2.0.2",
+        url = "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+        transitive_closure = {
+            "estree-walker": ["registry.npmjs.org/estree-walker/2.0.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__fs.realpath__registry.npmjs.org_fs.realpath_1.0.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "fs.realpath",
+        version = "registry.npmjs.org/fs.realpath/1.0.0",
+        url = "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+        transitive_closure = {
+            "fs.realpath": ["registry.npmjs.org/fs.realpath/1.0.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__function-bind__registry.npmjs.org_function-bind_1.1.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "function-bind",
+        version = "registry.npmjs.org/function-bind/1.1.1",
+        url = "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+        transitive_closure = {
+            "function-bind": ["registry.npmjs.org/function-bind/1.1.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__glob__registry.npmjs.org_glob_8.0.3",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "glob",
+        version = "registry.npmjs.org/glob/8.0.3",
+        url = "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+        deps = {
+            "fs.realpath": "registry.npmjs.org/fs.realpath/1.0.0",
+            "inflight": "registry.npmjs.org/inflight/1.0.6",
+            "inherits": "registry.npmjs.org/inherits/2.0.4",
+            "minimatch": "registry.npmjs.org/minimatch/5.1.1",
+            "once": "registry.npmjs.org/once/1.4.0",
+        },
+        transitive_closure = {
+            "glob": ["registry.npmjs.org/glob/8.0.3"],
+            "fs.realpath": ["registry.npmjs.org/fs.realpath/1.0.0"],
+            "inflight": ["registry.npmjs.org/inflight/1.0.6"],
+            "inherits": ["registry.npmjs.org/inherits/2.0.4"],
+            "minimatch": ["registry.npmjs.org/minimatch/5.1.1"],
+            "once": ["registry.npmjs.org/once/1.4.0"],
+            "wrappy": ["registry.npmjs.org/wrappy/1.0.2"],
+            "brace-expansion": ["registry.npmjs.org/brace-expansion/2.0.1"],
+            "balanced-match": ["registry.npmjs.org/balanced-match/1.0.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__has__registry.npmjs.org_has_1.0.3",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "has",
+        version = "registry.npmjs.org/has/1.0.3",
+        url = "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+        deps = {
+            "function-bind": "registry.npmjs.org/function-bind/1.1.1",
+        },
+        transitive_closure = {
+            "has": ["registry.npmjs.org/has/1.0.3"],
+            "function-bind": ["registry.npmjs.org/function-bind/1.1.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__inflight__registry.npmjs.org_inflight_1.0.6",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "inflight",
+        version = "registry.npmjs.org/inflight/1.0.6",
+        url = "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+        deps = {
+            "once": "registry.npmjs.org/once/1.4.0",
+            "wrappy": "registry.npmjs.org/wrappy/1.0.2",
+        },
+        transitive_closure = {
+            "inflight": ["registry.npmjs.org/inflight/1.0.6"],
+            "once": ["registry.npmjs.org/once/1.4.0"],
+            "wrappy": ["registry.npmjs.org/wrappy/1.0.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__inherits__registry.npmjs.org_inherits_2.0.4",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "inherits",
+        version = "registry.npmjs.org/inherits/2.0.4",
+        url = "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+        transitive_closure = {
+            "inherits": ["registry.npmjs.org/inherits/2.0.4"],
+        },
+    )
+
+    npm_import(
+        name = "npm__is-builtin-module__registry.npmjs.org_is-builtin-module_3.2.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "is-builtin-module",
+        version = "registry.npmjs.org/is-builtin-module/3.2.0",
+        url = "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+        deps = {
+            "builtin-modules": "registry.npmjs.org/builtin-modules/3.3.0",
+        },
+        transitive_closure = {
+            "is-builtin-module": ["registry.npmjs.org/is-builtin-module/3.2.0"],
+            "builtin-modules": ["registry.npmjs.org/builtin-modules/3.3.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__is-core-module__registry.npmjs.org_is-core-module_2.11.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "is-core-module",
+        version = "registry.npmjs.org/is-core-module/2.11.0",
+        url = "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+        deps = {
+            "has": "registry.npmjs.org/has/1.0.3",
+        },
+        transitive_closure = {
+            "is-core-module": ["registry.npmjs.org/is-core-module/2.11.0"],
+            "has": ["registry.npmjs.org/has/1.0.3"],
+            "function-bind": ["registry.npmjs.org/function-bind/1.1.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__is-module__registry.npmjs.org_is-module_1.0.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "is-module",
+        version = "registry.npmjs.org/is-module/1.0.0",
+        url = "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+        transitive_closure = {
+            "is-module": ["registry.npmjs.org/is-module/1.0.0"],
+        },
+    )
+
+    npm_import(
         name = "npm__is-number__registry.npmjs.org_is-number_6.0.0",
         root_package = "",
         link_workspace = "",
         link_packages = {},
         package = "is-number",
         version = "registry.npmjs.org/is-number/6.0.0",
-        url = "https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz",
+        url = "https://registry.yarnpkg.com/is-number/-/is-number-6.0.0.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
         integrity = "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==",
@@ -87,7 +530,7 @@ def npm_repositories():
         },
         package = "is-odd",
         version = "registry.npmjs.org/is-odd/3.0.1",
-        url = "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz",
+        url = "https://registry.yarnpkg.com/is-odd/-/is-odd-3.0.1.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
         integrity = "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==",
@@ -101,13 +544,33 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__is-reference__registry.npmjs.org_is-reference_1.2.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "is-reference",
+        version = "registry.npmjs.org/is-reference/1.2.1",
+        url = "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+        deps = {
+            "@types/estree": "registry.npmjs.org/@types/estree/1.0.0",
+        },
+        transitive_closure = {
+            "is-reference": ["registry.npmjs.org/is-reference/1.2.1"],
+            "@types/estree": ["registry.npmjs.org/@types/estree/1.0.0"],
+        },
+    )
+
+    npm_import(
         name = "npm__lru-cache__registry.npmjs.org_lru-cache_6.0.0",
         root_package = "",
         link_workspace = "",
         link_packages = {},
         package = "lru-cache",
         version = "registry.npmjs.org/lru-cache/6.0.0",
-        url = "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+        url = "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
         integrity = "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
@@ -121,18 +584,137 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__magic-string__registry.npmjs.org_magic-string_0.26.7",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "magic-string",
+        version = "registry.npmjs.org/magic-string/0.26.7",
+        url = "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.7.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+        deps = {
+            "sourcemap-codec": "registry.npmjs.org/sourcemap-codec/1.4.8",
+        },
+        transitive_closure = {
+            "magic-string": ["registry.npmjs.org/magic-string/0.26.7"],
+            "sourcemap-codec": ["registry.npmjs.org/sourcemap-codec/1.4.8"],
+        },
+    )
+
+    npm_import(
+        name = "npm__minimatch__registry.npmjs.org_minimatch_5.1.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "minimatch",
+        version = "registry.npmjs.org/minimatch/5.1.1",
+        url = "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.1.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+        deps = {
+            "brace-expansion": "registry.npmjs.org/brace-expansion/2.0.1",
+        },
+        transitive_closure = {
+            "minimatch": ["registry.npmjs.org/minimatch/5.1.1"],
+            "brace-expansion": ["registry.npmjs.org/brace-expansion/2.0.1"],
+            "balanced-match": ["registry.npmjs.org/balanced-match/1.0.2"],
+        },
+    )
+
+    npm_import(
         name = "npm__ms__registry.npmjs.org_ms_2.1.2",
         root_package = "",
         link_workspace = "",
         link_packages = {},
         package = "ms",
         version = "registry.npmjs.org/ms/2.1.2",
-        url = "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+        url = "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
         integrity = "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
         transitive_closure = {
             "ms": ["registry.npmjs.org/ms/2.1.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__once__registry.npmjs.org_once_1.4.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "once",
+        version = "registry.npmjs.org/once/1.4.0",
+        url = "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+        deps = {
+            "wrappy": "registry.npmjs.org/wrappy/1.0.2",
+        },
+        transitive_closure = {
+            "once": ["registry.npmjs.org/once/1.4.0"],
+            "wrappy": ["registry.npmjs.org/wrappy/1.0.2"],
+        },
+    )
+
+    npm_import(
+        name = "npm__path-parse__registry.npmjs.org_path-parse_1.0.7",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "path-parse",
+        version = "registry.npmjs.org/path-parse/1.0.7",
+        url = "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+        transitive_closure = {
+            "path-parse": ["registry.npmjs.org/path-parse/1.0.7"],
+        },
+    )
+
+    npm_import(
+        name = "npm__picomatch__registry.npmjs.org_picomatch_2.3.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "picomatch",
+        version = "registry.npmjs.org/picomatch/2.3.1",
+        url = "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+        transitive_closure = {
+            "picomatch": ["registry.npmjs.org/picomatch/2.3.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__resolve__registry.npmjs.org_resolve_1.22.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "resolve",
+        version = "registry.npmjs.org/resolve/1.22.1",
+        url = "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+        deps = {
+            "is-core-module": "registry.npmjs.org/is-core-module/2.11.0",
+            "path-parse": "registry.npmjs.org/path-parse/1.0.7",
+            "supports-preserve-symlinks-flag": "registry.npmjs.org/supports-preserve-symlinks-flag/1.0.0",
+        },
+        transitive_closure = {
+            "resolve": ["registry.npmjs.org/resolve/1.22.1"],
+            "is-core-module": ["registry.npmjs.org/is-core-module/2.11.0"],
+            "path-parse": ["registry.npmjs.org/path-parse/1.0.7"],
+            "supports-preserve-symlinks-flag": ["registry.npmjs.org/supports-preserve-symlinks-flag/1.0.0"],
+            "has": ["registry.npmjs.org/has/1.0.3"],
+            "function-bind": ["registry.npmjs.org/function-bind/1.1.1"],
         },
     )
 
@@ -145,7 +727,7 @@ def npm_repositories():
         },
         package = "semver",
         version = "registry.npmjs.org/semver/7.3.8",
-        url = "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+        url = "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
         integrity = "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
@@ -160,13 +742,61 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__sourcemap-codec__registry.npmjs.org_sourcemap-codec_1.4.8",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "sourcemap-codec",
+        version = "registry.npmjs.org/sourcemap-codec/1.4.8",
+        url = "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+        transitive_closure = {
+            "sourcemap-codec": ["registry.npmjs.org/sourcemap-codec/1.4.8"],
+        },
+    )
+
+    npm_import(
+        name = "npm__supports-preserve-symlinks-flag__registry.npmjs.org_supports-preserve-symlinks-flag_1.0.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "supports-preserve-symlinks-flag",
+        version = "registry.npmjs.org/supports-preserve-symlinks-flag/1.0.0",
+        url = "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+        transitive_closure = {
+            "supports-preserve-symlinks-flag": ["registry.npmjs.org/supports-preserve-symlinks-flag/1.0.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__wrappy__registry.npmjs.org_wrappy_1.0.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "wrappy",
+        version = "registry.npmjs.org/wrappy/1.0.2",
+        url = "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz",
+        lifecycle_hooks_no_sandbox = True,
+        npm_translate_lock_repo = "npm",
+        integrity = "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+        transitive_closure = {
+            "wrappy": ["registry.npmjs.org/wrappy/1.0.2"],
+        },
+    )
+
+    npm_import(
         name = "npm__yallist__registry.npmjs.org_yallist_4.0.0",
         root_package = "",
         link_workspace = "",
         link_packages = {},
         package = "yallist",
         version = "registry.npmjs.org/yallist/4.0.0",
-        url = "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+        url = "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz",
         lifecycle_hooks_no_sandbox = True,
         npm_translate_lock_repo = "npm",
         integrity = "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",

--- a/e2e/npm_translate_lock/test.sh
+++ b/e2e/npm_translate_lock/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+# @rollup npm package should use registry.npmjs.org as per @rollup:registry=https://registry.npmjs.org/ override
+if ! grep registry.npmjs.org/@rollup > /dev/null < repositories_checked.bzl; then
+  echo "Expected to find registry.npmjs.org/@rollup in repositories_checked.bzl"
+  exit 1
+fi
+if ! grep -v registry.yarnpkg.com/@rollup > /dev/null < repositories_checked.bzl; then
+  echo "Expected to not find registry.yarnpkg.com/@rollup in repositories_checked.bzl"
+  exit 1
+fi
+
+# all other npm packages (which includes @types) should use registry.yarnpkg.com as per the default registry=https://registry.yarnpkg.com
+if ! grep registry.yarnpkg.com/@types > /dev/null < repositories_checked.bzl; then
+  echo "Expected to find registry.yarnpkg.com/@types in repositories_checked.bzl"
+  exit 1
+fi
+if ! grep -v registry.npmjs.org/@types > /dev/null < repositories_checked.bzl; then
+  echo "Expected to not find registry.npmjs.org/@types in repositories_checked.bzl"
+  exit 1
+fi
+
+echo "All tests passed"

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -416,14 +416,20 @@ def _gen_npm_imports(lockfile, root_package, attr, registries, default_registry)
             url = repo
         elif tarball:
             if _is_url(tarball):
-                if registry and tarball.startswith(default_registry):
-                    url = registry + tarball[len(default_registry):]
+                # pnpm sometimes prefixes the `tarball` url with the default npm registry `https://registry.npmjs.org/`
+                # in pnpm-lock.yaml which we must replace with the desired registry in the `registry` field:
+                #   tarball: https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz
+                #   registry: https://registry.yarnpkg.com/
+                if registry and tarball.startswith(DEFAULT_REGISTRY):
+                    url = registry + tarball[len(DEFAULT_REGISTRY):]
                 else:
                     url = tarball
             else:
                 if not registry:
                     registry = utils.npm_registry_url(name, registries, default_registry)
-                url = "{0}/{1}".format(registry.removesuffix("/"), tarball)
+                url = "{}/{}".format(registry.removesuffix("/"), tarball)
+        else:
+            url = utils.npm_registry_download_url(name, version, registries, default_registry)
 
         result.append(struct(
             custom_postinstall = custom_postinstall,


### PR DESCRIPTION
Not sure when this regressed since we only had the bzl snapshot test for coverage. I added a `test.sh` script now to make appropriate assertions on the bzl snapshot.