### PR TITLE
fix: fix a unit test that fails on osx

### DIFF
--- a/js/private/test/BUILD.bazel
+++ b/js/private/test/BUILD.bazel
@@ -22,7 +22,7 @@ genrule(
     name = "shell_launcher_sed",
     srcs = [":shellcheck_launcher"],
     outs = ["shellcheck_launcher_sed.sh"],
-    cmd = "cat $(execpath :shellcheck_launcher) | sed \"s#$(BINDIR)#bazel-out/k8-fastbuild/bin#\" | sed \"s#%s#linux_amd64#\" | sed \"s#\\\"%s\\\"#\\\"k8\\\"#\" > $@" % (
+    cmd = "cat $(execpath :shellcheck_launcher) | sed \"s#$(BINDIR)#bazel-out/k8-fastbuild/bin#\" | sed \"s#JS_BINARY__TARGET_CPU=\\\"$(TARGET_CPU)\\\"#JS_BINARY__TARGET_CPU=\\\"k8\\\"#\" | sed \"s#%s#linux_amd64#\" | sed \"s#\\\"%s\\\"#\\\"k8\\\"#\" > $@" % (
         host.platform,
         host.os,
     ),


### PR DESCRIPTION
Without this, on osx we get the diff_test error:
```
9c9
< export JS_BINARY__TARGET_CPU="linux_amd64"
---
> export JS_BINARY__TARGET_CPU="k8"
FAIL: files "js/private/test/shellcheck_launcher_sed.sh" and "js/private/test/shellcheck_launcher.sh" differ. 
```

This variable is the one case where we don't want to substitute `linux_amd64` for the `host.platform`.