### PR TITLE
chore: add verify_node_modules_ignored to bzlmod release snippet

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -32,6 +32,7 @@ npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependenc
 npm.npm_translate_lock(
     name = "npm",
     pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
 )
 
 use_repo(npm, "npm")


### PR DESCRIPTION
This is a strongly recommended default to prevent foot guns for new users. For example, https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1685918918219999?thread_ts=1685915820.300699&cid=CEZUUKQ6P.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Next release should have this included in release snippet.
