### PR TITLE
feat: verify patches via a generated source file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -152,7 +152,7 @@ npm_translate_lock(
     },
     update_pnpm_lock = True,
     verify_node_modules_ignored = "//:.bazelignore",
-    verify_patches = "examples/npm_deps/patches",
+    verify_patches = "//examples/npm_deps/patches:patches",
 )
 
 load("@npm//:repositories.bzl", "npm_repositories")

--- a/docs/npm_import.md
+++ b/docs/npm_import.md
@@ -27,6 +27,32 @@ Advanced users may want to directly fetch a package from npm rather than start f
 [`npm_import`](#npm_import) does this.
 
 
+<a id="list_patches"></a>
+
+## list_patches
+
+<pre>
+list_patches(<a href="#list_patches-name">name</a>, <a href="#list_patches-out">out</a>, <a href="#list_patches-include_patterns">include_patterns</a>, <a href="#list_patches-exclude_patterns">exclude_patterns</a>)
+</pre>
+
+Write a file containing a list of all patches in the current folder to the source tree.
+
+Use this together with the `verify_patches` attribute of `npm_translate_lock` to verify
+that all patches in a patch folder are included. This macro stamps a test to ensure the
+file stays up to date.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="list_patches-name"></a>name |  Name of the target   |  none |
+| <a id="list_patches-out"></a>out |  Name of file to write to the source tree. If unspecified, <code>name</code> is used   |  <code>None</code> |
+| <a id="list_patches-include_patterns"></a>include_patterns |  Patterns to pass to a glob of patch files   |  <code>["*.diff", "*.patch"]</code> |
+| <a id="list_patches-exclude_patterns"></a>exclude_patterns |  Patterns to ignore in a glob of patch files   |  <code>[]</code> |
+
+
 <a id="npm_import"></a>
 
 ## npm_import
@@ -182,10 +208,9 @@ npm_translate_lock(<a href="#npm_translate_lock-name">name</a>, <a href="#npm_tr
                    <a href="#npm_translate_lock-public_hoist_packages">public_hoist_packages</a>, <a href="#npm_translate_lock-dev">dev</a>, <a href="#npm_translate_lock-no_optional">no_optional</a>, <a href="#npm_translate_lock-run_lifecycle_hooks">run_lifecycle_hooks</a>, <a href="#npm_translate_lock-lifecycle_hooks">lifecycle_hooks</a>,
                    <a href="#npm_translate_lock-lifecycle_hooks_envs">lifecycle_hooks_envs</a>, <a href="#npm_translate_lock-lifecycle_hooks_exclude">lifecycle_hooks_exclude</a>,
                    <a href="#npm_translate_lock-lifecycle_hooks_execution_requirements">lifecycle_hooks_execution_requirements</a>, <a href="#npm_translate_lock-lifecycle_hooks_no_sandbox">lifecycle_hooks_no_sandbox</a>, <a href="#npm_translate_lock-bins">bins</a>,
-                   <a href="#npm_translate_lock-verify_node_modules_ignored">verify_node_modules_ignored</a>, <a href="#npm_translate_lock-verify_patches">verify_patches</a>, <a href="#npm_translate_lock-verify_patches_extensions">verify_patches_extensions</a>, <a href="#npm_translate_lock-quiet">quiet</a>,
-                   <a href="#npm_translate_lock-link_workspace">link_workspace</a>, <a href="#npm_translate_lock-pnpm_version">pnpm_version</a>, <a href="#npm_translate_lock-register_copy_directory_toolchains">register_copy_directory_toolchains</a>,
-                   <a href="#npm_translate_lock-register_copy_to_directory_toolchains">register_copy_to_directory_toolchains</a>, <a href="#npm_translate_lock-package_json">package_json</a>,
-                   <a href="#npm_translate_lock-warn_on_unqualified_tarball_url">warn_on_unqualified_tarball_url</a>, <a href="#npm_translate_lock-kwargs">kwargs</a>)
+                   <a href="#npm_translate_lock-verify_node_modules_ignored">verify_node_modules_ignored</a>, <a href="#npm_translate_lock-verify_patches">verify_patches</a>, <a href="#npm_translate_lock-quiet">quiet</a>, <a href="#npm_translate_lock-link_workspace">link_workspace</a>, <a href="#npm_translate_lock-pnpm_version">pnpm_version</a>,
+                   <a href="#npm_translate_lock-register_copy_directory_toolchains">register_copy_directory_toolchains</a>, <a href="#npm_translate_lock-register_copy_to_directory_toolchains">register_copy_to_directory_toolchains</a>,
+                   <a href="#npm_translate_lock-package_json">package_json</a>, <a href="#npm_translate_lock-warn_on_unqualified_tarball_url">warn_on_unqualified_tarball_url</a>, <a href="#npm_translate_lock-kwargs">kwargs</a>)
 </pre>
 
 Repository macro to generate starlark code from a lock file.
@@ -236,8 +261,7 @@ For more about how to use npm_translate_lock, read [pnpm and rules_js](/docs/pnp
 | <a id="npm_translate_lock-lifecycle_hooks_no_sandbox"></a>lifecycle_hooks_no_sandbox |  If True, a "no-sandbox" execution requirement is added to all lifecycle hooks unless overridden by <code>lifecycle_hooks_execution_requirements</code>.<br><br>Equivalent to adding <code>"*": ["no-sandbox"]</code> to <code>lifecycle_hooks_execution_requirements</code>.<br><br>This defaults to True to limit the overhead of sandbox creation and copying the output TreeArtifacts out of the sandbox.<br><br>Read more: [lifecycles](/docs/pnpm.md#lifecycles)   |  <code>True</code> |
 | <a id="npm_translate_lock-bins"></a>bins |  Binary files to create in <code>node_modules/.bin</code> for packages in this lock file.<br><br>For a given package, this is typically derived from the "bin" attribute in the package.json file of that package.<br><br>For example:<br><br><pre><code> bins = {     "@foo/bar": {         "foo": "./foo.js",         "bar": "./bar.js"     }, } </code></pre><br><br>Dicts of bins not additive. The most specific match wins.<br><br>In the future, this field may be automatically populated from information in the pnpm lock file. That feature is currently blocked on https://github.com/pnpm/pnpm/issues/5131.   |  <code>{}</code> |
 | <a id="npm_translate_lock-verify_node_modules_ignored"></a>verify_node_modules_ignored |  node_modules folders in the source tree should be ignored by Bazel.<br><br>This points to a <code>.bazelignore</code> file to verify that all nested node_modules directories pnpm will create are listed.<br><br>See https://github.com/bazelbuild/bazel/issues/8106   |  <code>None</code> |
-| <a id="npm_translate_lock-verify_patches"></a>verify_patches |  Path to a workspace folder containing all patches used in the <code>patches</code> attribute. Will fail if any patches are missing. Does not recurse into subfolders.<br><br>For example:<br><br><pre><code> verify_patches = "path/to/patches", </code></pre>   |  <code>None</code> |
-| <a id="npm_translate_lock-verify_patches_extensions"></a>verify_patches_extensions |  Patch file extensions to look for when using <code>verify_patches</code>. Add <code>""</code> to allow extensionless patches.   |  <code>[".diff", ".patch"]</code> |
+| <a id="npm_translate_lock-verify_patches"></a>verify_patches |  Label to a patch list file.<br><br>Use this in together with the <code>list_patches</code> macro to guarantee that all patches in a patch folder are included in the <code>patches</code> attribute.<br><br>For example:<br><br><pre><code> verify_patches = "//patches:patches.list", </code></pre><br><br>In your patches folder add a BUILD.bazel file containing. <pre><code> load("@aspect_rules_js//npm:npm_import.bzl", "list_patches")<br><br>list_patches(     name = "patches",     out = "patches.list", ) </code></pre><br><br>See the <code>list_patches</code> documentation for further info.   |  <code>None</code> |
 | <a id="npm_translate_lock-quiet"></a>quiet |  Set to False to print info logs and output stdout & stderr of pnpm lock update actions to the console.   |  <code>True</code> |
 | <a id="npm_translate_lock-link_workspace"></a>link_workspace |  The workspace name where links will be created for the packages in this lock file.<br><br>This is typically set in rule sets and libraries that vendor the starlark generated by npm_translate_lock so the link_workspace passed to npm_import is set correctly so that links are created in the external repository and not the user workspace.<br><br>Can be left unspecified if the link workspace is the user workspace.   |  <code>None</code> |
 | <a id="npm_translate_lock-pnpm_version"></a>pnpm_version |  pnpm version to use when generating the @pnpm repository. Set to None to not create this repository.   |  <code>"7.25.0"</code> |

--- a/e2e/verify_patches/MODULE.bazel
+++ b/e2e/verify_patches/MODULE.bazel
@@ -32,9 +32,7 @@ npm.npm_translate_lock(
     npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
     update_pnpm_lock = True,
-    verify_patches = "patches",
-    verify_patches_extensions = [".patch"],
-    verify_node_modules_ignored = "//:.bazelignore",
+    verify_patches = "//patches:patches.list",
 )
 
 use_repo(npm, "npm")

--- a/e2e/verify_patches/README.md
+++ b/e2e/verify_patches/README.md
@@ -1,1 +1,2 @@
-# Test coverage for `verify_patches`.
+# Test coverage for `verify_patches` attribute of `npm_translate_lock` and the
+# companion `list_patches` macro.

--- a/e2e/verify_patches/WORKSPACE
+++ b/e2e/verify_patches/WORKSPACE
@@ -35,8 +35,7 @@ npm_translate_lock(
     pnpm_lock = "//:pnpm-lock.yaml",
     update_pnpm_lock = True,
     verify_node_modules_ignored = "//:.bazelignore",
-    verify_patches = "patches",
-    verify_patches_extensions = [".patch"],
+    verify_patches = "//patches:patches.list",
 )
 
 load("@npm//:repositories.bzl", "npm_repositories")

--- a/e2e/verify_patches/patches/BUILD.bazel
+++ b/e2e/verify_patches/patches/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@aspect_rules_js//npm:npm_import.bzl", "list_patches")
+
+list_patches(
+    name = "patches",
+    out = "patches.list",
+    include_patterns = ["*.patch"],
+)

--- a/e2e/verify_patches/patches/patches.list
+++ b/e2e/verify_patches/patches/patches.list
@@ -1,0 +1,3 @@
+patches/test-a.patch
+patches/test-a@0.0.1.patch
+patches/test-b.patch

--- a/examples/npm_deps/patches/BUILD.bazel
+++ b/examples/npm_deps/patches/BUILD.bazel
@@ -1,0 +1,5 @@
+load("//npm:npm_import.bzl", "list_patches")
+
+list_patches(
+    name = "patches"
+)

--- a/examples/npm_deps/patches/patches
+++ b/examples/npm_deps/patches/patches
@@ -1,0 +1,3 @@
+examples/npm_deps/patches/test-a.patch
+examples/npm_deps/patches/test-a@0.0.1.patch
+examples/npm_deps/patches/test-b.patch

--- a/npm/BUILD.bazel
+++ b/npm/BUILD.bazel
@@ -44,11 +44,13 @@ bzl_library(
     srcs = ["npm_import.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//npm/private:list_sources",
         "//npm/private:npm_import",
         "//npm/private:npm_translate_lock",
         "//npm/private:utils",
         "//npm/private:versions",
         "@aspect_bazel_lib//lib:repositories",
+        "@aspect_bazel_lib//lib:write_source_files",
         "@bazel_skylib//lib:dicts",
     ],
 )

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -35,7 +35,6 @@ def _extension_impl(module_ctx):
                 update_pnpm_lock = attr.update_pnpm_lock,
                 verify_node_modules_ignored = attr.verify_node_modules_ignored,
                 verify_patches = attr.verify_patches,
-                verify_patches_extensions = attr.verify_patches_extensions,
                 yarn_lock = attr.yarn_lock,
             )
 

--- a/npm/private/BUILD.bazel
+++ b/npm/private/BUILD.bazel
@@ -8,6 +8,15 @@ exports_files(
 )
 
 bzl_library(
+    name = "list_sources",
+    srcs = ["list_sources.bzl"],
+    visibility = [
+        "//docs:__subpackages__",
+        "//npm:__subpackages__",
+    ],
+)
+
+bzl_library(
     name = "npm_package",
     srcs = ["npm_package.bzl"],
     visibility = [

--- a/npm/private/list_sources.bzl
+++ b/npm/private/list_sources.bzl
@@ -1,0 +1,19 @@
+"Output a list of source files to a file"
+
+def _impl(ctx):
+    output = ctx.actions.declare_file(ctx.label.name)
+    content = "\n".join([file.path for file in ctx.files.srcs]) + "\n"
+
+    ctx.actions.write(
+        output,
+        content,
+    )
+
+    return DefaultInfo(files = depset([output]), runfiles = ctx.runfiles(files = [output]))
+
+list_sources = rule(
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+    },
+    implementation = _impl,
+)

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -40,8 +40,7 @@ _ATTRS = {
     "update_pnpm_lock": attr.bool(),
     "use_home_npmrc": attr.bool(),
     "verify_node_modules_ignored": attr.label(),
-    "verify_patches": attr.string(),
-    "verify_patches_extensions": attr.string_list(default = [".diff", ".patch"]),
+    "verify_patches": attr.label(),
     "yarn_lock": attr.label(),
 }
 
@@ -69,7 +68,8 @@ def _impl(rctx):
                 state.reload_lockfile()
 
     gen_helpers.verify_node_modules_ignored(rctx, state.importers(), state.root_package())
-    helpers.verify_patches(rctx)
+
+    helpers.verify_patches(rctx, state.label_store)
 
     rctx.report_progress("Translating {}".format(state.label_store.relative_path("pnpm_lock")))
 

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -2,49 +2,34 @@
 
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 
-def _workspace_path(rctx, short_path, user_workspace_label):
-    """Get the absolute path in the user repository of a short path using a reference label from the user repository."""
-    label_path = rctx.path(user_workspace_label)
-    label_short_path = user_workspace_label.package + ("/" if user_workspace_label.package else "") + user_workspace_label.name
-    workspace_path = str(label_path).removesuffix(label_short_path)
-    return rctx.path(workspace_path + "/" + short_path)
-
-def _verify_patches(rctx):
-    for ext in rctx.attr.verify_patches_extensions:
-        if ext != "" and not ext.startswith("."):
-            fail("ERROR: Invalid patch extension '{ext}' in `verify_patches_extensions`.".format(ext = ext))
-
+def _verify_patches(rctx, label_store):
     if rctx.attr.verify_patches and rctx.attr.patches != None:
-        patches_folder_path = _workspace_path(rctx, rctx.attr.verify_patches, rctx.attr.pnpm_lock)
+        rctx.report_progress("Verifying patches in {}".format(label_store.relative_path("verify_patches")))
 
-        files_in_patch_folder = patches_folder_path.readdir()
-        all_patch_files = sets.make()
-        for file in files_in_patch_folder:
-            for ext in rctx.attr.verify_patches_extensions:
-                if ext == "" and file.basename.find(".") == -1 or file.basename.endswith(ext):
-                    sets.insert(all_patch_files, file)
-                    break
+        # Patches in the patch list verification file
+        verify_patches_content = rctx.read(label_store.label("verify_patches")).strip(" \t\n\r")
+        verify_patches = sets.make(verify_patches_content.split("\n"))
 
-        declared_patch_files = sets.make()
+        # Patches declared in the `patches` attr
+        declared_patch_count = 0
+        for pkg_patches in rctx.attr.patches.values():
+            declared_patch_count += len(pkg_patches)
+        declared_patches = sets.make([label_store.relative_path("patches_%d" % i) for i in range(declared_patch_count)])
 
-        for (_, pkg_patches) in rctx.attr.patches.items():
-            for patch in pkg_patches:
-                sets.insert(declared_patch_files, rctx.path(rctx.attr.pnpm_lock.relative(patch)))
-
-        if not sets.is_subset(all_patch_files, declared_patch_files):
-            missing_patches = sets.to_list(sets.difference(all_patch_files, declared_patch_files))
-            missing_patches_formatted = "\n".join(["- %s" % path.basename for path in missing_patches])
+        if not sets.is_subset(verify_patches, declared_patches):
+            missing_patches = sets.to_list(sets.difference(verify_patches, declared_patches))
+            missing_patches_formatted = "\n".join(["- %s" % path for path in missing_patches])
             fail("""
 ERROR: in verify_patches:
 
-The following patches were found in {patches_folder} but were not listed
+The following patches were found in {patches_list} but were not listed
 in the `patches` attribute of `npm_translate_lock`.
 
 {missing_patches}
 
 To disable this check, remove the `verify_patches` attribute from `npm_translate_lock`.
 
-""".format(patches_folder = patches_folder_path, missing_patches = missing_patches_formatted))
+""".format(patches_list = label_store.relative_path("verify_patches"), missing_patches = missing_patches_formatted))
 
 helpers = struct(
     verify_patches = _verify_patches,

--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -40,6 +40,8 @@ WARNING: `update_pnpm_lock` attribute in `npm_translate_lock(name = "{rctx_name}
         # labels only needed when updating the pnpm lock file
         _init_update_labels(rctx, label_store)
 
+    _init_patch_labels(rctx, label_store)
+
     _init_link_workspace(priv, rctx, label_store)
 
     # parse the pnpm lock file incase since we need the importers list for additional init
@@ -133,6 +135,21 @@ def _init_update_labels(rctx, label_store):
         label_store.add("npm_package_lock", attr.npm_package_lock, seed_root = True)
     if attr.yarn_lock:
         label_store.add("yarn_lock", attr.yarn_lock, seed_root = True)
+
+################################################################################
+def _init_patch_labels(rctx, label_store):
+    if rctx.attr.verify_patches:
+        label_store.add("verify_patches", rctx.attr.verify_patches)
+
+    patches = []
+    for pkg_patches in rctx.attr.patches.values():
+        patches.extend(pkg_patches)
+
+    # Convert patch label strings to labels
+    patches = [rctx.attr.pnpm_lock.relative(p) for p in patches]
+
+    for i, d in enumerate(patches):
+        label_store.add("patches_{}".format(i), d)
 
 ################################################################################
 def _init_importer_labels(priv, label_store):


### PR DESCRIPTION
This solves the problem where npm_translate_lock wouldn't invalidate when a patch was added to the patch folder.