### PR TITLE
ci: ignore a bzlmod e2e that doesn't yet have a MODULE.bazel file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,6 +157,8 @@ jobs:
                       bzlmodEnabled: true
                     - folder: e2e/npm_translate_lock
                       bzlmodEnabled: true
+                    - folder: e2e/npm_translate_lock_auth
+                      bzlmodEnabled: true
                     - folder: e2e/npm_translate_package_lock
                       bzlmodEnabled: true
                     - folder: e2e/npm_translate_yarn_lock


### PR DESCRIPTION
Missed one that only runs after merging.