### PR TITLE
Make launcher.sh generated by js_binary more self-documenting.

### DIFF
--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -348,6 +348,9 @@ def _bash_launcher(ctx, entry_point_path, log_prefix_rule_set, log_prefix_rule, 
         toolchain_files.append(npm_wrapper)
 
     launcher_subst = {
+        "{{target_label}}": str(ctx.label),
+        "{{template_label}}": str(ctx.attr._launcher_template.label),
+        "{{entry_point_label}}": str(ctx.attr.entry_point.label),
         "{{entry_point_path}}": entry_point_path,
         "{{envs}}": "\n".join(envs),
         "{{fixed_args}}": " ".join(fixed_args_expanded),

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -247,6 +247,18 @@ _NODE_OPTION = """JS_BINARY__NODE_OPTIONS+=(\"{value}\")"""
 def _target_tool_short_path(path):
     return ("../" + path[len("external/"):]) if path.startswith("external/") else path
 
+# Generate a consistent label string between Bazel versions.
+# TODO: hoist this function to bazel-lib and use from there (as well as the dup in npm/private/utils.bzl)
+def _consistent_label_str(workspace_name, label):
+    # Starting in Bazel 6, the workspace name is empty for the local workspace and there's no other way to determine it.
+    # This behavior differs from Bazel 5 where the local workspace name was fully qualified in str(label).
+    workspace_name = "" if label.workspace_name == workspace_name else label.workspace_name
+    return "@{}//{}:{}".format(
+        workspace_name,
+        label.package,
+        label.name,
+    )
+
 def _bash_launcher(ctx, entry_point_path, log_prefix_rule_set, log_prefix_rule, fixed_args, fixed_env, is_windows):
     envs = []
     for (key, value) in dicts.add(fixed_env, ctx.attr.env).items():
@@ -348,9 +360,9 @@ def _bash_launcher(ctx, entry_point_path, log_prefix_rule_set, log_prefix_rule, 
         toolchain_files.append(npm_wrapper)
 
     launcher_subst = {
-        "{{target_label}}": str(ctx.label),
-        "{{template_label}}": str(ctx.attr._launcher_template.label),
-        "{{entry_point_label}}": str(ctx.attr.entry_point.label),
+        "{{target_label}}": _consistent_label_str(ctx.workspace_name, ctx.label),
+        "{{template_label}}": _consistent_label_str(ctx.workspace_name, ctx.attr._launcher_template.label),
+        "{{entry_point_label}}": _consistent_label_str(ctx.workspace_name, ctx.attr.entry_point.label),
         "{{entry_point_path}}": entry_point_path,
         "{{envs}}": "\n".join(envs),
         "{{fixed_args}}": " ".join(fixed_args_expanded),

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# This bash script is a wrapper around the NodeJS JavaScript file
+# entry point with the following bazel label:
+#     {{entry_point_label}}
+#
+# The script's was generated to execute the js_binary target
+#     {{target_label}}
+#
+# The template used to generate this script is
+#     {{template_label}}
+
 set -o pipefail -o errexit -o nounset
 
 {{envs}}

--- a/js/private/test/shellcheck_launcher.sh
+++ b/js/private/test/shellcheck_launcher.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# This bash script is a wrapper around the NodeJS JavaScript file
+# entry point with the following bazel label:
+#     @//js/private/test:shellcheck.js
+#
+# The script's was generated to execute the js_binary target
+#     @//js/private/test:shellcheck_launcher
+#
+# The template used to generate this script is
+#     @//js/private:js_binary.sh.tpl
+
 set -o pipefail -o errexit -o nounset
 
 export JS_BINARY__BINDIR="bazel-out/k8-fastbuild/bin"


### PR DESCRIPTION
I often find launcher.sh files are the entry point to some failed command. When I inspect launcher.sh, it takes some digging to figure out what js_binary it corresponds to. Some additional comments at the top of the script will reduce this debug time.

Before:

    #!/usr/bin/env bash

    set -o pipefail -o errexit -o nounset

    export JS_BINARY__BINDIR="bazel-out/k8-opt-exec-2B5CBBC6/bin"
    export JS_BINARY__BUILD_FILE_PATH="BUILD.bazel"
    export JS_BINARY__COMPILATION_MODE="opt"
    export JS_BINARY__PACKAGE=""

After:

    #!/usr/bin/env bash

    # This is a bash script generated to execute the js_binary target
    #     @esbuild_linux-x64//:launcher
    #
    # This bash script is a wrapper around the NodeJS JavaScript file
    # entry point with the following bazel label:
    #     @esbuild_linux-x64//:launcher.js
    #
    # The template used to generate this script is
    #     @aspect_rules_js//js/private:js_binary.sh.tpl

    set -o pipefail -o errexit -o nounset

    export JS_BINARY__BINDIR="bazel-out/k8-opt-exec-2B5CBBC6/bin"
    export JS_BINARY__BUILD_FILE_PATH="BUILD.bazel"
    export JS_BINARY__COMPILATION_MODE="opt"
    export JS_BINARY__PACKAGE=""