### PR TITLE
fix: provide a better experience for patch_args when pnpm patches are used

### DIFF
--- a/e2e/npm_translate_lock_subdir_patch/MODULE.bazel
+++ b/e2e/npm_translate_lock_subdir_patch/MODULE.bazel
@@ -11,9 +11,6 @@ npm.npm_translate_lock(
         "//subdir:package.json",
         "//subdir:patches/debug@4.3.4.patch",
     ],
-    patch_args = {
-        "*": ["-p1"],
-    },
     pnpm_lock = "//subdir:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
 )

--- a/e2e/npm_translate_lock_subdir_patch/WORKSPACE
+++ b/e2e/npm_translate_lock_subdir_patch/WORKSPACE
@@ -22,9 +22,6 @@ npm_translate_lock(
         "//subdir:package.json",
         "//subdir:patches/debug@4.3.4.patch",
     ],
-    patch_args = {
-        "*": ["-p1"],
-    },
     pnpm_lock = "//subdir:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
 )

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -373,7 +373,9 @@ def _gen_npm_imports(importers, packages, patched_dependencies, root_package, rc
                 msg = """\
 ERROR: patch_args for package {package} contains a strip prefix that is incompatible with a patch applied via `pnpm.patchedDependencies`.
 
-`pnpm.patchedDependencies` requires a strip prefix of `-p1`. All applied patches must use the same strip prefix.
+`pnpm.patchedDependencies` requires a strip prefix of `-p1`. All applied patches to a package must use the same strip prefix.
+
+Double check that the `patch_args` in `npm_translate_lock` does not declare a different strip prefix.
 
 """.format(package = friendly_name)
                 fail(msg)


### PR DESCRIPTION
Revisiting this change as it was brought up recently in the Bazel slack group: https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1691179585032929