### PR TITLE
fix: delete .git folder when downloading npm package from git

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,11 +66,16 @@ jobs:
         runs-on: ubuntu-latest
         env:
             ASPECT_NPM_AUTH_TOKEN: ${{ secrets.ASPECT_NPM_AUTH_TOKEN }}
+            SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         steps:
             - id: root
               run: echo "folder=." >> $GITHUB_OUTPUT
             - id: bzlmod
               run: echo "folder=e2e/bzlmod" >> $GITHUB_OUTPUT
+            - id: git_dep_metadata
+              run: echo "folder=e2e/git_dep_metadata" >> $GITHUB_OUTPUT
+              # Don't run e2e/git_dep_metadata if there is no ssh key secret which is the case on forks.
+              if: ${{ env.SSH_PRIVATE_KEY != '' }}
             - id: js_image
               run: echo "folder=e2e/js_image" >> $GITHUB_OUTPUT
             - id: js_run_devserver
@@ -175,6 +180,15 @@ jobs:
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v3
+
+            # Setup an ssh keypair and github.com in known_hosts for e2e/git_dep_metadata,
+            # which exercises fetching a git repository via ssh.
+            - uses: webfactory/ssh-agent@v0.7.0
+              env:
+                  SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+              if: ${{ env.SSH_PRIVATE_KEY != '' }}
+              with:
+                  ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
             - name: Mount bazel caches
               uses: actions/cache@v3

--- a/e2e/git_dep_metadata/.bazeliskrc
+++ b/e2e/git_dep_metadata/.bazeliskrc
@@ -1,0 +1,1 @@
+../../.bazeliskrc

--- a/e2e/git_dep_metadata/.bazelrc
+++ b/e2e/git_dep_metadata/.bazelrc
@@ -1,0 +1,2 @@
+# import common bazelrc shared with e2e workspaces
+import %workspace%/../../.bazelrc.common

--- a/e2e/git_dep_metadata/.bazelversion
+++ b/e2e/git_dep_metadata/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/git_dep_metadata/BUILD.bazel
+++ b/e2e/git_dep_metadata/BUILD.bazel
@@ -1,0 +1,12 @@
+# Test that a package imported directly from a git repository has its
+# .git folder removed.
+sh_test(
+    name = "no_git_metadata_test",
+    srcs = ["no_git_metadata_test.sh"],
+    args = [
+        "$(rootpath @protoc-gen-grpc//:pkg)",
+    ],
+    data = [
+        "@protoc-gen-grpc//:pkg",
+    ],
+)

--- a/e2e/git_dep_metadata/MODULE.bazel
+++ b/e2e/git_dep_metadata/MODULE.bazel
@@ -1,0 +1,25 @@
+module(
+    version = "0.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "aspect_rules_js", version = "0.0.0")
+
+local_path_override(
+    module_name = "aspect_rules_js",
+    path = "../..",
+)
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
+
+npm.npm_import(
+    name = "protoc-gen-grpc",
+    commit = "be5580b06348d3eb9b4610a4a94065154a0df41f",
+    package = "protoc-gen-grpc",
+    root_package = "",
+    url = "git+ssh://git@github.com/gregmagolan-codaio/protoc-gen-grpc-ts.git",
+    version = "github.com/gregmagolan-codaio/protoc-gen-grpc-ts/be5580b06348d3eb9b4610a4a94065154a0df41f",
+)
+
+use_repo(npm, "protoc-gen-grpc")
+use_repo(npm, "protoc-gen-grpc__links")

--- a/e2e/git_dep_metadata/README.md
+++ b/e2e/git_dep_metadata/README.md
@@ -1,0 +1,4 @@
+This e2e tests that an imported git dependency has it's .git metadata folder removed. The git
+dependency is fetched via npm_import rather than npm_translate_lock because pnpm will automatically
+convert `git+ssh` protocols to `https` in the lockfile when the repository is public, preventing us
+from exercising the ssh logic specifically.

--- a/e2e/git_dep_metadata/WORKSPACE
+++ b/e2e/git_dep_metadata/WORKSPACE
@@ -1,0 +1,26 @@
+local_repository(
+    name = "aspect_rules_js",
+    path = "../..",
+)
+
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "nodejs",
+    node_version = DEFAULT_NODE_VERSION,
+)
+
+load("@aspect_rules_js//npm:npm_import.bzl", "npm_import")
+
+npm_import(
+    name = "protoc-gen-grpc",
+    commit = "be5580b06348d3eb9b4610a4a94065154a0df41f",
+    package = "protoc-gen-grpc",
+    root_package = "",
+    url = "git+ssh://git@github.com/gregmagolan-codaio/protoc-gen-grpc-ts.git",
+    version = "github.com/gregmagolan-codaio/protoc-gen-grpc-ts/be5580b06348d3eb9b4610a4a94065154a0df41f",
+)

--- a/e2e/git_dep_metadata/no_git_metadata_test.sh
+++ b/e2e/git_dep_metadata/no_git_metadata_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+PACKAGE_DIR="$1"
+
+if [ -d "$PACKAGE_DIR/.git" ]; then
+    echo "Expected $PACKAGE_DIR/.git to have been deleted"
+    exit 1
+fi

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -372,6 +372,10 @@ def _fetch_git_repository(rctx):
     _git_reset(rctx, git_repo)
     _git_clean(rctx, git_repo)
 
+    git_metadata_folder = git_repo.directory.get_child(".git")
+    if not rctx.delete(git_metadata_folder):
+        fail("Failed to delete .git folder in %s" % str(git_repo.directory))
+
 def _download_and_extract_archive(rctx):
     download_url = rctx.attr.url if rctx.attr.url else utils.npm_registry_download_url(rctx.attr.package, rctx.attr.version, {}, utils.default_registry())
 


### PR DESCRIPTION
An ssh keypair is required to clone via ssh. Secrets aren't accessible in GitHub actions on forks, so I had to move the test to an e2e that is exclusively run inside this repo.