### PR TITLE
fix: js_image_layer build on RBE

### DIFF
--- a/e2e/js_image/BUILD.bazel
+++ b/e2e/js_image/BUILD.bazel
@@ -60,8 +60,6 @@ container_test(
     name = "image_test",
     configs = [":smoketest.yaml"],
     image = ":image",
-    # ./image_test.image: line 214: /usr/bin/docker: No such file or directory
-    tags = ["no-remote-exec"],
 )
 
 bzl_library(


### PR DESCRIPTION
The `js_image_layer`  rule currently relies on a hacky approach to get the symlinks targets working in the built Docker images by stripping the `execroot` from the path. The problem is that there is no `execroot` on the RBE, so I tried to get the paths corrected on remote builds too.

This has been tested on the open-source [Bazel Buildfarm](https://github.com/bazelbuild/bazel-buildfarm) RBE.