### PR TITLE
fix: invalid error when `translate_lock` action cache needs update

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -297,7 +297,7 @@ def _fail_if_frozen_pnpm_lock(rctx, state):
 
 ERROR: `{action_cache}` is out of date. `{pnpm_lock}` may require an update. To update run,
 
-           bazel run @//{rctx_name}:sync
+           bazel run @{rctx_name}//:sync
 
 """.format(
             action_cache = state.label_store.relative_path("action_cache"),


### PR DESCRIPTION
```
~/p/vscode-ng-language-service  main *5  bazel run @//npm:sync                                                                    INT х  pgschwendtner@devversion  01:26:14 PM 
Starting local Bazel server and connecting to it...
ERROR: Skipping '@//npm:sync': no such package 'npm': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /usr/local/google/home/pgschwendtner/projects/vscode-ng-language-service/npm
WARNING: Target pattern parsing failed.
ERROR: no such package 'npm': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /usr/local/google/home/pgschwendtner/projects/vscode-ng-language-service/npm
INFO: Elapsed time: 11.058s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
FAILED: Build did NOT complete successfully (0 packages loaded)
```