### PR TITLE
feat: add public_hoist_packages to bzlmod api

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -30,6 +30,7 @@ def _extension_impl(module_ctx):
                 pnpm_lock = attr.pnpm_lock,
                 pnpm_version = attr.pnpm_version,
                 preupdate = attr.preupdate,
+                public_hoist_packages = attr.public_hoist_packages,
                 quiet = attr.quiet,
                 register_copy_directory_toolchains = False,  # this registration is handled elsewhere with bzlmod
                 register_copy_to_directory_toolchains = False,  # this registration is handled elsewhere with bzlmod


### PR DESCRIPTION
In support of https://github.com/aspect-build/rules_js/issues/644.

Needed for a client.

This one doesn't have an e2e to exercise it. I could add one if you prefer, or we could just wait until `test //...` is ready to run under bzlmod and that should exercise it.