### PR TITLE
Set fs._unpatched when patching the 'node:fs' module

### DIFF
--- a/js/private/node-patches/fs.js
+++ b/js/private/node-patches/fs.js
@@ -46,6 +46,12 @@ const _fs = require('fs');
 const HOP_NON_LINK = Symbol.for('HOP NON LINK');
 const patcher = (fs = _fs, roots) => {
     fs = fs || _fs;
+    // Make the original version of the library available for when access to the
+    // unguarded file system is necessary, such as the esbuild plugin that
+    // protects against sandbox escaping that occurs through module resolution
+    // in the Go binary. See
+    // https://github.com/aspect-build/rules_esbuild/issues/58.
+    fs._unpatched = Object.assign({}, fs);
     roots = roots || [];
     roots = roots.filter((root) => fs.existsSync(root));
     if (!roots.length) {

--- a/js/private/node-patches/src/fs.ts
+++ b/js/private/node-patches/src/fs.ts
@@ -32,6 +32,12 @@ const HOP_NON_LINK = Symbol.for('HOP NON LINK')
 
 export const patcher = (fs: any = _fs, roots: string[]) => {
     fs = fs || _fs
+    // Make the original version of the library available for when access to the
+    // unguarded file system is necessary, such as the esbuild plugin that
+    // protects against sandbox escaping that occurs through module resolution
+    // in the Go binary. See
+    // https://github.com/aspect-build/rules_esbuild/issues/58.
+    fs._unpatched = {...fs};
     roots = roots || []
     roots = roots.filter((root) => fs.existsSync(root))
     if (!roots.length) {


### PR DESCRIPTION
This allows inspecting the unsandboxed view of the file system if it's needed, such as for writing other sandbox guarding logic.