### PR TITLE
build: bump @kubernetes/client-node dep due to failure

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,7 +1,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2065072158
-pnpm-lock.yaml=-59888855
+pnpm-lock.yaml=-2047510405
 package.json=301352699
 pnpm-workspace.yaml=1306476322
 examples/js_binary/package.json=-41174383
@@ -13,6 +13,6 @@ examples/npm_package/packages/pkg_b/package.json=-994654274
 examples/webpack_cli/package.json=1775843160
 js/private/coverage/bundle/package.json=-975746706
 js/private/worker/src/package.json=837209084
-npm/private/test/package.json=-1998521308
+npm/private/test/package.json=-605924734
 npm/private/test/vendored/is-odd/package.json=1041695223
 npm/private/test/vendored/semver-max/package.json=578664053

--- a/npm/private/test/package.json
+++ b/npm/private/test/package.json
@@ -4,7 +4,7 @@
     "devDependencies": {
         "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e",
         "@figma/nodegit": "^0.28.0-figma.2",
-        "@kubernetes/client-node": "https://github.com/kubernetes-client/javascript#763decf",
+        "@kubernetes/client-node": "https://github.com/kubernetes-client/javascript#fc681991e61c6808dd26012a2331f83671a11218",
         "@plotly/regl": "2.1.2",
         "bufferutil": "4.0.1",
         "debug": "ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
     specifiers:
       '@blockprotocol/type-system-web': https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e
       '@figma/nodegit': ^0.28.0-figma.2
-      '@kubernetes/client-node': https://github.com/kubernetes-client/javascript#763decf
+      '@kubernetes/client-node': https://github.com/kubernetes-client/javascript#fc681991e61c6808dd26012a2331f83671a11218
       '@plotly/regl': 2.1.2
       bufferutil: 4.0.1
       debug: ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53
@@ -170,7 +170,7 @@ importers:
     devDependencies:
       '@blockprotocol/type-system-web': '@gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%2540blockprotocol/type-system-web?6526c0e'
       '@figma/nodegit': 0.28.0-figma.2
-      '@kubernetes/client-node': github.com/kubernetes-client/javascript/763decf_bufferutil@4.0.1
+      '@kubernetes/client-node': github.com/kubernetes-client/javascript/fc681991e61c6808dd26012a2331f83671a11218_bufferutil@4.0.1
       '@plotly/regl': 2.1.2
       bufferutil: 4.0.1
       debug: github.com/ngokevin/debug/9742c5f383a6f8046241920156236ade8ec30d53
@@ -2567,21 +2567,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  /execa/5.0.0:
-    resolution: {integrity: sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-    dev: true
-
   /ext/1.6.0:
     resolution: {integrity: sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==}
     dependencies:
@@ -2690,6 +2675,15 @@ packages:
 
   /form-data/2.3.3:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: true
+
+  /form-data/2.5.1:
+    resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
     engines: {node: '>= 0.12'}
     dependencies:
       asynckit: 0.4.0
@@ -3167,11 +3161,6 @@ packages:
       - supports-color
     dev: true
 
-  /human-signals/2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
-    dev: true
-
   /humanize-ms/1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
     dependencies:
@@ -3261,11 +3250,6 @@ packages:
     dependencies:
       make-dir: 2.1.0
       tmp: 0.0.33
-    dev: true
-
-  /interpret/1.4.0:
-    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
-    engines: {node: '>= 0.10'}
     dev: true
 
   /interpret/3.1.1:
@@ -3408,11 +3392,6 @@ packages:
       '@types/estree': registry.npmjs.org/@types/estree/1.0.0
     dev: true
 
-  /is-stream/2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-    dev: true
-
   /is-string-blank/1.0.1:
     resolution: {integrity: sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw==}
     dev: true
@@ -3449,12 +3428,12 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  /isomorphic-ws/4.0.1_ws@7.5.8:
-    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+  /isomorphic-ws/5.0.0_ws@8.12.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
       ws: '*'
     dependencies:
-      ws: 7.5.8_bufferutil@4.0.1
+      ws: 8.12.0_bufferutil@4.0.1
     dev: true
 
   /isstream/0.1.2:
@@ -3563,11 +3542,6 @@ packages:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
       graceful-fs: 4.2.10
-    dev: true
-
-  /jsonpath-plus/0.19.0:
-    resolution: {integrity: sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==}
-    engines: {node: '>=6.0'}
     dev: true
 
   /jsonpath-plus/7.2.0:
@@ -3817,11 +3791,6 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-
-  /mimic-fn/2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-    dev: true
 
   /mimic-response/1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
@@ -4295,13 +4264,6 @@ packages:
       npm-normalize-package-bin: 1.0.1
     dev: true
 
-  /npm-run-path/4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-    dependencies:
-      path-key: 3.1.1
-    dev: true
-
   /npmlog/4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
     dependencies:
@@ -4378,13 +4340,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-
-  /onetime/5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
-    dependencies:
-      mimic-fn: 2.1.0
-    dev: true
 
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
@@ -4850,13 +4805,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /rechoir/0.6.2:
-    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      resolve: 1.22.1
-    dev: true
-
   /rechoir/0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
@@ -5182,16 +5130,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  /shelljs/0.8.5:
-    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dependencies:
-      glob: 7.2.3
-      interpret: 1.4.0
-      rechoir: 0.6.2
-    dev: true
-
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5358,11 +5296,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-
-  /strip-final-newline/2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-    dev: true
 
   /strip-json-comments/2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -5644,10 +5577,6 @@ packages:
 
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
-
-  /tslib/1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
   /tslib/2.4.1:
@@ -6127,6 +6056,21 @@ packages:
       bufferutil: 4.0.1
     dev: true
 
+  /ws/8.12.0_bufferutil@4.0.1:
+    resolution: {integrity: sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dependencies:
+      bufferutil: 4.0.1
+    dev: true
+
   /xml/1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
     dev: true
@@ -6257,31 +6201,32 @@ packages:
     bundledDependencies:
       - '@mapbox/node-pre-gyp'
 
-  github.com/kubernetes-client/javascript/763decf_bufferutil@4.0.1:
-    resolution: {tarball: https://codeload.github.com/kubernetes-client/javascript/tar.gz/763decf}
-    id: github.com/kubernetes-client/javascript/763decf
+  github.com/kubernetes-client/javascript/fc681991e61c6808dd26012a2331f83671a11218_bufferutil@4.0.1:
+    resolution: {tarball: https://codeload.github.com/kubernetes-client/javascript/tar.gz/fc681991e61c6808dd26012a2331f83671a11218}
+    id: github.com/kubernetes-client/javascript/fc681991e61c6808dd26012a2331f83671a11218
     name: '@kubernetes/client-node'
-    version: 0.18.0
+    version: 0.18.1
     prepare: true
     requiresBuild: true
     dependencies:
-      '@types/node': registry.npmjs.org/@types/node/10.17.60
+      '@types/js-yaml': registry.npmjs.org/@types/js-yaml/4.0.5
+      '@types/node': registry.npmjs.org/@types/node/18.11.18
+      '@types/request': registry.npmjs.org/@types/request/2.48.8
       '@types/underscore': registry.npmjs.org/@types/underscore/1.11.4
+      '@types/ws': registry.npmjs.org/@types/ws/8.5.4
       byline: 5.0.0
-      execa: 5.0.0
-      isomorphic-ws: 4.0.1_ws@7.5.8
+      isomorphic-ws: 5.0.0_ws@8.12.0
       js-yaml: 4.1.0
-      jsonpath-plus: 0.19.0
+      jsonpath-plus: 7.2.0
       request: 2.88.2
       rfc4648: 1.5.2
-      shelljs: 0.8.5
       stream-buffers: 3.0.2
       tar: 6.1.11
       tmp-promise: 3.0.3
-      tslib: 1.14.1
+      tslib: 2.4.1
       typescript: 4.7.4
       underscore: 1.13.6
-      ws: 7.5.8_bufferutil@4.0.1
+      ws: 8.12.0_bufferutil@4.0.1
     optionalDependencies:
       openid-client: 5.3.1
     transitivePeerDependencies:
@@ -6311,6 +6256,12 @@ packages:
       '@types/keyv': registry.npmjs.org/@types/keyv/3.1.4
       '@types/node': registry.npmjs.org/@types/node/18.11.11
       '@types/responselike': registry.npmjs.org/@types/responselike/1.0.0
+    dev: true
+
+  registry.npmjs.org/@types/caseless/0.12.2:
+    resolution: {integrity: sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz}
+    name: '@types/caseless'
+    version: 0.12.2
     dev: true
 
   registry.npmjs.org/@types/eslint-scope/3.7.4:
@@ -6363,6 +6314,12 @@ packages:
     version: 2.0.4
     dev: false
 
+  registry.npmjs.org/@types/js-yaml/4.0.5:
+    resolution: {integrity: sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz}
+    name: '@types/js-yaml'
+    version: 4.0.5
+    dev: true
+
   registry.npmjs.org/@types/json-buffer/3.0.0:
     resolution: {integrity: sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz}
     name: '@types/json-buffer'
@@ -6382,12 +6339,6 @@ packages:
       '@types/node': registry.npmjs.org/@types/node/18.11.11
     dev: true
 
-  registry.npmjs.org/@types/node/10.17.60:
-    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz}
-    name: '@types/node'
-    version: 10.17.60
-    dev: true
-
   registry.npmjs.org/@types/node/16.11.68:
     resolution: {integrity: sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz}
     name: '@types/node'
@@ -6398,6 +6349,23 @@ packages:
     resolution: {integrity: sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz}
     name: '@types/node'
     version: 18.11.11
+
+  registry.npmjs.org/@types/node/18.11.18:
+    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz}
+    name: '@types/node'
+    version: 18.11.18
+    dev: true
+
+  registry.npmjs.org/@types/request/2.48.8:
+    resolution: {integrity: sha512-whjk1EDJPcAR2kYHRbFl/lKeeKYTi05A15K9bnLInCVroNDCtXce57xKdI0/rQaA3K+6q0eFyUBPmqfSndUZdQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/request/-/request-2.48.8.tgz}
+    name: '@types/request'
+    version: 2.48.8
+    dependencies:
+      '@types/caseless': registry.npmjs.org/@types/caseless/0.12.2
+      '@types/node': registry.npmjs.org/@types/node/18.11.18
+      '@types/tough-cookie': registry.npmjs.org/@types/tough-cookie/4.0.2
+      form-data: 2.5.1
+    dev: true
 
   registry.npmjs.org/@types/resolve/1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz}
@@ -6413,8 +6381,22 @@ packages:
       '@types/node': registry.npmjs.org/@types/node/18.11.11
     dev: true
 
+  registry.npmjs.org/@types/tough-cookie/4.0.2:
+    resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz}
+    name: '@types/tough-cookie'
+    version: 4.0.2
+    dev: true
+
   registry.npmjs.org/@types/underscore/1.11.4:
     resolution: {integrity: sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/underscore/-/underscore-1.11.4.tgz}
     name: '@types/underscore'
     version: 1.11.4
+    dev: true
+
+  registry.npmjs.org/@types/ws/8.5.4:
+    resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz}
+    name: '@types/ws'
+    version: 8.5.4
+    dependencies:
+      '@types/node': registry.npmjs.org/@types/node/18.11.18
     dev: true


### PR DESCRIPTION
Not sure why but at some point the following error started to happen outside of bazel in the prepare lifecycle hook which is being testing:
```
src/oidc_auth.ts(2,48): error TS2307: Cannot find module 'openid-client' or its corresponding type declarations.
```

full error log:
```
...2107_38676d339eae84ca91c8293d2287683a npm-install$ npm install
│ npm WARN deprecated har-validator@5.1.5: this library is no longer supported
│ npm WARN deprecated mkdirp@0.5.4: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
│ npm WARN deprecated debug@3.2.6: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.
│ npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8/
│ npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
│ > @kubernetes/client-node@0.18.0 prepare
│ > npm run build
│ > @kubernetes/client-node@0.18.0 build
│ > tsc
│ src/oidc_auth.ts(2,48): error TS2307: Cannot find module 'openid-client' or its corresponding type declarations.
│ npm ERR! code 2
│ npm ERR! path /Users/greg/Library/pnpm/store/v3/tmp/_tmp_92107_38676d339eae84ca91c8293d2287683a
│ npm ERR! command failed
│ npm ERR! command sh -c -- npm run build
│ npm ERR! A complete log of this run can be found in:
│ npm ERR!     /Users/greg/.npm/_logs/2023-01-13T23_24_58_155Z-debug-0.log
└─ Failed in 12s at /Users/greg/Library/pnpm/store/v3/tmp/_tmp_92107_38676d339eae84ca91c8293d2287683a
 ERR_PNPM_PREPARE_PACKAGE  Failed to prepare git-hosted package fetched from "https://codeload.github.com/kubernetes-client/javascript/tar.gz/763decf": @kubernetes/client-node@0.18.0 npm-install: `npm install`
Exit status 2
```

This PR the problematic dep to the latest commit hash which doesn't have this issue