### PR TITLE
chore: remove legacy Workflows option

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -81,4 +81,4 @@ tasks:
     test:
         flags:
             - --remote_default_exec_properties=cache-silo-key="74aed5f7"
-        archive_execution_log: false
+


### PR DESCRIPTION
This option has been superseded by `bazel_debug_assistance` and defaults false.