### PR TITLE
fix: cleanup flaky devserver tests

### DIFF
--- a/e2e/js_run_devserver/multirun_test.sh
+++ b/e2e/js_run_devserver/multirun_test.sh
@@ -14,13 +14,13 @@ _sedi () {
   sed "${sedi[@]}" "$@"
 }
 
-echo "TEST - $0: $1"
+echo "$$: TEST - $0: $1"
 
 ./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" >/dev/null 2>&1 &
 ibazel_pid="$!"
 
 function _exit {
-  echo "Cleanup..."
+  echo "$$: Cleanup..."
   kill "$ibazel_pid"
   wait "$ibazel_pid"
   git checkout src/index.html src/BUILD.bazel
@@ -28,78 +28,78 @@ function _exit {
 }
 trap _exit EXIT
 
-echo "Waiting for $1 devserver to launch on 8080..."
+echo "$$: Waiting for $1 devserver to launch on 8080..."
 
 n=0
 while ! nc -z localhost 8080; do
   if [ $n -gt 100 ]; then
-    echo "ERROR: Expected http://localhost:8080 to be available"
+    echo "$$: ERROR: Expected http://localhost:8080 to be available"
     exit 1
   fi
   sleep 1 # wait before check again
   ((n=n+1))
 done
 
-echo "Waiting for $1 devserver to launch on 8081..."
+echo "$$: Waiting for $1 devserver to launch on 8081..."
 
 n=0
 while ! nc -z localhost 8081; do
   if [ $n -gt 100 ]; then
-    echo "ERROR: Expected http://localhost:8081 to be available"
+    echo "$$: ERROR: Expected http://localhost:8081 to be available"
     exit 1
   fi
   sleep 1 # wait before check again
   ((n=n+1))
 done
 
-echo "Devservers ready"
+echo "$$: Devservers ready"
 
 if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "My first website"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to contain 'My first website'"
+  echo "$$: ERROR: Expected http://localhost:8080/index.html to contain 'My first website'"
   exit 1
 fi
 
 if ! curl http://localhost:8081/index.html --fail 2>/dev/null | grep "My first website"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to contain 'My first website'"
+  echo "$$: ERROR: Expected http://localhost:8081/index.html to contain 'My first website'"
   exit 1
 fi
 
 if ! curl http://localhost:8080/other.html --fail 2>/dev/null | grep "My other website"; then
-  echo "ERROR: Expected http://localhost:8080/other.html to contain 'My other website'"
+  echo "$$: ERROR: Expected http://localhost:8080/other.html to contain 'My other website'"
   exit 1
 fi
 
 if ! curl http://localhost:8081/other.html --fail 2>/dev/null | grep "My other website"; then
-  echo "ERROR: Expected http://localhost:8080/other.html to contain 'My other website'"
+  echo "$$: ERROR: Expected http://localhost:8081/other.html to contain 'My other website'"
   exit 1
 fi
 
 if curl http://localhost:8080/new.html --fail 2>/dev/null; then
-  echo "ERROR: Expected http://localhost:8080/new.html to fail with 404"
+  echo "$$: ERROR: Expected http://localhost:8080/new.html to fail with 404"
   exit 1
 fi
 
 if curl http://localhost:8081/new.html --fail 2>/dev/null; then
-  echo "ERROR: Expected http://localhost:8080/new.html to fail with 404"
+  echo "$$: ERROR: Expected http://localhost:8081/new.html to fail with 404"
   exit 1
 fi
 
 if curl http://localhost:8080/index.html --fail 2>/dev/null | grep "A second line"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to NOT contain 'A second line'"
+  echo "$$: ERROR: Expected http://localhost:8080/index.html to NOT contain 'A second line'"
   exit 1
 fi
 
 if curl http://localhost:8081/index.html --fail 2>/dev/null | grep "A second line"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to NOT contain 'A second line'"
+  echo "$$: ERROR: Expected http://localhost:8081/index.html to NOT contain 'A second line'"
   exit 1
 fi
 
-echo "<div>A second line</div>" >> src/index.html
+echo "$$: <div>A second line</div>" >> src/index.html
 
 n=0
 while ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "A second line"; do
   if [ $n -gt 30 ]; then
-    echo "ERROR: Expected http://localhost:8080/index.html to contain 'A second line'"
+    echo "$$: ERROR: Expected http://localhost:8080/index.html to contain 'A second line'"
     exit 1
   fi
   sleep 1 # wait before check again
@@ -107,17 +107,17 @@ while ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "A secon
 done
 
 if ! curl http://localhost:8081/index.html --fail 2>/dev/null | grep "A second line"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to contain 'A second line'"
+  echo "$$: ERROR: Expected http://localhost:8081/index.html to contain 'A second line'"
   exit 1
 fi
 
-echo "<div>A new file</div>" > src/new.html
+echo "$$: <div>A new file</div>" > src/new.html
 _sedi 's#"other.html"#"other.html", "new.html"#' src/BUILD.bazel
 
 n=0
 while ! curl http://localhost:8080/new.html --fail 2>/dev/null | grep "A new file"; do
   if [ $n -gt 30 ]; then
-    echo "ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"
+    echo "$$: ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"
     exit 1
   fi
   sleep 1 # wait before check again
@@ -125,8 +125,8 @@ while ! curl http://localhost:8080/new.html --fail 2>/dev/null | grep "A new fil
 done
 
 if ! curl http://localhost:8081/new.html --fail 2>/dev/null | grep "A new file"; then
-  echo "ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"
+  echo "$$: ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"
   exit 1
 fi
 
-echo "All tests passed"
+echo "$$: All tests passed"

--- a/e2e/js_run_devserver/multirun_test.sh
+++ b/e2e/js_run_devserver/multirun_test.sh
@@ -16,7 +16,7 @@ _sedi () {
 
 echo "$$: TEST - $0: $1"
 
-./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" >/dev/null 2>&1 &
+./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" 2>&1 &
 ibazel_pid="$!"
 
 function _exit {

--- a/e2e/js_run_devserver/multirun_test.sh
+++ b/e2e/js_run_devserver/multirun_test.sh
@@ -30,20 +30,27 @@ trap _exit EXIT
 
 echo "Waiting for $1 devserver to launch on 8080..."
 
+n=0
 while ! nc -z localhost 8080; do
-  echo "... waiting (8080)"
-  sleep 0.5 # wait before check again
+  if [ $n -gt 100 ]; then
+    echo "ERROR: Expected http://localhost:8080 to be available"
+    exit 1
+  fi
+  sleep 1 # wait before check again
+  ((n=n+1))
 done
 
 echo "Waiting for $1 devserver to launch on 8081..."
 
+n=0
 while ! nc -z localhost 8081; do
-  echo "... waiting (8081)"
-  sleep 0.5 # wait before check again
+  if [ $n -gt 100 ]; then
+    echo "ERROR: Expected http://localhost:8081 to be available"
+    exit 1
+  fi
+  sleep 1 # wait before check again
+  ((n=n+1))
 done
-
-echo "Waiting 10 seconds for devservers to settle to mitigate flakiness..."
-sleep 10
 
 echo "Devservers ready"
 
@@ -89,13 +96,15 @@ fi
 
 echo "<div>A second line</div>" >> src/index.html
 
-echo "Waiting 10 seconds for ibazel rebuild after change to src/index.html..."
-sleep 10
-
-if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "A second line"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to contain 'A second line'"
-  exit 1
-fi
+n=0
+while ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "A second line"; do
+  if [ $n -gt 30 ]; then
+    echo "ERROR: Expected http://localhost:8080/index.html to contain 'A second line'"
+    exit 1
+  fi
+  sleep 1 # wait before check again
+  ((n=n+1))
+done
 
 if ! curl http://localhost:8081/index.html --fail 2>/dev/null | grep "A second line"; then
   echo "ERROR: Expected http://localhost:8080/index.html to contain 'A second line'"
@@ -105,13 +114,15 @@ fi
 echo "<div>A new file</div>" > src/new.html
 _sedi 's#"other.html"#"other.html", "new.html"#' src/BUILD.bazel
 
-echo "Waiting 10 seconds for ibazel rebuild after change to src/BUILD.bazel..."
-sleep 10
-
-if ! curl http://localhost:8080/new.html --fail 2>/dev/null | grep "A new file"; then
-  echo "ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"
-  exit 1
-fi
+n=0
+while ! curl http://localhost:8080/new.html --fail 2>/dev/null | grep "A new file"; do
+  if [ $n -gt 30 ]; then
+    echo "ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"
+    exit 1
+  fi
+  sleep 1 # wait before check again
+  ((n=n+1))
+done
 
 if ! curl http://localhost:8081/new.html --fail 2>/dev/null | grep "A new file"; then
   echo "ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"

--- a/e2e/js_run_devserver/multirun_test.sh
+++ b/e2e/js_run_devserver/multirun_test.sh
@@ -22,6 +22,7 @@ ibazel_pid="$!"
 function _exit {
   echo "Cleanup..."
   kill "$ibazel_pid"
+  wait "$ibazel_pid"
   git checkout src/index.html src/BUILD.bazel
   rm -f src/new.html
 }

--- a/e2e/js_run_devserver/serve_test.sh
+++ b/e2e/js_run_devserver/serve_test.sh
@@ -16,7 +16,7 @@ _sedi () {
 
 echo "$$: TEST - $0: $1"
 
-./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" >/dev/null 2>&1 &
+./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" 2>&1 &
 ibazel_pid="$!"
 
 function _exit {

--- a/e2e/js_run_devserver/serve_test.sh
+++ b/e2e/js_run_devserver/serve_test.sh
@@ -22,6 +22,7 @@ ibazel_pid="$!"
 function _exit {
   echo "Cleanup..."
   kill "$ibazel_pid"
+  wait "$ibazel_pid"
   git checkout src/index.html src/BUILD.bazel
   rm -f src/new.html
 }

--- a/e2e/js_run_devserver/serve_test.sh
+++ b/e2e/js_run_devserver/serve_test.sh
@@ -14,13 +14,13 @@ _sedi () {
   sed "${sedi[@]}" "$@"
 }
 
-echo "TEST - $0: $1"
+echo "$$: TEST - $0: $1"
 
 ./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" >/dev/null 2>&1 &
 ibazel_pid="$!"
 
 function _exit {
-  echo "Cleanup..."
+  echo "$$: Cleanup..."
   kill "$ibazel_pid"
   wait "$ibazel_pid"
   git checkout src/index.html src/BUILD.bazel
@@ -28,64 +28,64 @@ function _exit {
 }
 trap _exit EXIT
 
-echo "Waiting for $1 devserver to launch on 8080..."
+echo "$$: Waiting for $1 devserver to launch on 8080..."
 
 n=0
 while ! nc -z localhost 8080; do
   if [ $n -gt 100 ]; then
-    echo "ERROR: Expected http://localhost:8080 to be available"
+    echo "$$: ERROR: Expected http://localhost:8080 to be available"
     exit 1
   fi
   sleep 1 # wait before check again
   ((n=n+1))
 done
 
-echo "Waiting 5 seconds for devservers to settle..."
+echo "$$: Waiting 5 seconds for devservers to settle..."
 sleep 5
 
-echo "Devserver ready"
+echo "$$: Devserver ready"
 
 if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "My first website"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to contain 'My first website'"
+  echo "$$: ERROR: Expected http://localhost:8080/index.html to contain 'My first website'"
   exit 1
 fi
 
 if ! curl http://localhost:8080/other.html --fail 2>/dev/null | grep "My other website"; then
-  echo "ERROR: Expected http://localhost:8080/other.html to contain 'My other website'"
+  echo "$$: ERROR: Expected http://localhost:8080/other.html to contain 'My other website'"
   exit 1
 fi
 
 if curl http://localhost:8080/new.html --fail 2>/dev/null; then
-  echo "ERROR: Expected http://localhost:8080/new.html to fail with 404"
+  echo "$$: ERROR: Expected http://localhost:8080/new.html to fail with 404"
   exit 1
 fi
 
 if curl http://localhost:8080/index.html --fail 2>/dev/null | grep "A second line"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to NOT contain 'A second line'"
+  echo "$$: ERROR: Expected http://localhost:8080/index.html to NOT contain 'A second line'"
   exit 1
 fi
 
-echo "<div>A second line</div>" >> src/index.html
+echo "$$: <div>A second line</div>" >> src/index.html
 
-echo "Waiting 5 seconds for ibazel rebuild after change to src/index.html..."
+echo "$$: Waiting 5 seconds for ibazel rebuild after change to src/index.html..."
 sleep 5
 
 if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "A second line"; then
-  echo "ERROR: Expected http://localhost:8080/index.html to contain 'A second line'"
+  echo "$$: ERROR: Expected http://localhost:8080/index.html to contain 'A second line'"
   exit 1
 fi
 
-echo "<div>A new file</div>" > src/new.html
+echo "$$: <div>A new file</div>" > src/new.html
 _sedi 's#"other.html"#"other.html", "new.html"#' src/BUILD.bazel
 
 n=0
 while ! curl http://localhost:8080/new.html --fail 2>/dev/null | grep "A new file"; do
   if [ $n -gt 60 ]; then
-    echo "ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"
+    echo "$$: ERROR: Expected http://localhost:8080/new.html to contain 'A new file'"
     exit 1
   fi
   sleep 1 # wait before check again
   ((n=n+1))
 done
 
-echo "All tests passed"
+echo "$$: All tests passed"

--- a/e2e/js_run_devserver/src/naughty.js
+++ b/e2e/js_run_devserver/src/naughty.js
@@ -21,4 +21,9 @@ http.createServer(function (req, res) {
         console.log(require.resolve('chalk'))
         return res.end()
     })
-}).listen(8080)
+})
+    .on('error', (e) => {
+        console.error(e)
+        process.exit(1)
+    })
+    .listen(8080)

--- a/e2e/js_run_devserver/src/simple.js
+++ b/e2e/js_run_devserver/src/simple.js
@@ -18,4 +18,9 @@ http.createServer(function (req, res) {
         console.log(require.resolve('chalk'))
         return res.end()
     })
-}).listen(8080)
+})
+    .on('error', (e) => {
+        console.error(e)
+        process.exit(1)
+    })
+    .listen(8080)


### PR DESCRIPTION
I'm not sure if or what could have change but these devserver tests are failing frequently on CI atm, often >50% of the time, and we run them 4x (bzlmod x bazel 5/6).