### PR TITLE
fix: include runfiles tree in js_image_layer when --nobuild_runfile_links is set

### DIFF
--- a/e2e/js_image_docker/test.sh
+++ b/e2e/js_image_docker/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+BZLMOD_FLAG="${BZLMOD_FLAG:-}"
+
+# shellcheck disable=SC2086
+if ! bazel test $BZLMOD_FLAG --nobuild_runfile_links //...; then
+  echo "ERROR: expected 'bazel test $BZLMOD_FLAG --nobuild_runfile_links //...' to pass"
+  exit 1
+fi

--- a/e2e/js_image_oci/test.sh
+++ b/e2e/js_image_oci/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+BZLMOD_FLAG="${BZLMOD_FLAG:-}"
+
+# shellcheck disable=SC2086
+if ! bazel test $BZLMOD_FLAG --nobuild_runfile_links //...; then
+  echo "ERROR: expected 'bazel test $BZLMOD_FLAG --nobuild_runfile_links //...' to pass"
+  exit 1
+fi

--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -136,7 +136,15 @@ def _runfile_path(ctx, file, runfiles_dir):
 def _runfiles_dir(root, default_info):
     manifest = default_info.files_to_run.runfiles_manifest
 
-    runfiles = manifest.short_path.replace(manifest.basename, "")[:-1]
+    nobuild_runfile_links_is_set = manifest.short_path.endswith("_manifest")
+
+    if nobuild_runfile_links_is_set:
+        # When `--nobuild_runfile_links` is set, runfiles_manifest points to the manifest
+        # file sitting adjacent to the runfiles tree rather than within it.
+        runfiles = default_info.files_to_run.runfiles_manifest.short_path.replace("_manifest", "")
+    else:
+        runfiles = manifest.short_path.replace(manifest.basename, "")[:-1]
+
     return paths.join(root, runfiles.replace(".sh", ""))
 
 def _js_image_layer_impl(ctx):


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_js/issues/902.

The runfiles tree doesn't need to exist, we just need the correct path to it.