### PR TITLE
fix: don't mutate the frozen values in lifecycle_hooks dict

### DIFF
--- a/npm/npm_import.bzl
+++ b/npm/npm_import.bzl
@@ -361,6 +361,7 @@ WARNING: `package_json` attribute in `npm_translate_lock(name = "{name}")` is de
         fail("expected update_pnpm_lock to be True when preupdate are specified")
 
     # lifecycle_hooks_exclude is a convenience attribute to set `<value>: []` in `lifecycle_hooks`
+    lifecycle_hooks = dict(lifecycle_hooks)
     for p in lifecycle_hooks_exclude:
         if p in lifecycle_hooks:
             fail("expected '{}' to be in only one of lifecycle_hooks or lifecycle_hooks_exclude".format(p))


### PR DESCRIPTION
https://github.com/aspect-build/rules_js/pull/718 introduced a bug when using lifecycle hook exclusions where the values in the frozen dict `lifecycle_hooks` are mutated, which results in a hard error.

Just before the check, create a copy of the original frozen value. This is likely very cheap as these dicts are small if not empty.

Unblocks https://github.com/aspect-build/silo/pull/1005