### PR TITLE
fix: reduce distribution size by excluding e2e,examples

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -8,6 +8,8 @@ TAG=${GITHUB_REF_NAME}
 # The prefix is chosen to match what GitHub generates for source archives
 PREFIX="rules_js-${TAG:1}"
 ARCHIVE="rules_js-$TAG.tar.gz"
+# Don't include e2e or examples in the distribution artifact, to reduce size
+echo -n "e2e export-ignore\nexamples export-ignore" > .git/info/attributes
 git archive --format=tar --prefix="${PREFIX}/" "${TAG}" | gzip > "$ARCHIVE"
 SHA=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
 


### PR DESCRIPTION
This is possible now that we ship our distribution artifact and calculate its hash, we aren't bound to produce something similar to GitHub's archive file.

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases - we have some testing of our distribution artifact in BCR. Otherwise this is risky since we've always assumed we ship the whole repo.

```
# AFTER
alexeagle@MacBook-Pro rules_js % ls -lh rjs.tgz
-rw-r--r--@ 1 alexeagle  staff   1.5M Aug 21 17:45 rjs.tgz

# BEFORE
alexeagle@MacBook-Pro rules_js % rm .git/info/attributes 
alexeagle@MacBook-Pro rules_js % git archive --format=tar HEAD | gzip > rjs.tgz
alexeagle@MacBook-Pro rules_js % ls -lh rjs.tgz                                
-rw-r--r--@ 1 alexeagle  staff   2.1M Aug 21 17:48 rjs.tgz
```