### PR TITLE
docs: add note documenting js_binary(args)

### DIFF
--- a/docs/js_binary.md
+++ b/docs/js_binary.md
@@ -37,7 +37,7 @@ based on the requested target platform. Use the
 Bazel option to see more detail about the selection.
 
 All [common binary attributes](https://bazel.build/reference/be/common-definitions#common-attributes-binaries) are supported
-including `args` as the list of arguments passed node.js.
+including `args` as the list of arguments passed Node.js.
 
 This rules requires that Bazel was run with
 [`--enable_runfiles`](https://docs.bazel.build/versions/main/command-line-reference.html#flag--enable_runfiles). 
@@ -81,9 +81,8 @@ js_test(<a href="#js_test-name">name</a>, <a href="#js_test-chdir">chdir</a>, <a
 
 Identical to js_binary, but usable under `bazel test`.
 
-All [common binary attributes](https://bazel.build/reference/be/common-definitions#common-attributes-binaries)
-and [common test attributes](https://bazel.build/reference/be/common-definitions#common-attributes-tests) are
-supported including `args` as the list of arguments passed node.js.
+All [common test attributes](https://bazel.build/reference/be/common-definitions#common-attributes-tests) are
+supported including `args` as the list of arguments passed Node.js.
 
 Bazel will set environment variables when a test target is run under `bazel test` and `bazel run`
 that a test runner can use.

--- a/docs/js_binary.md
+++ b/docs/js_binary.md
@@ -36,6 +36,9 @@ based on the requested target platform. Use the
 [`--toolchain_resolution_debug`](https://docs.bazel.build/versions/main/command-line-reference.html#flag--toolchain_resolution_debug)
 Bazel option to see more detail about the selection.
 
+All [common binary attributes](https://bazel.build/reference/be/common-definitions#common-attributes-binaries) are supported
+including `args` as the list of arguments passed node.js.
+
 This rules requires that Bazel was run with
 [`--enable_runfiles`](https://docs.bazel.build/versions/main/command-line-reference.html#flag--enable_runfiles). 
 
@@ -77,6 +80,10 @@ js_test(<a href="#js_test-name">name</a>, <a href="#js_test-chdir">chdir</a>, <a
 </pre>
 
 Identical to js_binary, but usable under `bazel test`.
+
+All [common binary attributes](https://bazel.build/reference/be/common-definitions#common-attributes-binaries)
+and [common test attributes](https://bazel.build/reference/be/common-definitions#common-attributes-tests) are
+supported including `args` as the list of arguments passed node.js.
 
 Bazel will set environment variables when a test target is run under `bazel test` and `bazel run`
 that a test runner can use.

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -553,8 +553,7 @@ js_binary = rule(
 js_test = rule(
     doc = """Identical to js_binary, but usable under `bazel test`.
 
-All [common binary attributes](https://bazel.build/reference/be/common-definitions#common-attributes-binaries)
-and [common test attributes](https://bazel.build/reference/be/common-definitions#common-attributes-tests) are
+All [common test attributes](https://bazel.build/reference/be/common-definitions#common-attributes-tests) are
 supported including `args` as the list of arguments passed node.js.
 
 Bazel will set environment variables when a test target is run under `bazel test` and `bazel run`

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -33,7 +33,7 @@ based on the requested target platform. Use the
 Bazel option to see more detail about the selection.
 
 All [common binary attributes](https://bazel.build/reference/be/common-definitions#common-attributes-binaries) are supported
-including `args` as the list of arguments passed node.js.
+including `args` as the list of arguments passed Node.js.
 
 This rules requires that Bazel was run with
 [`--enable_runfiles`](https://docs.bazel.build/versions/main/command-line-reference.html#flag--enable_runfiles). 
@@ -554,7 +554,7 @@ js_test = rule(
     doc = """Identical to js_binary, but usable under `bazel test`.
 
 All [common test attributes](https://bazel.build/reference/be/common-definitions#common-attributes-tests) are
-supported including `args` as the list of arguments passed node.js.
+supported including `args` as the list of arguments passed Node.js.
 
 Bazel will set environment variables when a test target is run under `bazel test` and `bazel run`
 that a test runner can use.

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -32,6 +32,9 @@ based on the requested target platform. Use the
 [`--toolchain_resolution_debug`](https://docs.bazel.build/versions/main/command-line-reference.html#flag--toolchain_resolution_debug)
 Bazel option to see more detail about the selection.
 
+All [common binary attributes](https://bazel.build/reference/be/common-definitions#common-attributes-binaries) are supported
+including `args` as the list of arguments passed node.js.
+
 This rules requires that Bazel was run with
 [`--enable_runfiles`](https://docs.bazel.build/versions/main/command-line-reference.html#flag--enable_runfiles). 
 """
@@ -549,6 +552,10 @@ js_binary = rule(
 
 js_test = rule(
     doc = """Identical to js_binary, but usable under `bazel test`.
+
+All [common binary attributes](https://bazel.build/reference/be/common-definitions#common-attributes-binaries)
+and [common test attributes](https://bazel.build/reference/be/common-definitions#common-attributes-tests) are
+supported including `args` as the list of arguments passed node.js.
 
 Bazel will set environment variables when a test target is run under `bazel test` and `bazel run`
 that a test runner can use.


### PR DESCRIPTION
Fix #1019

All binary+test targets have an `args` but I don't see a way to document it. I think this is a stardoc issue and an issue should be created?