### PR TITLE
prefactor: sort bzlmod attributes and fix npm_translate_lock name

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -10,13 +10,12 @@ load("//npm:npm_import.bzl", "npm_import", "npm_translate_lock")
 load("//npm/private:transitive_closure.bzl", "translate_to_transitive_closure")
 
 def _extension_impl(module_ctx):
-    npm_translate_lock_name = "npm"
     for mod in module_ctx.modules:
         for attr in mod.tags.npm_translate_lock:
             # npm_translate_lock MUST run before parse_pnpm_lock below since it may update
             # the pnpm-lock.yaml file when update_pnpm_lock is True.
             npm_translate_lock(
-                name = npm_translate_lock_name,
+                name = attr.name,
                 pnpm_lock = attr.pnpm_lock,
                 # TODO: get this working with bzlmod
                 # update_pnpm_lock = attr.update_pnpm_lock,
@@ -28,45 +27,61 @@ def _extension_impl(module_ctx):
             registries = {}
             lock_importers, lock_packages = utils.parse_pnpm_lock(module_ctx.read(attr.pnpm_lock))
             importers, packages = translate_to_transitive_closure(lock_importers, lock_packages, attr.prod, attr.dev, attr.no_optional)
-            imports = npm_translate_lock_helpers.gen_npm_imports(importers, packages, attr.pnpm_lock.package, npm_translate_lock_name, attr, registries, utils.default_registry())
+            imports = npm_translate_lock_helpers.gen_npm_imports(importers, packages, attr.pnpm_lock.package, attr.name, attr, registries, utils.default_registry())
             for i in imports:
                 npm_import(
                     name = i.name,
-                    package = i.package,
-                    version = i.version,
-                    link_packages = i.link_packages,
                     custom_postinstall = i.custom_postinstall,
                     deps = i.deps,
                     integrity = i.integrity,
+                    lifecycle_hooks = i.lifecycle_hooks,
+                    link_packages = i.link_packages,
+                    npm_translate_lock_repo = attr.name,
+                    package = i.package,
                     patch_args = i.patch_args,
                     patches = i.patches,
                     root_package = i.root_package,
-                    lifecycle_hooks = i.lifecycle_hooks,
                     transitive_closure = i.transitive_closure,
                     url = i.url,
-                    npm_translate_lock_repo = "npm",
+                    version = i.version,
                 )
 
         for i in mod.tags.npm_import:
             npm_import(
                 name = i.name,
-                package = i.package,
-                version = i.version,
-                link_packages = i.link_packages,
+                custom_postinstall = i.custom_postinstall,
                 integrity = i.integrity,
+                lifecycle_hooks = i.lifecycle_hooks,
+                link_packages = i.link_packages,
+                link_workspace = i.link_workspace,
+                package = i.package,
                 patch_args = i.patch_args,
                 patches = i.patches,
-                lifecycle_hooks = i.lifecycle_hooks,
-                custom_postinstall = i.custom_postinstall,
-                link_workspace = i.link_workspace,
-                url = i.url,
                 root_package = i.root_package,
+                url = i.url,
+                version = i.version,
             )
+
+def _npm_translate_lock_attrs():
+    attrs = dict(**npm_translate_lock_lib.attrs)
+
+    # Add macro attrs that aren't in the rule attrs.
+    attrs["name"] = attr.string()
+
+    return attrs
+
+def _npm_import_attrs():
+    attrs = dict(**npm_import_lib.attrs)
+
+    # Add macro attrs that aren't in the rule attrs.
+    attrs["name"] = attr.string()
+
+    return attrs
 
 npm = module_extension(
     implementation = _extension_impl,
     tag_classes = {
-        "npm_translate_lock": tag_class(attrs = dict({"name": attr.string()}, **npm_translate_lock_lib.attrs)),
-        "npm_import": tag_class(attrs = dict({"name": attr.string()}, **npm_import_lib.attrs)),
+        "npm_translate_lock": tag_class(attrs = _npm_translate_lock_attrs()),
+        "npm_import": tag_class(attrs = _npm_import_attrs()),
     },
 )


### PR DESCRIPTION
Prefactor for https://github.com/aspect-build/rules_js/pull/647. Step towards https://github.com/aspect-build/rules_js/issues/644.

Sorting the attributes alphabetically makes it easier to keep track of what's missing from the WORKSPACE api.