### PR TITLE
chore: add new issues to Aspect OSS Bazel Rules project and label untriaged

### DIFF
--- a/.github/workflows/new_issue_labels.yaml
+++ b/.github/workflows/new_issue_labels.yaml
@@ -1,0 +1,21 @@
+name: Label issues when opened
+on:
+    issues:
+        types:
+            - opened
+            - reopened
+jobs:
+    label_issues:
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - uses: actions/github-script@v6
+              with:
+                  script: |
+                      github.rest.issues.addLabels({
+                        issue_number: context.issue.number,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        labels: ["untriaged"]
+                      })

--- a/.github/workflows/new_issue_project.yaml
+++ b/.github/workflows/new_issue_project.yaml
@@ -1,0 +1,27 @@
+name: Add to Aspect OSS Bazel Rules project when opened
+on:
+    issues:
+        types:
+            - opened
+            - reopened
+jobs:
+    comment:
+        runs-on: ubuntu-latest
+        steps:
+            - run: |
+                  gh api graphql -f query='
+                    mutation {
+                      addProjectV2ItemById(input: {projectId: "$PROJECT_ID" contentId: "$ISSUE_ID"}) {
+                        item {
+                          id
+                        }
+                      }
+                    }
+                  '
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_RW_TOKEN }}
+                  OWNER: ${{ github.repository_owner }}
+                  REPO: ${{ github.event.repository.name }}
+                  ISSUE_ID: ${{ github.event.issue.node_id }}
+                  # Project: Aspect OSS Bazel Rules
+                  PROJECT_ID: PVT_kwDOA6IKMs4ALj2o


### PR DESCRIPTION
Closes the loop so that new issues automatically show up on project board and don't fall through the cracks.

Follow-up later today will do the same for new PRs