### PR TITLE
fix(public api): expose two targets that downstream rulesets need

### DIFF
--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -1,10 +1,23 @@
 "Public API"
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
     glob(["*.bzl"]),
     visibility = ["//docs:__pkg__"],
+)
+
+config_setting(
+    name = "allow_unresolved_symlinks",
+    values = {bazel_features.flags.allow_unresolved_symlinks: "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "enable_runfiles",
+    values = {"enable_runfiles": "true"},
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(

--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -29,11 +29,11 @@ load(
 def js_binary(**kwargs):
     _js_binary(
         enable_runfiles = select({
-            "@aspect_rules_js//js/private:enable_runfiles": True,
+            "@aspect_rules_js//js:enable_runfiles": True,
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         **kwargs
@@ -42,11 +42,11 @@ def js_binary(**kwargs):
 def js_test(**kwargs):
     _js_test(
         enable_runfiles = select({
-            "@aspect_rules_js//js/private:enable_runfiles": True,
+            "@aspect_rules_js//js:enable_runfiles": True,
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         **kwargs

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -3,7 +3,6 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_features//:features.bzl", "bazel_features")
 load("//js:defs.bzl", "js_binary")
 
 exports_files(
@@ -19,16 +18,16 @@ exports_files([
     "npm_wrapper.sh",
 ])
 
-config_setting(
+# rules_jest and friends refer to these two private targets via the js_binary lib (naughty)
+# TODO(2.0): remove
+alias(
     name = "enable_runfiles",
-    values = {"enable_runfiles": "true"},
-    visibility = ["//visibility:public"],
+    actual = "//js:enable_runfiles",
 )
 
-config_setting(
-    name = "allow_unresolved_symlinks",
-    values = {bazel_features.flags.allow_unresolved_symlinks: "true"},
-    visibility = ["//visibility:public"],
+alias(
+    name = "experimental_allow_unresolved_symlinks",
+    actual = "//js:allow_unresolved_symlinks",
 )
 
 bzl_library(

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -240,11 +240,11 @@ def js_run_devserver(
     _js_run_devserver(
         name = name,
         enable_runfiles = select({
-            "@aspect_rules_js//js/private:enable_runfiles": True,
+            "@aspect_rules_js//js:enable_runfiles": True,
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         entry_point = "@aspect_rules_js//js/private:js_devserver_entrypoint",

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -24,12 +24,12 @@ coverage_fail_test(
     name = "fail",
     data = ["lib.js"],
     enable_runfiles = select({
-        "@aspect_rules_js//js/private:enable_runfiles": True,
+        "@aspect_rules_js//js:enable_runfiles": True,
         "//conditions:default": False,
     }),
     entry_point = "lib.js",
     unresolved_symlinks_enabled = select({
-        "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+        "@aspect_rules_js//js:allow_unresolved_symlinks": True,
         "//conditions:default": False,
     }),
 )
@@ -61,7 +61,7 @@ coverage_pass_test(
     }),
     entry_point = "lib.js",
     unresolved_symlinks_enabled = select({
-        "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+        "@aspect_rules_js//js:allow_unresolved_symlinks": True,
         "//conditions:default": False,
     }),
 )

--- a/js/private/test/create_launcher/custom_test.bzl
+++ b/js/private/test/create_launcher/custom_test.bzl
@@ -47,11 +47,11 @@ _custom_test = rule(
 def custom_test(**kwargs):
     _custom_test(
         enable_runfiles = select({
-            "//js/private:enable_runfiles": True,
+            "//js:enable_runfiles": True,
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         **kwargs

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -69,7 +69,7 @@ def npm_imported_package_store(
         dev = {dev},
         tags = ["manual"],
         use_declare_symlink = select({{
-            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }}),
     )
@@ -84,7 +84,7 @@ def npm_imported_package_store(
         deps = ref_deps,
         tags = ["manual"],
         use_declare_symlink = select({{
-            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }}),
     )
@@ -100,7 +100,7 @@ def npm_imported_package_store(
         visibility = visibility,
         tags = ["manual"],
         use_declare_symlink = select({{
-            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }}),
     )
@@ -125,7 +125,7 @@ def npm_imported_package_store(
             deps = ref_deps,
             tags = ["manual"],
             use_declare_symlink = select({{
-                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }}),
         )
@@ -139,7 +139,7 @@ def npm_imported_package_store(
             deps = lc_deps,
             tags = ["manual"],
             use_declare_symlink = select({{
-                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }}),
         )
@@ -208,7 +208,7 @@ def npm_link_imported_package_store(
         visibility = visibility,
         tags = ["manual"],
         use_declare_symlink = select({{
-            "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }}),{maybe_bins}
     )

--- a/npm/private/npm_link_package.bzl
+++ b/npm/private/npm_link_package.bzl
@@ -79,7 +79,7 @@ def npm_link_package(
             visibility = visibility,
             tags = tags,
             use_declare_symlink = select({
-                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }),
             **kwargs
@@ -97,7 +97,7 @@ def npm_link_package(
             tags = tags,
             visibility = visibility,
             use_declare_symlink = select({
-                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }),
         )

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -39,7 +39,7 @@ _FP_STORE_TMPL = \
             visibility = ["//visibility:public"],
             tags = ["manual"],
             use_declare_symlink = select({{
-                "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+                "@aspect_rules_js//js:allow_unresolved_symlinks": True,
                 "//conditions:default": False,
             }}),
         )"""
@@ -55,7 +55,7 @@ _FP_DIRECT_TMPL = \
                 visibility = ["//visibility:public"],
                 tags = ["manual"],
                 use_declare_symlink = select({{
-                    "@aspect_rules_js//js/private:allow_unresolved_symlinks": True,
+                    "@aspect_rules_js//js:allow_unresolved_symlinks": True,
                     "//conditions:default": False,
                 }}),
             )


### PR DESCRIPTION
rules_jest, rules_jasmine and others use the js_binary API which requires a select() that needs these config_settings.
So, they are broken by the (unreleased) #1178

See https://github.com/aspect-build/rules_jasmine/blob/049a30281525c0fd4819d2989515d47f6728f288/jasmine/defs.bzl#L71-L78

So, we should just make these public API so we know we cannot change them. Add two `alias` targets to make this change non-breaking.

---

### Type of change

- Bug fix (change which fixes an issue)


### Test plan

- Covered by existing test cases
