### PR TITLE
fix: allow for Bazel 7 flag rename

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
+bazel_dep(name = "bazel_features", version = "0.0.1")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -33,7 +33,7 @@ def js_binary(**kwargs):
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         **kwargs
@@ -46,7 +46,7 @@ def js_test(**kwargs):
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         **kwargs

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -3,6 +3,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//js:defs.bzl", "js_binary")
 
 exports_files(
@@ -25,8 +26,8 @@ config_setting(
 )
 
 config_setting(
-    name = "experimental_allow_unresolved_symlinks",
-    values = {"experimental_allow_unresolved_symlinks": "true"},
+    name = "allow_unresolved_symlinks",
+    values = {bazel_features.allow_unresolved_symlinks_flag: "true"},
     visibility = ["//visibility:public"],
 )
 

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -244,7 +244,7 @@ def js_run_devserver(
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         entry_point = "@aspect_rules_js//js/private:js_devserver_entrypoint",

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -29,7 +29,7 @@ coverage_fail_test(
     }),
     entry_point = "lib.js",
     unresolved_symlinks_enabled = select({
-        "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+        "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
         "//conditions:default": False,
     }),
 )
@@ -61,7 +61,7 @@ coverage_pass_test(
     }),
     entry_point = "lib.js",
     unresolved_symlinks_enabled = select({
-        "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+        "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
         "//conditions:default": False,
     }),
 )

--- a/js/private/test/create_launcher/custom_test.bzl
+++ b/js/private/test/create_launcher/custom_test.bzl
@@ -51,7 +51,7 @@ def custom_test(**kwargs):
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         **kwargs

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -25,3 +25,10 @@ def rules_js_dependencies():
         strip_prefix = "bazel-lib-1.32.1",
         url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
     )
+
+    http_archive(
+        name = "bazel_features",
+        sha256 = "5836c7e7b23cd20bcaef703838ee320580fe535d0337b981fb2c8367ec2a070b",
+        strip_prefix = "bazel_features-0.0.1",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v0.0.1/bazel_features-v0.0.1.tar.gz",
+    )

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -69,7 +69,7 @@ def npm_imported_package_store(
         dev = {dev},
         tags = ["manual"],
         use_declare_symlink = select({{
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }}),
     )
@@ -84,7 +84,7 @@ def npm_imported_package_store(
         deps = ref_deps,
         tags = ["manual"],
         use_declare_symlink = select({{
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }}),
     )
@@ -100,7 +100,7 @@ def npm_imported_package_store(
         visibility = visibility,
         tags = ["manual"],
         use_declare_symlink = select({{
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }}),
     )
@@ -125,7 +125,7 @@ def npm_imported_package_store(
             deps = ref_deps,
             tags = ["manual"],
             use_declare_symlink = select({{
-                "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }}),
         )
@@ -139,7 +139,7 @@ def npm_imported_package_store(
             deps = lc_deps,
             tags = ["manual"],
             use_declare_symlink = select({{
-                "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }}),
         )
@@ -208,7 +208,7 @@ def npm_link_imported_package_store(
         visibility = visibility,
         tags = ["manual"],
         use_declare_symlink = select({{
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }}),{maybe_bins}
     )

--- a/npm/private/npm_link_package.bzl
+++ b/npm/private/npm_link_package.bzl
@@ -79,7 +79,7 @@ def npm_link_package(
             visibility = visibility,
             tags = tags,
             use_declare_symlink = select({
-                "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }),
             **kwargs
@@ -97,7 +97,7 @@ def npm_link_package(
             tags = tags,
             visibility = visibility,
             use_declare_symlink = select({
-                "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }),
         )

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -39,7 +39,7 @@ _FP_STORE_TMPL = \
             visibility = ["//visibility:public"],
             tags = ["manual"],
             use_declare_symlink = select({{
-                "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }}),
         )"""
@@ -55,7 +55,7 @@ _FP_DIRECT_TMPL = \
                 visibility = ["//visibility:public"],
                 tags = ["manual"],
                 use_declare_symlink = select({{
-                    "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+                    "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
                     "//conditions:default": False,
                 }}),
             )

--- a/npm/repositories.bzl
+++ b/npm/repositories.bzl
@@ -1,11 +1,16 @@
 """Repository rules to fetch third-party npm packages"""
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("//npm/private:npm_import.bzl", _npm_import = "npm_import")
 load("//npm/private:npm_translate_lock.bzl", _list_patches = "list_patches", _npm_translate_lock = "npm_translate_lock")
 load("//npm/private:pnpm_repository.bzl", _LATEST_PNPM_VERSION = "LATEST_PNPM_VERSION", _pnpm_repository = "pnpm_repository")
 
 npm_import = _npm_import
-npm_translate_lock = _npm_translate_lock
+
+def npm_translate_lock(**kwargs):
+    bazel_features_deps()
+    _npm_translate_lock(**kwargs)
+
 pnpm_repository = _pnpm_repository
 LATEST_PNPM_VERSION = _LATEST_PNPM_VERSION
 list_patches = _list_patches


### PR DESCRIPTION
blocked on https://github.com/bazel-contrib/bazel_features/pull/15
fixes #1102

### Type of change

- Bug fix (change which fixes an issue)

### Test plan
- Manual testing; please provide instructions so we can reproduce:

`USE_BAZEL_VERSION=last_green bazel build --nobuild js/...  --override_repository=bazel_features=$HOME/Projects/bazel_features`
