### PR TITLE
Add `@generated` to npm_translate_lock_state.bzl action cache

### DIFF
--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -400,6 +400,7 @@ def _action_cache_miss(priv, rctx, label_store):
 ################################################################################
 def _write_action_cache(priv, rctx, label_store):
     contents = [
+        "# @generated",
         "# Input hashes for repository rule npm_translate_lock(name = \"{}\", pnpm_lock = \"{}\").".format(helpers.to_apparent_repo_name(rctx.name), utils.consistent_label_str(label_store.label("pnpm_lock"))),
         "# This file should be checked into version control along with the pnpm-lock.yaml file.",
     ]


### PR DESCRIPTION
For users of Phabricator (or other code review tools that respect this pattern) add a `@generated` to the top of the generated file so it can be collapsed during a PR/Diff review

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below:
action cache lock will now add a `@generated` banner to the file to mark it as "generated" for relevant code review tools.

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
