### PR TITLE
fix: delete .git folder when downloading npm package from git

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,16 +178,16 @@ jobs:
               with:
                   persist-credentials: false
 
-            # - name: Reconfigure git to use HTTP authentication
-            #   run: >
-            #       git config --global url."https://github.com/".insteadOf
-            #       ssh://git@github.com/
+            - name: Reconfigure git to use HTTP authentication
+              run: >
+                  git config --global url."https://github.com/".insteadOf
+                  ssh://git@github.com/
 
             # - uses: webfactory/ssh-agent@v0.7.0
             #   with:
             #       ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-            - run: ssh -vT git@github.com
+            # - run: ssh -vT git@github.com
 
             - name: Mount bazel caches
               uses: actions/cache@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,6 +175,19 @@ jobs:
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v3
+              with:
+                  persist-credentials: false
+
+            # - name: Reconfigure git to use HTTP authentication
+            #   run: >
+            #       git config --global url."https://github.com/".insteadOf
+            #       ssh://git@github.com/
+
+            # - uses: webfactory/ssh-agent@v0.7.0
+            #   with:
+            #       ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+            - run: ssh -vT git@github.com
 
             - name: Mount bazel caches
               uses: actions/cache@v3

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -172,3 +172,14 @@ npm_import(
     root_package = "",
     version = "8.4.0",
 )
+
+# Import a package using git+ssh to test that the .git folder is removed
+# See //npm/private/test:no_git_metadata_test.
+npm_import(
+    name = "protoc-gen-grpc",
+    commit = "be5580b06348d3eb9b4610a4a94065154a0df41f",
+    package = "protoc-gen-grpc",
+    root_package = "",
+    url = "git+ssh://git@github.com/gregmagolan-codaio/protoc-gen-grpc-ts.git",
+    version = "github.com/gregmagolan-codaio/protoc-gen-grpc-ts/be5580b06348d3eb9b4610a4a94065154a0df41f",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -175,11 +175,21 @@ npm_import(
 
 # Import a package using git+ssh to test that the .git folder is removed
 # See //npm/private/test:no_git_metadata_test.
+# npm_import(
+#     name = "protoc-gen-grpc",
+#     commit = "be5580b06348d3eb9b4610a4a94065154a0df41f",
+#     package = "protoc-gen-grpc",
+#     root_package = "",
+#     url = "git+ssh://git@github.com/gregmagolan-codaio/protoc-gen-grpc-ts.git",
+#     version = "github.com/gregmagolan-codaio/protoc-gen-grpc-ts/be5580b06348d3eb9b4610a4a94065154a0df41f",
+# )
 npm_import(
     name = "protoc-gen-grpc",
-    commit = "be5580b06348d3eb9b4610a4a94065154a0df41f",
-    package = "protoc-gen-grpc",
+    commit = "2f900b62fe2529c8cb07da0cf64f2625994021f3",
+    package = "lodash",
     root_package = "",
-    url = "git+ssh://git@github.com/gregmagolan-codaio/protoc-gen-grpc-ts.git",
-    version = "github.com/gregmagolan-codaio/protoc-gen-grpc-ts/be5580b06348d3eb9b4610a4a94065154a0df41f",
+    url = "git+ssh://git@github.com/lodash/lodash.git",
+    version = "github.com/lodash/lodash/2f900b62fe2529c8cb07da0cf64f2625994021f3",
 )
+
+# 2cb6c7ac4f8868e22b483dfd07774d05e429daab

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -372,6 +372,10 @@ def _fetch_git_repository(rctx):
     _git_reset(rctx, git_repo)
     _git_clean(rctx, git_repo)
 
+    git_metadata_folder = git_repo.directory.get_child(".git")
+    if not rctx.delete(git_metadata_folder):
+        fail("Failed to delete .git folder in %s" % str(git_repo.directory))
+
 def _download_and_extract_archive(rctx):
     download_url = rctx.attr.url if rctx.attr.url else utils.npm_registry_download_url(rctx.attr.package, rctx.attr.version, {}, utils.default_registry())
 

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -87,3 +87,16 @@ sh_test(
     ],
     toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
 )
+
+# Test that a package imported directly from a git repository has its
+# .git folder removed.
+sh_test(
+    name = "no_git_metadata_test",
+    srcs = ["no_git_metadata_test.sh"],
+    args = [
+        "$(rootpath @protoc-gen-grpc//:pkg)",
+    ],
+    data = [
+        "@protoc-gen-grpc//:pkg",
+    ],
+)

--- a/npm/private/test/no_git_metadata_test.sh
+++ b/npm/private/test/no_git_metadata_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+PACKAGE_DIR="$1"
+
+if [ -d "$PACKAGE_DIR/.git" ]; then
+    echo "Expected $PACKAGE_DIR/.git to have been deleted"
+    exit 1
+fi


### PR DESCRIPTION
Found that the `.git` folder was non-hermitic in some client work.