### PR TITLE
fix: add support for local `node_toolchain`

### DIFF
--- a/js/private/coverage/coverage.sh.tpl
+++ b/js/private/coverage/coverage.sh.tpl
@@ -30,7 +30,7 @@ if [ ! -f "$entry_point" ]; then
     exit 1
 fi
 
-node="$RUNFILES/{{workspace_name}}/{{node}}"
+node="$RUNFILES/{{node}}"
 if [ ! -f "$node" ]; then
     logf_fatal "node binary '%s' not found in runfiles" "$node"
     exit 1

--- a/js/private/coverage/coverage.sh.tpl
+++ b/js/private/coverage/coverage.sh.tpl
@@ -2,8 +2,6 @@
 
 set -o pipefail -o errexit -o nounset
 
-export JS_BINARY__LOG_PREFIX="{{log_prefix_rule_set}}[{{log_prefix_rule}}]"
-
 function logf_stderr {
     local format_string="$1\n"
     shift
@@ -12,7 +10,7 @@ function logf_stderr {
 }
 
 function logf_fatal {
-    printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+    printf "FATAL: " >&2
     logf_stderr "$@"
 }
 

--- a/js/private/coverage/coverage.sh.tpl
+++ b/js/private/coverage/coverage.sh.tpl
@@ -2,6 +2,8 @@
 
 set -o pipefail -o errexit -o nounset
 
+export JS_BINARY__LOG_PREFIX="{{log_prefix_rule_set}}[{{log_prefix_rule}}]"
+
 function logf_stderr {
     local format_string="$1\n"
     shift

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -216,7 +216,7 @@ if [ "${node:0:1}" = "/" ]; then
         exit 1
     fi
 else
-    export JS_BINARY__NODE_BINARY="$JS_BINARY__RUNFILES/{{workspace_name}}/{{node}}"
+    export JS_BINARY__NODE_BINARY="$JS_BINARY__RUNFILES/{{node}}"
     if [ ! -f "$JS_BINARY__NODE_BINARY" ]; then
         logf_fatal "node binary '%s' not found in runfiles" "$JS_BINARY__NODE_BINARY"
         exit 1
@@ -238,7 +238,7 @@ if [ "$npm" ]; then
             exit 1
         fi
     else
-        export JS_BINARY__NPM_BINARY="$JS_BINARY__RUNFILES/{{workspace_name}}/{{npm}}"
+        export JS_BINARY__NPM_BINARY="$JS_BINARY__RUNFILES/{{npm}}"
         if [ ! -f "$JS_BINARY__NPM_BINARY" ]; then
             logf_fatal "npm binary '%s' not found in runfiles" "$JS_BINARY__NPM_BINARY"
             exit 1

--- a/js/private/test/shellcheck_launcher.sh
+++ b/js/private/test/shellcheck_launcher.sh
@@ -324,7 +324,7 @@ if [ ! -f "$entry_point" ]; then
     exit 1
 fi
 
-node="$(_normalize_path "../nodejs_linux_amd64/bin/nodejs/bin/node")"
+node="$(_normalize_path "aspect_rules_js/../nodejs_linux_amd64/bin/nodejs/bin/node")"
 if [ "${node:0:1}" = "/" ]; then
     # A user may specify an absolute path to node using target_tool_path in node_toolchain
     export JS_BINARY__NODE_BINARY="$node"
@@ -355,7 +355,7 @@ if [ "$npm" ]; then
             exit 1
         fi
     else
-        export JS_BINARY__NPM_BINARY="$JS_BINARY__RUNFILES/aspect_rules_js/"
+        export JS_BINARY__NPM_BINARY="$JS_BINARY__RUNFILES/"
         if [ ! -f "$JS_BINARY__NPM_BINARY" ]; then
             logf_fatal "npm binary '%s' not found in runfiles" "$JS_BINARY__NPM_BINARY"
             exit 1


### PR DESCRIPTION
# Summary
This closes https://github.com/aspect-build/rules_js/issues/899 and it has all the context. Make the `_target_tool_short_path` path resolve when it’s in an external repo or repo-local.