### PR TITLE
fix: add missing 'warming' task

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -44,6 +44,7 @@ workspaces:
     #           icon: js
 
 tasks:
+    warming:
     branch_freshness:
     test:
         flags:


### PR DESCRIPTION
Greens up the warming jobs for rules_js builds