### PR TITLE
chore: update to rules_nodejs 5.8.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,14 +8,10 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.27.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "rules_nodejs", version = "5.8.0")
+bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "platforms", version = "0.0.4")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-
-node.toolchain(
-    name = "nodejs",
-)
 
 use_repo(node, "nodejs_toolchains")
 
@@ -26,10 +22,6 @@ use_repo(node, "nodejs_linux_arm64")
 use_repo(node, "nodejs_linux_s390x")
 use_repo(node, "nodejs_linux_ppc64le")
 use_repo(node, "nodejs_windows_amd64")
-
-register_toolchains(
-    "@nodejs_toolchains//:all"
-)
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 

--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_nodejs", version = "5.8.0")
+bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 
 local_path_override(
@@ -14,20 +14,11 @@ local_path_override(
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 
-node.toolchain(
-    name = "nodejs",
-)
-
 use_repo(node, "nodejs_toolchains")
-
 use_repo(node, "nodejs_linux_amd64")
 use_repo(node, "nodejs_linux_arm64")
 use_repo(node, "nodejs_darwin_amd64")
 use_repo(node, "nodejs_darwin_arm64")
-
-register_toolchains(
-    "@nodejs_toolchains//:all"
-)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 

--- a/e2e/pnpm_workspace_deps/MODULE.bazel
+++ b/e2e/pnpm_workspace_deps/MODULE.bazel
@@ -4,29 +4,11 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_nodejs", version = "5.8.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 
 local_path_override(
     module_name = "aspect_rules_js",
     path = "../..",
-)
-
-node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-
-node.toolchain(
-    name = "nodejs",
-)
-
-use_repo(node, "nodejs_toolchains")
-
-use_repo(node, "nodejs_linux_amd64")
-use_repo(node, "nodejs_linux_arm64")
-use_repo(node, "nodejs_darwin_amd64")
-use_repo(node, "nodejs_darwin_arm64")
-
-register_toolchains(
-    "@nodejs_toolchains//:all"
 )
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")

--- a/e2e/pnpm_workspace_rerooted/MODULE.bazel
+++ b/e2e/pnpm_workspace_rerooted/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_nodejs", version = "5.8.0")
+bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 
 local_path_override(

--- a/e2e/vendored_node/MODULE.bazel
+++ b/e2e/vendored_node/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "rules_nodejs", version = "5.8.0")
+bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "platforms", version = "0.0.4")
 
 local_path_override(

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -19,8 +19,8 @@ def rules_js_dependencies():
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "08337d4fffc78f7fe648a93be12ea2fc4e8eb9795a4e6aa48595b66b34555626",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.0/rules_nodejs-core-5.8.0.tar.gz"],
+        sha256 = "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
     )
 
     http_archive(


### PR DESCRIPTION
In support of https://github.com/aspect-build/rules_js/issues/644.

Fixes https://github.com/aspect-build/rules_js/issues/864.

Node toolchain no longer needs to be explicitly registered unless using a different default version or registering a second copy.