### PR TITLE
ci: make folder part of cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,6 +117,16 @@ jobs:
             # Will look like [".", "e2e/bzlmod", ...]
             folders: ${{ toJSON(steps.*.outputs.folder) }}
 
+    matrix-prep-root-hash:
+        # Prepares the 'folder' axis of the test matrix
+        runs-on: ubuntu-latest
+        steps:
+            # need to checkout repository to hash files.
+            - uses: actions/checkout@v3
+            - id: root
+              run: echo "hash=${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'MODULE.bazel', '**/*.js', '!e2e') }}" >> $GITHUB_OUTPUT
+        outputs:
+            hash: ${{ steps.root.outputs.hash }}
     test:
         runs-on: ubuntu-latest
 
@@ -124,6 +134,7 @@ jobs:
             - matrix-prep-config
             - matrix-prep-bazelversion
             - matrix-prep-folder
+            - matrix-prep-root-hash
 
         strategy:
             fail-fast: false
@@ -182,8 +193,14 @@ jobs:
                   path: |
                       ~/.cache/bazel
                       ~/.cache/bazel-repo
-                  key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', '**/*.js') }}
-                  restore-keys: bazel-cache-
+                  key: >-
+                      bazel-cache-
+                      ${{ matrix.config }}-${{ matrix.bazelversion }}-
+                      ${{ matrix.folder }}-${{ matrix.bzlmodEnabled }}-
+                      ${{ needs.matrix-prep-root-hash.outputs.hash }}-
+                      ${{ hashFiles( format('{0}/**/BUILD.bazel', matrix.folder), format('{0}/**/*.bzl', matrix.folder), format('{0}/WORKSPACE', matrix.folder),format('{0}/MODULE.bazel', matrix.folder), format('{0}/**/*.js', matrix.folder) ) }}
+                  restore-keys: |
+                      bazel-cache-${{ matrix.config }}-${{ matrix.bazelversion }}-${{ matrix.folder }}-${{ matrix.bzlmodEnabled }}-
 
             - name: Configure Bazel version
               working-directory: ${{ matrix.folder }}
@@ -204,14 +221,6 @@ jobs:
               env:
                   ENGFLOW_CLIENT_CRT: ${{ secrets.ENGFLOW_CLIENT_CRT }}
                   ENGFLOW_PRIVATE_KEY: ${{ secrets.ENGFLOW_PRIVATE_KEY }}
-
-            - name: Check for test.sh
-              # Checks for the existence of test.sh in the folder. Downstream steps can use
-              # steps.has_test_sh.outputs.files_exists as a conditional.
-              id: has_test_sh
-              uses: andstor/file-existence-action@v2
-              with:
-                  files: '${{ matrix.folder }}/test.sh'
 
             - name: Set bzlmod flag
               # Store the --enable_bzlmod flag that we add to the test command below
@@ -248,7 +257,7 @@ jobs:
 
             - name: ./test.sh
               # Run if there is a test.sh file in the folder.
-              if: steps.has_test_sh.outputs.files_exists == 'true'
+              if: ${{ hashFiles(format('{0}/test.sh', matrix.folder)) != '' }}
               working-directory: ${{ matrix.folder }}
               shell: bash
               # Run the script potentially setting BZLMOD_FLAG=--enable_bzlmod. All test.sh


### PR DESCRIPTION
Currently, all matrix members use the same cache key for storing caches, preventing all matrix folders to upload their own caches and use the from the root folder all the time. this slows down all matrices except the root. 