### PR TITLE
Revert "chore(deps): update dependency aspect_bazel_lib to v1.31.0"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
 
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/js_image_oci/WORKSPACE
+++ b/e2e/js_image_oci/WORKSPACE
@@ -79,11 +79,9 @@ oci_pull(
 ###
 http_archive(
     name = "container_structure_test",
-    sha256 = "9f22497625d822afd590ea06be4f20cb7a5f5096e5a4de5edff846d56578e030",
-    strip_prefix = "container-structure-test-100d7b1a8d78a79abbba996a94abe8da947742fb",
-    # Note, this commit not on main, it comes from
-    # https://github.com/GoogleContainerTools/container-structure-test/pull/348
-    urls = ["https://github.com/GoogleContainerTools/container-structure-test/archive/100d7b1a8d78a79abbba996a94abe8da947742fb.zip"],
+    sha256 = "42edb647b51710cb917b5850380cc18a6c925ad195986f16e3b716887267a2d7",
+    strip_prefix = "container-structure-test-104a53ede5f78fff72172639781ac52df9f5b18f",
+    urls = ["https://github.com/GoogleContainerTools/container-structure-test/archive/104a53ede5f78fff72172639781ac52df9f5b18f.zip"],
 )
 
 load("@container_structure_test//:repositories.bzl", "container_structure_test_register_toolchain")

--- a/e2e/js_run_devserver/MODULE.bazel
+++ b/e2e/js_run_devserver/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
 bazel_dep(name = "rules_go", version = "0.35.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 

--- a/e2e/npm_translate_lock/MODULE.bazel
+++ b/e2e/npm_translate_lock/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 
 

--- a/e2e/npm_translate_lock_empty/MODULE.bazel
+++ b/e2e/npm_translate_lock_empty/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 
 

--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 
 local_path_override(

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -21,7 +21,7 @@ def rules_js_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "800c49c2a3d3dfe8d17e4f6ec05db195b4eee7f2b098f20f67023d883b587306",
-        strip_prefix = "bazel-lib-1.31.0",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.31.0/bazel-lib-v1.31.0.tar.gz",
+        sha256 = "97fa63d95cc9af006c4c7b2123ddd2a91fb8d273012f17648e6423bae2c69470",
+        strip_prefix = "bazel-lib-1.30.2",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.30.2/bazel-lib-v1.30.2.tar.gz",
     )


### PR DESCRIPTION
Reverts aspect-build/rules_js#1039

That version of bazel-lib had a breaking change in yq and was yanked.