### PR TITLE
refactor: removed unused is_windows params

### DIFF
--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -440,8 +440,8 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
 
     files = [bash_launcher] + toolchain_files
     if ctx.attr.copy_data_to_bin:
-        files.append(copy_file_to_bin_action(ctx, entry_point, is_windows = is_windows))
-        files.extend(copy_files_to_bin_actions(ctx, ctx.files.data, is_windows = is_windows))
+        files.append(copy_file_to_bin_action(ctx, entry_point))
+        files.extend(copy_files_to_bin_actions(ctx, ctx.files.data))
     else:
         files.append(entry_point)
         files.extend(ctx.files.data)

--- a/js/private/js_library.bzl
+++ b/js/private/js_library.bzl
@@ -88,10 +88,9 @@ runtime dependency on this target.
         providers = [JsInfo],
     ),
     "data": JS_LIBRARY_DATA_ATTR,
-    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 
-def _gather_sources_and_declarations(ctx, targets, files, is_windows = False):
+def _gather_sources_and_declarations(ctx, targets, files):
     """Gathers sources and declarations from a list of targets
 
     Args:
@@ -104,8 +103,6 @@ def _gather_sources_and_declarations(ctx, targets, files, is_windows = False):
         files: List of files to gather as sources and declarations.
 
             These typically come from the `srcs` and/or `data` attributes of a rule
-
-        is_windows: If true, an cmd.exe actions are created when copying files to the output tree so there is no bash dependency
 
     Returns:
         Sources & declaration files depsets in the sequence (sources, declarations)
@@ -143,7 +140,7 @@ target in {file_basename}'s package and add that target to the deps of {this_tar
                     this_target = ctx.label,
                 )
                 fail(msg)
-            file = copy_file_to_bin_action(ctx, file, is_windows = is_windows)
+            file = copy_file_to_bin_action(ctx, file)
 
         if file.is_directory:
             # assume a directory contains declarations since we can't know that it doesn't
@@ -183,20 +180,16 @@ target in {file_basename}'s package and add that target to the deps of {this_tar
     return (sources, declarations)
 
 def _js_library_impl(ctx):
-    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
-
     sources, declarations = _gather_sources_and_declarations(
         ctx = ctx,
         targets = ctx.attr.srcs,
         files = ctx.files.srcs,
-        is_windows = is_windows,
     )
 
     additional_sources, additional_declarations = _gather_sources_and_declarations(
         ctx = ctx,
         targets = ctx.attr.declarations,
         files = ctx.files.declarations,
-        is_windows = is_windows,
     )
 
     sources = depset(transitive = [sources, additional_sources])


### PR DESCRIPTION
# Description

The need for this param was removed a long time ago in the bazel-lib copy action helpers so it is no longer bearing.

# Type of change

- [x] Refactor (a code change that neither fixes a bug or adds a new feature)

# Test plan

How has this been tested?

- [x] Covered by existing tests cases
