### PR TITLE
chore: reduce bzlmod min aspect_bazel_lib version back to 1.31.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "platforms", version = "0.0.4")


### PR DESCRIPTION
This was unintentionally bumped to 1.32.0 in https://github.com/aspect-build/rules_js/pull/1074 since that PR was initially depending on the new expand_template but that dep was removed before landing.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)
