### PR TITLE
perf: use Bazel 6 optimized patches in js_run_devserver when --experimental_allow_unresolved_symlinks is set

### DIFF
--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -243,6 +243,10 @@ def js_run_devserver(
             "@aspect_rules_js//js/private:enable_runfiles": True,
             "//conditions:default": False,
         }),
+        unresolved_symlinks_enabled = select({
+            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "//conditions:default": False,
+        }),
         entry_point = "@aspect_rules_js//js/private:js_devserver_entrypoint",
         # This rule speaks the ibazel protocol
         tags = kwargs.pop("tags", []) + ["ibazel_notify_changes"],

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -28,6 +28,10 @@ coverage_fail_test(
         "//conditions:default": False,
     }),
     entry_point = "lib.js",
+    unresolved_symlinks_enabled = select({
+        "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+        "//conditions:default": False,
+    }),
 )
 
 PASS_CMD = """\
@@ -56,4 +60,8 @@ coverage_pass_test(
         "//conditions:default": False,
     }),
     entry_point = "lib.js",
+    unresolved_symlinks_enabled = select({
+        "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+        "//conditions:default": False,
+    }),
 )

--- a/js/private/test/create_launcher/custom_test.bzl
+++ b/js/private/test/create_launcher/custom_test.bzl
@@ -50,5 +50,9 @@ def custom_test(**kwargs):
             "//js/private:enable_runfiles": True,
             "//conditions:default": False,
         }),
+        unresolved_symlinks_enabled = select({
+            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "//conditions:default": False,
+        }),
         **kwargs
     )


### PR DESCRIPTION
rules_js js_test base attributes that js_run_devserver uses requires setting `unresolved_symlinks_enabled` to True based on the `@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks` condition to enable the optimized Bazel 6 patches only when the user is using Bazel 6 **AND** unresolved symlinks are enabled. They are enabled by default but they can be disabled by the user so we need to check anyway.

**Type of change**

- [x] Performance (a code change that improves performance)

**Test plan**

- [x] Covered by existing test cases
