### PR TITLE
chore: add Aspect Workflows CI (on GCP + Buildkite)

### DIFF
--- a/.aspect/workflows/README.md
+++ b/.aspect/workflows/README.md
@@ -1,0 +1,67 @@
+# Aspect Workflows demonstration deployment
+
+This deployment of [Aspect Workflows](https://www.aspect.build/workflows) is configured to run on GCP + Buildkite.
+
+You can see this Aspect Workflows demonstration deployment live at
+https://buildkite.com/aspect/rules-js.
+
+The three components of the configuration are,
+
+1. Aspect Workflows terraform module
+1. Aspect Workflows configuration yaml
+1. Buildkite pipeline configuration (in the Buildkite UI)
+
+## Aspect Workflows terraform module
+
+This is found under the [.aspect/workflows/terraform](./terraform) directory.
+
+## Aspect Workflows configuration yaml
+
+This is the [config.yaml](./config.yaml) file in this directory.
+
+## Buildkite pipeline configuration (in the Buildkite UI)
+
+There are two pipelines configured on Buildkite.
+
+1. Main build & test pipeline: https://buildkite.com/aspect/rules-js
+2. Scheduled warming pipeline: https://buildkite.com/aspect/rules-js-warming
+
+### Main build & test pipeline configuration
+
+The main build & test pipeline found at https://buildkite.com/aspect/rules-js is configured
+with the following yaml steps:
+
+```
+steps:
+  - key: aspect-workflows-setup
+    label: ":aspect: Setup Aspect Workflows"
+    commands:
+      - "rosetta steps | buildkite-agent pipeline upload"
+    agents:
+      queue: aspect-default
+```
+
+### Scheduled warming pipeline configuration
+
+The scheduled warming pipeline found at https://buildkite.com/aspect/rules-js-warming is
+configured with the following yaml steps:
+
+```
+steps:
+  - label: ":fire: Create warming archives"
+    commands:
+      - 'echo "--- :aspect: Configure environment"'
+      - 'configure_workflows_env'
+      - 'echo "--- :stethoscope: Agent health checks"'
+      - 'agent_health_check'
+      - 'echo "--- :bazel: Create warming archive for ."'
+      - 'rosetta run warming'
+      - 'warming_archive'
+    agents:
+      queue: aspect-warming
+```
+
+The warming pipeline is not configured to trigger on commits or PRs. Instead, a scheduled is
+configured for this pipeline with the cron interval `0 1 * * * America/Vancouver` so that it
+runs periodically to create up-to-date warming archives that caches repository rules so that the
+"default" build & test runners don't have to re-fetch them on their first build.

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -99,5 +99,3 @@ workspaces:
 tasks:
     buildifier:
     test:
-        flags:
-            - --remote_default_exec_properties=cache-silo-key="74aed5f7"

--- a/.aspect/workflows/terraform/.terraform.lock.hcl
+++ b/.aspect/workflows/terraform/.terraform.lock.hcl
@@ -1,0 +1,100 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.79.0"
+  constraints = ">= 4.63.1"
+  hashes = [
+    "h1:WwOcCD1bX08jjcUTsfWA+8tJlv7vVV2hGlXPz2ZAZME=",
+    "zh:03e18743bc56ca2d482f9bbd9398d3b62874bfd59336b49569a67e288f95d75a",
+    "zh:0755d2658f097c6fd3445880510a79240b263762cdcafefbe9dcc6a66919d0a0",
+    "zh:2e21fadd825e3da54963731660c1a7243594c80d41670a67ec9755259c9dc154",
+    "zh:410b698731f4c90ab41767267de74d10cd82781aafce3926129d77d08b7ee2ae",
+    "zh:7f90dbe01ff21fdb802c9d089d35e9c520325f70325917110dd5e04443d2d3d5",
+    "zh:9406e4a8488e6b1b7e9e0294ef848705a6125942f544fa57d9fa9d0c02c92564",
+    "zh:952436a52730be26b0b4503327b3961ff14e44cbc0037712ffad7c8f5bceff62",
+    "zh:a7edfc96ba7d8bb46c985018184d3de40c5e21bf3e7c09288a5c34d778e9f78a",
+    "zh:b7604f0706550dd94607011d9a6fee3e64122a48eb7ee43fed6a9b5c82dad61b",
+    "zh:ce6b1e85349f4ab9179bfa5bbde72a9a811182941475fb1815b55dae60dcd122",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fa5c1ca75dd458cbd3cd2312420a0dead2a8de9792faa2502e27be91c2faa741",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.10.1"
+  constraints = ">= 2.9.0"
+  hashes = [
+    "h1:OFRsk+lMoRoNoJjJzRngH8hAq++Sb6LwrEKIjd7PeWA=",
+    "zh:0717312baed39fb0a00576297241b69b419880cad8771bf72dec97ebdc96b200",
+    "zh:0e0e287b4e8429a0700143c8159764502eba0b33b1d094bf0d4ef4d93c7802cb",
+    "zh:4f74605377dab4065aaad35a2c5fa6186558c6e2e57b9058bdc8a62cf91857b9",
+    "zh:505f4af4dedb7a4f8f45b4201900b8e16216bdc2a01cc84fe13cdbf937570e7e",
+    "zh:83f37fe692513c0ce307d487248765383e00f9a84ed95f993ce0d3efdf4204d3",
+    "zh:840e5a84e1b5744f0211f611a2c6890da58016a40aafd5971f12285164d4e29b",
+    "zh:8c03d8dee292fa0367b0511cf3e95b706e034f78025f5dff0388116e1798bf47",
+    "zh:937800d1860f6b3adbb20e65f11e5fcd940b21ce8bdb48198630426244691325",
+    "zh:c1853aa5cbbdd1d46f4b169e84c3482103f0e8575a9bb044dbde908e27348c5d",
+    "zh:c9b0f640590da20931c30818b0b0587aa517d5606cb6e8052e4e4bf38f97b54d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fe8bd4dd09dc7ca218959eda1ced9115408c2cdc9b4a76964bfa455f3bcadfd3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.23.0"
+  constraints = ">= 2.0.1"
+  hashes = [
+    "h1:cMs2scNCSgQhGamomGT5Ag4i8ms/mql1AR7NJc2hmbA=",
+    "zh:10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89",
+    "zh:1102ba5ca1a595f880e67102bbf999cc8b60203272a078a5b1e896d173f3f34b",
+    "zh:1347cf958ed3f3f80b3c7b3e23ddda3d6c6573a81847a8ee92b7df231c238bf6",
+    "zh:2cb18e9f5156bc1b1ee6bc580a709f7c2737d142722948f4a6c3c8efe757fa8d",
+    "zh:5506aa6f28dcca2a265ccf8e34478b5ec2cb43b867fe6d93b0158f01590fdadd",
+    "zh:6217a20686b631b1dcb448ee4bc795747ebc61b56fbe97a1ad51f375ebb0d996",
+    "zh:8accf916c00579c22806cb771e8909b349ffb7eb29d9c5468d0a3f3166c7a84a",
+    "zh:9379b0b54a0fa030b19c7b9356708ec8489e194c3b5e978df2d31368563308e5",
+    "zh:aa99c580890691036c2931841e88e7ee80d59ae52289c8c2c28ea0ac23e31520",
+    "zh:c57376d169875990ac68664d227fb69cd0037b92d0eba6921d757c3fd1879080",
+    "zh:e6068e3f94f6943b5586557b73f109debe19d1a75ca9273a681d22d1ce066579",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version = "0.9.1"
+  hashes = [
+    "h1:UHcDnIYFZ00uoou0TwPGMwOrE8gTkoRephIvdwDAK70=",
+    "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
+    "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",
+    "zh:5f79d0730fdec8cb148b277de3f00485eff3e9cf1ff47fb715b1c969e5bbd9d4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8c8094689a2bed4bb597d24a418bbbf846e15507f08be447d0a5acea67c2265a",
+    "zh:a6d9206e95d5681229429b406bc7a9ba4b2d9b67470bda7df88fa161508ace57",
+    "zh:aa299ec058f23ebe68976c7581017de50da6204883950de228ed9246f309e7f1",
+    "zh:b129f00f45fba1991db0aa954a6ba48d90f64a738629119bfb8e9a844b66e80b",
+    "zh:ef6cecf5f50cda971c1b215847938ced4cb4a30a18095509c068643b14030b00",
+    "zh:f1f46a4f6c65886d2dd27b66d92632232adc64f92145bf8403fe64d5ffa5caea",
+    "zh:f79d6155cda7d559c60d74883a24879a01c4d5f6fd7e8d1e3250f3cd215fb904",
+    "zh:fd59fa73074805c3575f08cd627eef7acda14ab6dac2c135a66e7a38d262201c",
+  ]
+}

--- a/.aspect/workflows/terraform/README.md
+++ b/.aspect/workflows/terraform/README.md
@@ -1,0 +1,7 @@
+# Aspect Workflows demonstration deployment terraform
+
+The terraform configuration found here is for a clean GCP project with only Aspect Workflows deployed.
+
+-   `main.tf` : terraform backend configuration
+-   `vpc.tf` : VPC configuration
+-   `workflows.tf` : Aspect Workflows terraform module & VM image configuration

--- a/.aspect/workflows/terraform/main.tf
+++ b/.aspect/workflows/terraform/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~> 1.4.0"
+
+  backend "gcs" {
+    bucket = "aw-deployment-terraform-state-rules-js"
+    prefix = "terraform/state"
+  }
+}
+
+provider "google" {
+  project = "aw-deployment-rules-js"
+  region  = "us-west2"
+}

--- a/.aspect/workflows/terraform/vpc.tf
+++ b/.aspect/workflows/terraform/vpc.tf
@@ -1,0 +1,40 @@
+resource "google_compute_network" "workflows_network" {
+  name                    = "workflows-network"
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+
+resource "google_compute_subnetwork" "workflows_subnet" {
+  name          = "workflows-subnet"
+  ip_cidr_range = "10.2.0.0/16"
+  network       = google_compute_network.workflows_network.id
+}
+
+resource "google_compute_firewall" "ssh" {
+  name        = "allow-ssh"
+  description = "Enable SSHing into VM instances"
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+  direction     = "INGRESS"
+  network       = google_compute_network.workflows_network.id
+  priority      = 1000
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_router" "router" {
+  name    = "router"
+  network = google_compute_network.workflows_network.id
+
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "router-nat"
+  router                             = google_compute_router.router.name
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}

--- a/.aspect/workflows/terraform/workflows.tf
+++ b/.aspect/workflows/terraform/workflows.tf
@@ -1,0 +1,76 @@
+data "google_compute_image" "runner_image" {
+  # Aspect's GCP aspect-workflows-images project provides public Aspect Workflows GCP images for
+  # getting started during the trial period. We recommend that all Workflows users build their own
+  # GCP images and keep up-to date with patches. See
+  # https://docs.aspect.build/v/workflows/install/packer for more info and/or
+  # https://github.com/aspect-build/workflows-images for example packer scripts and BUILD targets
+  # for building GCP images for Workflows.
+  project = "aspect-workflows-images"
+  name    = "aspect-workflows-ubuntu-2304-docker-gcc-make-1-1-0"
+}
+
+module "aspect_workflows" {
+  # Aspect Workflows terraform module
+  source = "gcs::https://storage.googleapis.com/storage/v1/aspect-artifacts/5.7.0-rc10/workflows-gcp/terraform-gcp-aspect-workflows.zip"
+
+  # Network properties
+  network    = google_compute_network.workflows_network.id
+  subnetwork = google_compute_subnetwork.workflows_subnet.id
+
+  # Number of nodes in the kubernetes cluster where the remote cache &
+  # observability services run.
+  cluster_standard_node_count = 3
+
+  # Remote cache configuration
+  remote = {
+    cache_size_gb          = 384
+    cache_shards           = 3
+    replicate_cache        = false
+    load_balancer_replicas = 1
+  }
+
+  # CI properties
+  hosts = ["bk"]
+
+  # Warming set definitions
+  warming_sets = {
+    default  = {}
+  }
+
+  # Resource types for use by runner groups
+  resource_types = {
+    default = {
+      # Aspect Workflows requires machine types that have local SSD drives. See
+      # https://cloud.google.com/compute/docs/machine-resource#machine_type_comparison for full list
+      # of machine types availble on GCP.
+      machine_type    = "n1-standard-4"
+      image_id        = data.google_compute_image.runner_image.id
+      use_preemptible = true
+    }
+  }
+
+  # Buildkite runner group definitions
+  bk_runner_groups = {
+    # The default runner group is use for the main build & test workflows.
+    default = {
+      agent_idle_timeout_min = 5
+      max_runners            = 10
+      min_runners            = 0
+      queue                  = "aspect-default"
+      resource_type          = "default"
+      warming                = true
+    }
+    # The warming runner group is used for the periodic warming job that creates
+    # warming archives for use by other runner groups.
+    warming = {
+      agent_idle_timeout_min = 1
+      max_runners            = 1
+      min_runners            = 0
+      queue                  = "aspect-warming"
+      resource_type          = "default"
+    }
+  }
+
+  # This varies by each customer. This one is dedicated to rules_js.
+  pagerduty_integration_key = "6c16035a05834405d0920f74b4b326c5"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bazel-*
+**/.terraform/*
 node_modules/
 .pnpm-*
 .DS_Store


### PR DESCRIPTION
Enable new deployment of Aspect Workflows on GCP + Buildkite and land the terraform here so it serves as a live example of the full GCP + Buildkite Workflows configuration.