### PR TITLE
chore: bump rules_go dep to 0.40.1 since 0.35.0 is yanked from BCR

### DIFF
--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
 
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/js_run_devserver/MODULE.bazel
+++ b/e2e/js_run_devserver/MODULE.bazel
@@ -5,8 +5,8 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
-bazel_dep(name = "rules_go", version = "0.35.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
+bazel_dep(name = "rules_go", version = "0.40.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/js_run_devserver/pnpm-lock.yaml
+++ b/e2e/js_run_devserver/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 

--- a/e2e/npm_translate_lock/MODULE.bazel
+++ b/e2e/npm_translate_lock/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_empty/MODULE.bazel
+++ b/e2e/npm_translate_lock_empty/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_partial_clone/MODULE.bazel
+++ b/e2e/npm_translate_lock_partial_clone/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
-bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/webpack_devserver/MODULE.bazel
+++ b/e2e/webpack_devserver/MODULE.bazel
@@ -1,5 +1,5 @@
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "rules_go", version = "0.35.0")
+bazel_dep(name = "rules_go", version = "0.40.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/webpack_devserver_esm/MODULE.bazel
+++ b/e2e/webpack_devserver_esm/MODULE.bazel
@@ -1,5 +1,5 @@
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "rules_go", version = "0.35.0")
+bazel_dep(name = "rules_go", version = "0.40.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",


### PR DESCRIPTION
CI is broken at HEAD due to rules_go 0.35.0 dep since it is yanked; 0.38.1 exists but it depends on a yanked gazelle version so bumping all the way to the latest 0.40.1.