### PR TITLE
chore: test a large npm package tgz.bz2 such as pyoxide

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2065072158
-pnpm-lock.yaml=-1324340320
+pnpm-lock.yaml=1986234547
 examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch=-442666336
 package.json=965846805
 pnpm-workspace.yaml=1536402859
@@ -17,7 +17,7 @@ js/private/coverage/bundle/package.json=-1543718929
 js/private/image/package.json=-266007263
 js/private/test/image/package.json=1295393035
 js/private/worker/src/package.json=-715289696
-npm/private/test/package.json=1424344949
+npm/private/test/package.json=-904220378
 npm/private/test/vendored/lodash-4.17.21.tgz=-1206623349
 npm/private/test/npm_package/package.json=-1991705133
 npm/private/test/vendored/is-odd/package.json=1041695223

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -65,6 +65,7 @@ build_test(
         ":node_modules/test-npm_package",
         ":node_modules/plotly.js",
         ":node_modules/protoc-gen-grpc",
+        ":node_modules/pyodide",
         ":node_modules/regl",
         ":node_modules/puppeteer",  # has a bin entry in the transitive closure with two segments: @puppeteer/browsers in https://unpkg.com/@puppeteer/browsers@0.5.0/package.json
         ":node_modules/segfault-handler",  # segfault-handler has a node-gyp install step

--- a/npm/private/test/package.json
+++ b/npm/private/test/package.json
@@ -17,6 +17,7 @@
         "plotly.js": "2.12.1",
         "protoc-gen-grpc": "git+ssh://git@github.com:gregmagolan-codaio/protoc-gen-grpc-ts#be5580b06348d3eb9b4610a4a94065154a0df41f",
         "puppeteer": "19.11.0",
+        "pyodide": "https://github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2",
         "regl": "npm:@plotly/regl@2.1.2",
         "segfault-handler": "1.3.0",
         "semver-first-satisfied": "1.1.0",

--- a/npm/private/test/repositories_checked.bzl
+++ b/npm/private/test/repositories_checked.bzl
@@ -5354,6 +5354,23 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__base-64__1.0.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "base-64",
+        version = "1.0.0",
+        url = "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+        npm_translate_lock_repo = "npm",
+        dev = True,
+        generate_bzl_library_targets = True,
+        integrity = "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+        transitive_closure = {
+            "base-64": ["1.0.0"],
+        },
+    )
+
+    npm_import(
         name = "npm__base64-js__1.5.1",
         root_package = "",
         link_workspace = "",
@@ -24448,6 +24465,37 @@ def npm_repositories():
         generate_bzl_library_targets = True,
         transitive_closure = {
             "@foo/jsonify": ["@github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz"],
+        },
+    )
+
+    npm_import(
+        name = "npm__pyodide__at_github.com_pyodide_pyodide_releases_download_0.23.3_pyodide-0.23.3.tar.bz2__bufferutil_4.0.7",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {
+            "npm/private/test": ["pyodide"],
+        },
+        package = "pyodide",
+        version = "@github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2_bufferutil_4.0.7",
+        url = "https://github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2",
+        npm_translate_lock_repo = "npm",
+        dev = True,
+        generate_bzl_library_targets = True,
+        deps = {
+            "base-64": "1.0.0",
+            "node-fetch": "2.6.9",
+            "ws": "8.13.0_bufferutil_4.0.7",
+        },
+        transitive_closure = {
+            "pyodide": ["@github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2_bufferutil_4.0.7"],
+            "base-64": ["1.0.0"],
+            "node-fetch": ["2.6.9"],
+            "ws": ["8.13.0_bufferutil_4.0.7"],
+            "bufferutil": ["4.0.7"],
+            "node-gyp-build": ["4.6.0"],
+            "whatwg-url": ["5.0.0"],
+            "tr46": ["0.0.3"],
+            "webidl-conversions": ["3.0.1"],
         },
     )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       puppeteer:
         specifier: 19.11.0
         version: 19.11.0(bufferutil@4.0.7)(typescript@4.9.5)
+      pyodide:
+        specifier: https://github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2
+        version: '@github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2(bufferutil@4.0.7)'
       regl:
         specifier: npm:@plotly/regl@2.1.2
         version: /@plotly/regl@2.1.2
@@ -1740,6 +1743,10 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /base-64@1.0.0:
+    resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
+    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -6956,6 +6963,21 @@ packages:
     resolution: {tarball: https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz}
     name: '@foo/jsonify'
     version: 0.0.0
+    dev: true
+
+  '@github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2(bufferutil@4.0.7)':
+    resolution: {tarball: https://github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2}
+    id: '@github.com/pyodide/pyodide/releases/download/0.23.3/pyodide-0.23.3.tar.bz2'
+    name: pyodide
+    version: 0.23.3
+    dependencies:
+      base-64: 1.0.0
+      node-fetch: 2.6.9
+      ws: 8.13.0(bufferutil@4.0.7)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
     dev: true
 
   '@gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%2540blockprotocol/type-system-web?6526c0e':


### PR DESCRIPTION
Test that rules_js can handle a large npm package tgz bz2 archive.

Bazel Slack thread for more context: https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1688396780749809

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- New test cases added
