### PR TITLE
feat: fail if any npm_translate_lock patches are not used

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -10,12 +10,13 @@ load("//npm:npm_import.bzl", "npm_import", "npm_translate_lock")
 load("//npm/private:transitive_closure.bzl", "translate_to_transitive_closure")
 
 def _extension_impl(module_ctx):
+    npm_translate_lock_name = "npm"
     for mod in module_ctx.modules:
         for attr in mod.tags.npm_translate_lock:
             # npm_translate_lock MUST run before parse_pnpm_lock below since it may update
             # the pnpm-lock.yaml file when update_pnpm_lock is True.
             npm_translate_lock(
-                name = "npm",
+                name = npm_translate_lock_name,
                 pnpm_lock = attr.pnpm_lock,
                 # TODO: get this working with bzlmod
                 # update_pnpm_lock = attr.update_pnpm_lock,
@@ -27,7 +28,7 @@ def _extension_impl(module_ctx):
             registries = {}
             lock_importers, lock_packages = utils.parse_pnpm_lock(module_ctx.read(attr.pnpm_lock))
             importers, packages = translate_to_transitive_closure(lock_importers, lock_packages, attr.prod, attr.dev, attr.no_optional)
-            imports = npm_translate_lock_helpers.gen_npm_imports(importers, packages, attr.pnpm_lock.package, attr, registries, utils.default_registry())
+            imports = npm_translate_lock_helpers.gen_npm_imports(importers, packages, attr.pnpm_lock.package, npm_translate_lock_name, attr, registries, utils.default_registry())
             for i in imports:
                 npm_import(
                     name = i.name,


### PR DESCRIPTION
Check that all patches files specified were used; this is a defense-in-depth since it is too easy to make a type in the patches keys or for a dep to change both of with could result in a patch file being silently ignored.

Tested manually to trigger the fail:
```
ERROR: Error computing the main repository mapping: no such package '@npm//': 

ERROR: Patch file key `not_a_package@1.2.3` does not match any npm packages in `npm_translate_lock(name = "npm").

Either remove this patch file if it is no longer needed or change its key to match an existing npm package.
```