### PR TITLE
fix: Launcher script detection

### DIFF
--- a/js/private/coverage/merger.bzl
+++ b/js/private/coverage/merger.bzl
@@ -10,7 +10,6 @@ _ATTRS = {
         default = Label("//js/private/coverage:coverage.sh.tpl"),
         allow_single_file = True,
     ),
-    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 
 # Do the opposite of _to_manifest_path in
@@ -20,9 +19,13 @@ _ATTRS = {
 def _target_tool_short_path(workspace_name, path):
     return (workspace_name + "/../" + path[len("external/"):]) if path.startswith("external/") else path
 
+def _is_windows(nodeinfo):
+    target_tool_path = nodeinfo.target_tool_path
+    return target_tool_path.endswith('.exe') or target_tool_path.endswith('.cmd') or target_tool_path.endswith('.bat')
+
 def _impl(ctx):
-    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
     node_bin = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo
+    is_windows = _is_windows(node_bin)
 
     # Create launcher
     bash_launcher = ctx.actions.declare_file("%s.sh" % ctx.label.name)

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -237,7 +237,6 @@ _ATTRS = {
         default = Label("//js/private:npm_wrapper.bat"),
         allow_single_file = True,
     ),
-    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     "_node_patches_legacy_files": attr.label_list(
         allow_files = True,
         default = ["@aspect_rules_js//js/private/node-patches_legacy:fs.js"],
@@ -409,8 +408,13 @@ def _bash_launcher(ctx, entry_point_path, log_prefix_rule_set, log_prefix_rule, 
 
     return launcher, toolchain_files
 
+def _is_windows(nodeinfo):
+    target_tool_path = nodeinfo.target_tool_path
+    return target_tool_path.endswith('.exe') or target_tool_path.endswith('.cmd') or target_tool_path.endswith('.bat')
+
 def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [], fixed_env = {}):
-    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+    toolchain = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"]
+    is_windows = _is_windows(toolchain.nodeinfo)
     is_bazel_6 = is_bazel_6_or_greater()
     unresolved_symlinks_enabled = False
     if hasattr(ctx.attr, "unresolved_symlinks_enabled"):
@@ -420,7 +424,7 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
     if is_windows and not ctx.attr.enable_runfiles:
         fail("need --enable_runfiles on Windows for to support rules_js")
 
-    if ctx.attr.include_npm and not hasattr(ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo, "npm_files"):
+    if ctx.attr.include_npm and not hasattr(toolchain.nodeinfo, "npm_files"):
         fail("include_npm requires a minimum @rules_nodejs version of 5.7.0")
 
     if DirectoryPathInfo in ctx.attr.entry_point:
@@ -449,9 +453,9 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
         files.extend(ctx.files._node_patches_legacy_files + [ctx.file._node_patches_legacy])
     else:
         files.extend(ctx.files._node_patches_files + [ctx.file._node_patches])
-    files.extend(ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo.tool_files)
+    files.extend(toolchain.nodeinfo.tool_files)
     if ctx.attr.include_npm:
-        files.extend(ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo.npm_files)
+        files.extend(toolchain.nodeinfo.npm_files)
 
     runfiles = ctx.runfiles(
         files = files,


### PR DESCRIPTION
Use the nodejs toolchain to detect the exec platform.

Fixes #977 

# Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

# Properties of change

- [ ] Breaking change (this change will cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test plan

How has this been tested?

- [ ] Covered by existing tests cases
- [ ] New test cases added
- [x ] Local testing
