### PR TITLE
feat: add src_directory attribute to NpmPackageStoreInfo provider

### DIFF
--- a/npm/private/npm_package_info.bzl
+++ b/npm/private/npm_package_info.bzl
@@ -5,7 +5,7 @@ NpmPackageInfo = provider(
     fields = {
         "package": "name of this npm package",
         "version": "version of this npm package",
-        "directory": "the output directory (a TreeArtifact) that contains the package sources",
+        "directory": "the directory (typically a TreeArtifact) that contains the package sources",
         "npm_package_store_deps": "A depset of NpmPackageStoreInfo providers from npm dependencies of the package and the packages's transitive deps to use as direct dependencies when linking with npm_link_package",
         "hardlink": "internal use only",
     },

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -174,6 +174,7 @@ def _impl(ctx):
 
     virtual_store_name = utils.virtual_store_name(package, version)
 
+    src_directory = None
     virtual_store_directory = None
     transitive_files = []
     direct_ref_deps = {}
@@ -305,6 +306,7 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
             package = package,
             version = version,
             ref_deps = direct_ref_deps,
+            src_directory = src_directory,
             virtual_store_directory = virtual_store_directory,
             files = files_depset,
             transitive_files = transitive_files_depset,

--- a/npm/private/npm_package_store_info.bzl
+++ b/npm/private/npm_package_store_info.bzl
@@ -11,6 +11,7 @@ NpmPackageStoreInfo = provider(
         "package": "name of this npm package",
         "version": "version of this npm package",
         "ref_deps": "dictionary of dependency npm_package_store ref targets",
+        "src_directory": "the directory (typically a TreeArtifact) that contains the package sources",
         "virtual_store_directory": "the TreeArtifact of this npm package's virtual store location",
         "files": "depset of files that are part of the npm package",
         "transitive_files": "depset of the files that are part of the npm package and its transitive deps",


### PR DESCRIPTION
This is useful when you want to know where a linked package was originally copied from before the virtual store.

---

### Type of change

- New feature or functionality (change which adds functionality)
