### PR TITLE
feat: accept (version, integrity) for pnpm_version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,8 @@ use_repo(node, "nodejs_windows_amd64")
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 pnpm.pnpm(
     name = "pnpm",
+    pnpm_version = "7.25.0",
+    pnpm_version_integrity = "sha512-FGFQUON8kJ6ma39elJ8lyD8wPIfgp3opGJD9sX0TgIJk4zSr556qCgC8AN+3BFHe4yuRkEauf4JVLW2RKyyEcA==",
 )
 use_repo(pnpm, "pnpm")
 use_repo(pnpm, "pnpm__links")
@@ -174,7 +176,6 @@ npm.npm_translate_lock(
         "meaning-of-life@1.0.0": ["//examples/npm_deps:patches/meaning-of-life@1.0.0-after_pnpm.patch"],
     },
     pnpm_lock = "//:pnpm-lock.yaml",
-    pnpm_version = "7.25.0",
     public_hoist_packages = {
         # Instructs the linker to hoist the ms@2.1.3 npm package to `node_modules/ms` in the `examples/npm_deps` package.
         # Similar to adding `public-hoist-pattern[]=ms` in .npmrc but with control over which version to hoist and where

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -155,7 +155,9 @@ npm_translate_lock(
         "meaning-of-life@1.0.0": ["//examples/npm_deps:patches/meaning-of-life@1.0.0-after_pnpm.patch"],
     },
     pnpm_lock = "//:pnpm-lock.yaml",
-    pnpm_version = "8.6.0",
+    # Use a version that's not vendored into rules_js by providing a (version, integrity) tuple.
+    # curl --silent https://registry.npmjs.org/pnpm | jq '.versions["8.6.11"].dist.integrity'
+    pnpm_version = ("8.6.11", "sha512-jqknppuj45tDzJsLcLqkAxytBHZXIx9JTYkGNq0/7pSRggpio9wRxTDj4NA2ilOHPlJ5BVjB5Ij5dx65woMi5A=="),
     public_hoist_packages = {
         # Instructs the linker to hoist the ms@2.1.3 npm package to `node_modules/ms` in the `examples/npm_deps` package.
         # Similar to adding `public-hoist-pattern[]=ms` in .npmrc but with control over which version to hoist and where

--- a/e2e/js_run_devserver/MODULE.bazel
+++ b/e2e/js_run_devserver/MODULE.bazel
@@ -13,6 +13,9 @@ local_path_override(
     path = "../..",
 )
 
+pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
+use_repo(pnpm, "pnpm")
+
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "npm",
@@ -27,9 +30,6 @@ npm.npm_translate_lock(
     verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "npm")
-
-pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
-use_repo(pnpm, "pnpm")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -161,6 +161,10 @@ def _npm_translate_lock_attrs():
     attrs["name"] = attr.string()
     attrs["lifecycle_hooks_exclude"] = attr.string_list(default = [])
     attrs["lifecycle_hooks_no_sandbox"] = attr.bool(default = True)
+
+    # Note, pnpm_version can't be a tuple here, so we can't accept the integrity hash.
+    # This is okay since you can just call the pnpm module extension below first.
+    # TODO(2.0): drop pnpm_version from this module extension
     attrs["pnpm_version"] = attr.string(default = LATEST_PNPM_VERSION)
     attrs["run_lifecycle_hooks"] = attr.bool(default = True)
 
@@ -197,12 +201,20 @@ def _pnpm_impl(module_ctx):
         for attr in mod.tags.pnpm:
             pnpm_repository(
                 name = attr.name,
-                pnpm_version = attr.pnpm_version,
+                pnpm_version = (
+                    (attr.pnpm_version, attr.pnpm_version_integrity) if attr.pnpm_version_integrity else attr.pnpm_version
+                ),
             )
 
 pnpm = module_extension(
     implementation = _pnpm_impl,
     tag_classes = {
-        "pnpm": tag_class(attrs = {"name": attr.string(), "pnpm_version": attr.string(default = LATEST_PNPM_VERSION)}),
+        "pnpm": tag_class(
+            attrs = {
+                "name": attr.string(),
+                "pnpm_version": attr.string(default = LATEST_PNPM_VERSION),
+                "pnpm_version_integrity": attr.string(),
+            },
+        ),
     },
 )

--- a/npm/private/pnpm_repository.bzl
+++ b/npm/private/pnpm_repository.bzl
@@ -15,12 +15,23 @@ def pnpm_repository(name, pnpm_version = LATEST_PNPM_VERSION):
     Args:
         name: name of the resulting external repository
         pnpm_version: version of pnpm, see https://www.npmjs.com/package/pnpm?activeTab=versions
+
+            May also be a tuple of (version, integrity) where the integrity value may be fetched like:
+            `curl --silent https://registry.npmjs.org/pnpm | jq '.versions["8.6.11"].dist.integrity'`
     """
 
     if not native.existing_rule(name):
+        if type(pnpm_version) == "tuple":
+            integrity = pnpm_version[1]
+            pnpm_version = pnpm_version[0]
+        elif type(pnpm_version) == "string":
+            integrity = PNPM_VERSIONS[pnpm_version]
+        else:
+            fail("pnpm_version should be string or tuple, got " + type(pnpm_version))
+
         _npm_import(
             name = name,
-            integrity = PNPM_VERSIONS[pnpm_version],
+            integrity = integrity,
             package = "pnpm",
             root_package = "",
             version = pnpm_version,


### PR DESCRIPTION
This allows users to choose a version we haven't vendored integrity hashes for.

Fixes #1173

---

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**

Seems like we are missing docgen for `pnpm_repository.bzl` - I'll add in a followup.

### Test plan

- Covered by existing test cases

I changed the versions we use ourselves and tested that I can still run pnpm with/without bzlmod