### PR TITLE
chore: run e2e/js_run_deverser on ci with bzlmod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,8 +180,6 @@ jobs:
                       bzlmodEnabled: true
                     - folder: e2e/js_image_oci
                       bzlmodEnabled: true
-                    - folder: e2e/js_run_devserver
-                      bzlmodEnabled: true
                     - folder: e2e/npm_link_package-esm
                       bzlmodEnabled: true
                     - folder: e2e/npm_link_package


### PR DESCRIPTION
This e2e was already converted but for some reason was added back to the ignore list.

Related: https://github.com/aspect-build/rules_js/issues/644