### PR TITLE
fix(npm_translate_lock): hash is stable when version changes

### DIFF
--- a/e2e/pnpm_workspace/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/pnpm_workspace/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,13 +1,14 @@
+# @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
-pnpm-lock.yaml=-768345290
+pnpm-lock.yaml=1498964476
 package.json=-716078204
 pnpm-workspace.yaml=-67685769
 app/a/package.json=574382986
-app/b/package.json=795450875
+app/b/package.json=1816699147
 app/c/package.json=1357235418
 lib/a/package.json=1162557353
 lib/b/package.json=1400635148
 lib/c/package.json=1015268365
-vendored/a/package.json=-174142441
-vendored/b/package.json=536664170
+vendored/a/package.json=1798571978
+vendored/b/package.json=-571308321

--- a/e2e/pnpm_workspace/app/b/package.json
+++ b/e2e/pnpm_workspace/app/b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@app/b",
+    "version": "0.0.5",
     "private": true,
     "dependencies": {
         "@aspect-test/h": "1.0.0",

--- a/e2e/pnpm_workspace/pnpm-lock.yaml
+++ b/e2e/pnpm_workspace/pnpm-lock.yaml
@@ -1,99 +1,115 @@
-lockfileVersion: 5.4
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 
   .:
-    specifiers:
-      '@aspect-test/a': 5.0.2
-      '@aspect-test/b': 5.0.2
-      '@aspect-test/c': 2.0.2
-      typescript: 4.9.5
     dependencies:
-      '@aspect-test/a': 5.0.2
-      typescript: 4.9.5
+      '@aspect-test/a':
+        specifier: 5.0.2
+        version: 5.0.2
+      typescript:
+        specifier: 4.9.5
+        version: 4.9.5
     optionalDependencies:
-      '@aspect-test/c': 2.0.2
+      '@aspect-test/c':
+        specifier: 2.0.2
+        version: 2.0.2
     devDependencies:
-      '@aspect-test/b': 5.0.2
+      '@aspect-test/b':
+        specifier: 5.0.2
+        version: 5.0.2
 
   app/a:
-    specifiers:
-      '@aspect-test/a': 5.0.2
-      '@aspect-test/g': 1.0.0
-      '@lib/a': workspace:*
     dependencies:
-      '@aspect-test/a': 5.0.2
-      '@aspect-test/g': 1.0.0
-      '@lib/a': link:../../lib/a
+      '@aspect-test/a':
+        specifier: 5.0.2
+        version: 5.0.2
+      '@aspect-test/g':
+        specifier: 1.0.0
+        version: 1.0.0
+      '@lib/a':
+        specifier: workspace:*
+        version: link:../../lib/a
 
   app/b:
-    specifiers:
-      '@aspect-test/h': 1.0.0
-      '@lib/b': workspace:*
-      '@lib/b_alias': workspace:@lib/b@*
     dependencies:
-      '@aspect-test/h': 1.0.0
-      '@lib/b': link:../../lib/b
-      '@lib/b_alias': link:../../lib/b
+      '@aspect-test/h':
+        specifier: 1.0.0
+        version: 1.0.0
+      '@lib/b':
+        specifier: workspace:*
+        version: link:../../lib/b
+      '@lib/b_alias':
+        specifier: workspace:@lib/b@*
+        version: link:../../lib/b
 
   app/c:
-    specifiers:
-      '@aspect-test/a': 5.0.2
-      '@aspect-test/g': 1.0.0
-      '@lib/c': file:../../lib/c
     dependencies:
-      '@aspect-test/a': 5.0.2
-      '@aspect-test/g': 1.0.0
-      '@lib/c': file:lib/c
+      '@aspect-test/a':
+        specifier: 5.0.2
+        version: 5.0.2
+      '@aspect-test/g':
+        specifier: 1.0.0
+        version: 1.0.0
+      '@lib/c':
+        specifier: file:../../lib/c
+        version: file:lib/c
 
   lib/a:
-    specifiers:
-      '@aspect-test/e': 1.0.0
-      '@lib/b': workspace:*
-      vendored-a: file:../../vendored/a
-      vendored-b: file:../../vendored/b
     dependencies:
-      '@aspect-test/e': 1.0.0
-      '@lib/b': link:../b
-      vendored-a: file:vendored/a
-      vendored-b: file:vendored/b_@lib+b@lib+b
+      '@aspect-test/e':
+        specifier: 1.0.0
+        version: 1.0.0
+      '@lib/b':
+        specifier: workspace:*
+        version: link:../b
+      vendored-a:
+        specifier: file:../../vendored/a
+        version: file:vendored/a
+      vendored-b:
+        specifier: file:../../vendored/b
+        version: file:vendored/b(@lib/b@lib+b)
 
   lib/b:
-    specifiers:
-      '@aspect-test/f': 1.0.0
     dependencies:
-      '@aspect-test/f': 1.0.0
+      '@aspect-test/f':
+        specifier: 1.0.0
+        version: 1.0.0
 
   lib/c:
-    specifiers:
-      '@aspect-test/f': 1.0.0
     dependencies:
-      '@aspect-test/f': 1.0.0
+      '@aspect-test/f':
+        specifier: 1.0.0
+        version: 1.0.0
 
 packages:
 
-  /@aspect-test/a/5.0.2:
+  /@aspect-test/a@5.0.2:
     resolution: {integrity: sha512-bURS+F0+tS2XPxUPbrqsTZxIre1U5ZglwzDqcOCrU7MbxuRrkO24hesgTMGJldCglwL/tiEGRlvdMndlPgRdNw==}
     hasBin: true
     dependencies:
       '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.2
-      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.2
+      '@aspect-test/d': 2.0.0(@aspect-test/c@2.0.2)
 
-  /@aspect-test/b/5.0.2:
+  /@aspect-test/b@5.0.2:
     resolution: {integrity: sha512-I8wnJV5J0h8ui1O3K6XPq1qGHKopTl/OnvkSfor7uJ9yRCm2Qv6Tf2LsTgR2xzkgiwhA4iBwdYFwecwinF244w==}
     hasBin: true
     dependencies:
       '@aspect-test/a': 5.0.2
       '@aspect-test/c': 2.0.2
-      '@aspect-test/d': 2.0.0_@aspect-test+c@2.0.2
+      '@aspect-test/d': 2.0.0(@aspect-test/c@2.0.2)
 
-  /@aspect-test/c/2.0.2:
+  /@aspect-test/c@2.0.2:
     resolution: {integrity: sha512-rMJmd3YBvY7y0jh+2m72TiAhe6dVKjMMNFFVOXFCbM233m7lsG4cq970H1C8rUsc3AcA5E/cEHlxSVffHlHD2Q==}
     hasBin: true
     requiresBuild: true
 
-  /@aspect-test/d/2.0.0_@aspect-test+c@2.0.2:
+  /@aspect-test/d@2.0.0(@aspect-test/c@2.0.2):
     resolution: {integrity: sha512-jndwr8pLUfn795uApTcXG/yZ5hV2At1aS/wo5BVLxqlVVgLoOETF/Dp4QOjMHE/SXkXFowz6Hao+WpmzVvAO0A==}
     hasBin: true
     peerDependencies:
@@ -101,27 +117,27 @@ packages:
     dependencies:
       '@aspect-test/c': 2.0.2
 
-  /@aspect-test/e/1.0.0:
+  /@aspect-test/e@1.0.0:
     resolution: {integrity: sha512-GyAxHYKN650db+xnimHnL2LPz65ilmQsVhCasWA7drDNQn/rfmPiEVMzjRiS7m46scXIERaBmiJMzYDf0bIUbA==}
     hasBin: true
     dev: false
 
-  /@aspect-test/f/1.0.0:
+  /@aspect-test/f@1.0.0:
     resolution: {integrity: sha512-VjuHu/TXdK0dfMeArZoOFaBY0Z/wAjWuCNtEWDTVJftbDcBtcH3IrhLrOy0NdJu+/CjE0qLCEb78eDGniKNUFA==}
     hasBin: true
     dev: false
 
-  /@aspect-test/g/1.0.0:
+  /@aspect-test/g@1.0.0:
     resolution: {integrity: sha512-nYxZCTIw+sHZfuKsqBBL7CW3KOliEoQh0D/ynWyUoB2Vi+DT2+nuvghXqL70/eNegjQ/8hUNTRBDBN2CPgoY8A==}
     hasBin: true
     dev: false
 
-  /@aspect-test/h/1.0.0:
+  /@aspect-test/h@1.0.0:
     resolution: {integrity: sha512-U1LStvh2QPmdQN7rlR0PTZZ1btTTcjiHxVmq5SvTxIRgIaJMCIsxcS5ghrd71H/JIwnJOmhI7BEQN3n6Hq9WSw==}
     hasBin: true
     dev: false
 
-  /typescript/4.9.5:
+  /typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
@@ -137,16 +153,14 @@ packages:
   file:vendored/a:
     resolution: {directory: vendored/a, type: directory}
     name: vendored-a
-    version: 1.0.0
     dependencies:
       '@aspect-test/f': 1.0.0
     dev: false
 
-  file:vendored/b_@lib+b@lib+b:
+  file:vendored/b(@lib/b@lib+b):
     resolution: {directory: vendored/b, type: directory}
     id: file:vendored/b
     name: vendored-b
-    version: 1.0.0
     peerDependencies:
       '@lib/b': workspace:*
     dependencies:


### PR DESCRIPTION
This is a requested feature from a large client who rely on `update_pnpm_lock=True`. They have frequent merge conflicts on the npm_translate_lock_[hash] file in our external_repository_action_cache because they frequently edit the version number in their packages. We should never need to perform a 'pnpm import' just because a first-party package.json version field changed.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

I changed the `version` in e2e/pnpm_workspace/app/b/package.json and ran the build, it no longer updates the `e2e/pnpm_workspace/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=` file.