### PR TITLE
Revert "Revert "js_run_devserver symlinks scoped node_modules to baze…

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,10 +2,10 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2065072158
-pnpm-lock.yaml=754060271
+pnpm-lock.yaml=1169067734
 examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch=-442666336
 package.json=965846805
-pnpm-workspace.yaml=1536402859
+pnpm-workspace.yaml=116986059
 examples/js_binary/package.json=-41174383
 examples/macro/package.json=857146175
 examples/npm_deps/package.json=283109008
@@ -16,6 +16,7 @@ examples/webpack_cli/package.json=1911342006
 js/private/coverage/bundle/package.json=-1543718929
 js/private/image/package.json=-1260474848
 js/private/test/image/package.json=1295393035
+js/private/test/js_run_devserver/package.json=-260856079
 js/private/worker/src/package.json=1608383745
 npm/private/test/package.json=1424344949
 npm/private/test/vendored/lodash-4.17.21.tgz=-1206623349

--- a/.bazelignore
+++ b/.bazelignore
@@ -9,6 +9,7 @@ examples/webpack_cli/node_modules/
 js/private/coverage/bundle/node_modules
 js/private/image/node_modules
 js/private/test/image/node_modules
+js/private/test/js_run_devserver/node_modules
 js/private/worker/src/node_modules
 node_modules/
 npm/private/test/node_modules/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,6 +89,7 @@ npm_translate_lock(
         "//js/private/coverage/bundle:package.json",
         "//js/private/image:package.json",
         "//js/private/test/image:package.json",
+        "//js/private/test/js_run_devserver:package.json",
         "//js/private/worker/src:package.json",
         "//npm/private/test:package.json",
         "//npm/private/test:vendored/lodash-4.17.21.tgz",

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -18,6 +18,7 @@ stardoc_with_diff_test(
 stardoc_with_diff_test(
     name = "js_run_devserver",
     bzl_library_target = "//js/private:js_run_devserver",
+    symbol_names = ["js_run_devserver"],
 )
 
 stardoc_with_diff_test(

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -95,10 +95,16 @@ def _impl(ctx):
         ),
     ]
 
-_js_run_devserver = rule(
+js_run_devserver_lib = struct(
     attrs = _attrs,
     implementation = _impl,
     toolchains = js_binary_lib.toolchains,
+)
+
+_js_run_devserver = rule(
+    attrs = js_run_devserver_lib.attrs,
+    implementation = js_run_devserver_lib.implementation,
+    toolchains = js_run_devserver_lib.toolchains,
     executable = True,
 )
 
@@ -237,7 +243,10 @@ def js_run_devserver(
     if kwargs.get("entry_point", None):
         fail("`entry_point` is set implicitly by `js_run_devserver` and cannot be overridden.")
 
-    _js_run_devserver(
+    # Allow the js_run_devserver rule to execute to be overridden for tests
+    rule_to_execute = kwargs.pop("rule_to_execute", _js_run_devserver)
+
+    rule_to_execute(
         name = name,
         enable_runfiles = select({
             "@aspect_rules_js//js:enable_runfiles": True,

--- a/js/private/test/js_run_devserver/BUILD
+++ b/js/private/test/js_run_devserver/BUILD
@@ -21,6 +21,11 @@ js_run_devserver_test(
         ":node_modules/@types/node",
         ":node_modules/jasmine",
     ],
+    tags = [
+        # devserver is meant to be `bazel run` locally.
+        # See https://github.com/aspect-build/rules_js/pull/1233
+        "no-remote-exec",
+    ],
     tool = ":jasmine",
 )
 

--- a/js/private/test/js_run_devserver/BUILD
+++ b/js/private/test/js_run_devserver/BUILD
@@ -1,0 +1,29 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//js/private/test/js_run_devserver:jasmine/package_json.bzl", jasmine_bin = "bin")
+load(":js_run_devserver_test.bzl", "js_run_devserver_test")
+
+npm_link_all_packages(name = "node_modules")
+
+# Checks node_modules symlinks that they refer to exec root (instead of runfiles)
+# in order to make sure bundlers see exactly one node_modules tree. Checks:
+#     - https://github.com/aspect-build/rules_js/pull/1043
+#     - https://github.com/aspect-build/rules_js/issues/1204
+js_run_devserver_test(
+    name = "node_modules_symlink_to_execroot_test",
+    args = ["node_modules_symlink_to_execroot.test.mjs"],
+    chdir = "js/private/test/js_run_devserver",
+    data = [
+        "node_modules_symlink_to_execroot.test.mjs",
+
+        # Some packages to link back to the exec root for the tests for
+        # https://github.com/aspect-build/rules_js/issues/1204 (and need jasmine
+        # anyway for the runner)
+        ":node_modules/@types/node",
+        ":node_modules/jasmine",
+    ],
+    tool = ":jasmine",
+)
+
+jasmine_bin.jasmine_binary(
+    name = "jasmine",
+)

--- a/js/private/test/js_run_devserver/js_run_devserver_test.bzl
+++ b/js/private/test/js_run_devserver/js_run_devserver_test.bzl
@@ -1,0 +1,41 @@
+"Implementation of the js_run_devserver_test rule (the 'test' version of js_run_devserver)"
+
+load("//js/private:js_run_devserver.bzl", "js_run_devserver", "js_run_devserver_lib")
+
+# 'test' version of the _js_run_devserver` rule
+_js_run_devserver_test = rule(
+    attrs = js_run_devserver_lib.attrs,
+    implementation = js_run_devserver_lib.implementation,
+    toolchains = js_run_devserver_lib.toolchains,
+    test = True,
+)
+
+def js_run_devserver_test(
+        name,
+        tags = [],
+        **kwargs):
+    """
+    'Test' version of the `js_run_devserver` macro.
+
+    Provides the test rule to the macro, along with the 'no-sandbox' tag in
+    order to properly simulate the js_run_devserver environment of 'bazel run'.
+
+    Args:
+        name: A unique name for this target.
+
+        tags: Additional Bazel tags to supply to the rule.
+
+        **kwargs: All other args for `js_run_devserver`.
+
+            See https://docs.aspect.build/rules/aspect_rules_js/docs/js_run_devserver
+    """
+    js_run_devserver(
+        name,
+        # Override the rule to execute
+        rule_to_execute = _js_run_devserver_test,
+        # 'no-sandbox' needed to simulate 'bazel run' command - normally tests
+        # are sandboxed, but sandboxing doesn't exhibit the issue in
+        # https://github.com/aspect-build/rules_js/issues/1204
+        tags = tags + ["no-sandbox"],
+        **kwargs
+    )

--- a/js/private/test/js_run_devserver/node_modules_symlink_to_execroot.test.mjs
+++ b/js/private/test/js_run_devserver/node_modules_symlink_to_execroot.test.mjs
@@ -1,0 +1,30 @@
+import fs from 'fs'
+
+describe('node_modules symlinks >', () => {
+    const execRootDir = process.env.JS_BINARY__EXECROOT
+    const runfilesDir = process.env.JS_BINARY__RUNFILES
+
+    beforeAll(() => {
+        // first ensure that the environment variables are strings with some value
+        if (typeof execRootDir !== 'string' || execRootDir.length === 0) {
+            throw new Error(`process.env.JS_BINARY__EXECROOT is empty - can't run tests which rely on it`)
+        }
+        if (typeof runfilesDir !== 'string' || runfilesDir.length === 0) {
+            throw new Error(`process.env.JS_BINARY__RUNFILES is empty - can't run tests which rely on it`)
+        }
+    })
+
+    it(`symlinks non-scoped node_modules (e.g. 'jasmine') to the exec root instead of runfiles to ensure bundlers see a single node_modules tree (https://github.com/aspect-build/rules_js/pull/1043)`, () => {
+        const jasmineSymlink = fs.readlinkSync('./node_modules/jasmine')
+
+        expect(jasmineSymlink).toContain(execRootDir)
+        expect(jasmineSymlink).not.toContain(runfilesDir)
+    })
+
+    it(`symlinks scoped node_modules (e.g. '@types/node') to the exec root instead of runfiles to ensure bundlers see a single node_modules tree (https://github.com/aspect-build/rules_js/issues/1204)`, () => {
+        const typesNodeSymlink = fs.readlinkSync('./node_modules/@types/node')
+
+        expect(typesNodeSymlink).toContain(execRootDir)
+        expect(typesNodeSymlink).not.toContain(runfilesDir)
+    })
+})

--- a/js/private/test/js_run_devserver/package.json
+++ b/js/private/test/js_run_devserver/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "js_run_devserver_test",
+    "version": "0.0.0",
+    "private": true,
+    "dependencies": {
+        "@types/node": "16.18.11",
+        "jasmine": "5.1.0"
+    }
+}

--- a/npm/private/test/repositories_checked.bzl
+++ b/npm/private/test/repositories_checked.bzl
@@ -1715,6 +1715,40 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__at_isaacs_cliui__8.0.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "@isaacs/cliui",
+        version = "8.0.2",
+        url = "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+        deps = {
+            "string-width": "5.1.2",
+            "string-width-cjs": "/string-width/4.2.3",
+            "strip-ansi": "7.1.0",
+            "strip-ansi-cjs": "/strip-ansi/6.0.1",
+            "wrap-ansi": "8.1.0",
+            "wrap-ansi-cjs": "/wrap-ansi/7.0.0",
+        },
+        transitive_closure = {
+            "@isaacs/cliui": ["8.0.2"],
+            "string-width": ["4.2.3", "5.1.2"],
+            "strip-ansi": ["6.0.1", "7.1.0"],
+            "wrap-ansi": ["7.0.0", "8.1.0"],
+            "ansi-styles": ["6.2.1", "4.3.0"],
+            "color-convert": ["2.0.1"],
+            "color-name": ["1.1.4"],
+            "ansi-regex": ["6.0.1", "5.0.1"],
+            "emoji-regex": ["9.2.2", "8.0.0"],
+            "is-fullwidth-code-point": ["3.0.0"],
+            "eastasianwidth": ["0.2.0"],
+        },
+    )
+
+    npm_import(
         name = "npm__at_istanbuljs_schema__0.1.3",
         root_package = "",
         link_workspace = "",
@@ -1994,7 +2028,7 @@ def npm_repositories():
             "detect-libc": "2.0.1",
             "https-proxy-agent": "5.0.1",
             "make-dir": "3.1.0",
-            "node-fetch": "2.6.9",
+            "node-fetch": "2.6.12",
             "nopt": "5.0.0",
             "npmlog": "5.0.1",
             "rimraf": "3.0.2",
@@ -2006,7 +2040,7 @@ def npm_repositories():
             "detect-libc": ["2.0.1"],
             "https-proxy-agent": ["5.0.1"],
             "make-dir": ["3.1.0"],
-            "node-fetch": ["2.6.9"],
+            "node-fetch": ["2.6.12"],
             "nopt": ["5.0.0"],
             "npmlog": ["5.0.1"],
             "rimraf": ["3.0.2"],
@@ -2208,6 +2242,24 @@ def npm_repositories():
             "balanced-match": ["1.0.2"],
             "concat-map": ["0.0.1"],
         },
+    )
+
+    npm_import(
+        name = "npm__at_pkgjs_parseargs__0.11.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "@pkgjs/parseargs",
+        version = "0.11.0",
+        url = "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+        transitive_closure = {
+            "@pkgjs/parseargs": ["0.11.0"],
+        },
+        lifecycle_hooks = ["preinstall", "install", "postinstall"],
+        lifecycle_hooks_execution_requirements = ["no-sandbox"],
     )
 
     npm_import(
@@ -4909,6 +4961,22 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__ansi-regex__6.0.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "ansi-regex",
+        version = "6.0.1",
+        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+        transitive_closure = {
+            "ansi-regex": ["6.0.1"],
+        },
+    )
+
+    npm_import(
         name = "npm__ansi-styles__3.2.1",
         root_package = "",
         link_workspace = "",
@@ -4948,6 +5016,22 @@ def npm_repositories():
             "ansi-styles": ["4.3.0"],
             "color-convert": ["2.0.1"],
             "color-name": ["1.1.4"],
+        },
+    )
+
+    npm_import(
+        name = "npm__ansi-styles__6.2.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "ansi-styles",
+        version = "6.2.1",
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+        transitive_closure = {
+            "ansi-styles": ["6.2.1"],
         },
     )
 
@@ -5645,7 +5729,6 @@ def npm_repositories():
         version = "2.0.1",
         url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
         npm_translate_lock_repo = "npm",
-        dev = True,
         generate_bzl_library_targets = True,
         integrity = "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
         deps = {
@@ -8073,23 +8156,23 @@ def npm_repositories():
     )
 
     npm_import(
-        name = "npm__debug__2.6.3",
+        name = "npm__debug__2.6.9",
         root_package = "",
         link_workspace = "",
         link_packages = {},
         package = "debug",
-        version = "2.6.3",
-        url = "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+        version = "2.6.9",
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
         npm_translate_lock_repo = "npm",
         dev = True,
         generate_bzl_library_targets = True,
-        integrity = "sha512-9k275CFA9z/NW+7nojeyxyOCFYsc+Dfiq4Sg8CBP5WjzmJT5K1utEepahY7wuWhlsumHgmAqnwAnxPCgOOyAHA==",
+        integrity = "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
         deps = {
-            "ms": "0.7.2",
+            "ms": "2.0.0",
         },
         transitive_closure = {
-            "debug": ["2.6.3"],
-            "ms": ["0.7.2"],
+            "debug": ["2.6.9"],
+            "ms": ["2.0.0"],
         },
     )
 
@@ -8629,6 +8712,22 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__eastasianwidth__0.2.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "eastasianwidth",
+        version = "0.2.0",
+        url = "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+        transitive_closure = {
+            "eastasianwidth": ["0.2.0"],
+        },
+    )
+
+    npm_import(
         name = "npm__ecc-jsbn__0.1.2",
         root_package = "",
         link_workspace = "",
@@ -8718,6 +8817,22 @@ def npm_repositories():
         integrity = "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
         transitive_closure = {
             "emoji-regex": ["8.0.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__emoji-regex__9.2.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "emoji-regex",
+        version = "9.2.2",
+        url = "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+        transitive_closure = {
+            "emoji-regex": ["9.2.2"],
         },
     )
 
@@ -10302,6 +10417,33 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__foreground-child__3.1.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "foreground-child",
+        version = "3.1.1",
+        url = "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+        deps = {
+            "cross-spawn": "7.0.3",
+            "signal-exit": "4.1.0",
+        },
+        transitive_closure = {
+            "foreground-child": ["3.1.1"],
+            "cross-spawn": ["7.0.3"],
+            "signal-exit": ["4.1.0"],
+            "path-key": ["3.1.1"],
+            "shebang-command": ["2.0.0"],
+            "which": ["2.0.2"],
+            "isexe": ["2.0.0"],
+            "shebang-regex": ["3.0.0"],
+        },
+    )
+
+    npm_import(
         name = "npm__forever-agent__0.6.1",
         root_package = "",
         link_workspace = "",
@@ -11014,6 +11156,56 @@ def npm_repositories():
         integrity = "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
         transitive_closure = {
             "glob-to-regexp": ["0.4.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__glob__10.3.3",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "glob",
+        version = "10.3.3",
+        url = "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+        deps = {
+            "foreground-child": "3.1.1",
+            "jackspeak": "2.2.3",
+            "minimatch": "9.0.3",
+            "minipass": "7.0.3",
+            "path-scurry": "1.10.1",
+        },
+        transitive_closure = {
+            "glob": ["10.3.3"],
+            "foreground-child": ["3.1.1"],
+            "jackspeak": ["2.2.3"],
+            "minimatch": ["9.0.3"],
+            "minipass": ["7.0.3"],
+            "path-scurry": ["1.10.1"],
+            "lru-cache": ["10.0.1"],
+            "brace-expansion": ["2.0.1"],
+            "balanced-match": ["1.0.2"],
+            "@isaacs/cliui": ["8.0.2"],
+            "@pkgjs/parseargs": ["0.11.0"],
+            "string-width": ["4.2.3", "5.1.2"],
+            "strip-ansi": ["6.0.1", "7.1.0"],
+            "wrap-ansi": ["7.0.0", "8.1.0"],
+            "ansi-styles": ["6.2.1", "4.3.0"],
+            "color-convert": ["2.0.1"],
+            "color-name": ["1.1.4"],
+            "ansi-regex": ["6.0.1", "5.0.1"],
+            "emoji-regex": ["9.2.2", "8.0.0"],
+            "is-fullwidth-code-point": ["3.0.0"],
+            "eastasianwidth": ["0.2.0"],
+            "cross-spawn": ["7.0.3"],
+            "signal-exit": ["4.1.0"],
+            "path-key": ["3.1.1"],
+            "shebang-command": ["2.0.0"],
+            "which": ["2.0.2"],
+            "isexe": ["2.0.0"],
+            "shebang-regex": ["3.0.0"],
         },
     )
 
@@ -12126,6 +12318,8 @@ def npm_repositories():
             "iconv-lite": ["0.6.3"],
             "safer-buffer": ["2.1.2"],
         },
+        lifecycle_hooks = ["preinstall", "install", "postinstall"],
+        lifecycle_hooks_execution_requirements = ["no-sandbox"],
     )
 
     npm_import(
@@ -13218,6 +13412,105 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__jackspeak__2.2.3",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "jackspeak",
+        version = "2.2.3",
+        url = "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.3.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-pF0kfjmg8DJLxDrizHoCZGUFz4P4czQ3HyfW4BU0ffebYkzAVlBywp5zaxW/TM+r0sGbmrQdi8EQQVTJFxnGsQ==",
+        deps = {
+            "@pkgjs/parseargs": "0.11.0",
+            "@isaacs/cliui": "8.0.2",
+        },
+        transitive_closure = {
+            "jackspeak": ["2.2.3"],
+            "@isaacs/cliui": ["8.0.2"],
+            "@pkgjs/parseargs": ["0.11.0"],
+            "string-width": ["4.2.3", "5.1.2"],
+            "strip-ansi": ["6.0.1", "7.1.0"],
+            "wrap-ansi": ["7.0.0", "8.1.0"],
+            "ansi-styles": ["6.2.1", "4.3.0"],
+            "color-convert": ["2.0.1"],
+            "color-name": ["1.1.4"],
+            "ansi-regex": ["6.0.1", "5.0.1"],
+            "emoji-regex": ["9.2.2", "8.0.0"],
+            "is-fullwidth-code-point": ["3.0.0"],
+            "eastasianwidth": ["0.2.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__jasmine-core__5.1.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "jasmine-core",
+        version = "5.1.0",
+        url = "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.1.0.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-bFMMwpKuTZXCuGd51yClFobw5SOtad1kmdWnYO8dNwYV8i01Xj0C2+nyQpSKl1EKxiPfyd1ZgBl/rsusL3aS6w==",
+        transitive_closure = {
+            "jasmine-core": ["5.1.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__jasmine__5.1.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {
+            "js/private/test/js_run_devserver": ["jasmine"],
+        },
+        package = "jasmine",
+        version = "5.1.0",
+        url = "https://registry.npmjs.org/jasmine/-/jasmine-5.1.0.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-prmJlC1dbLhti4nE4XAPDWmfJesYO15sjGXVp7Cs7Ym5I9Xtwa/hUHxxJXjnpfLO72+ySttA0Ztf8g/RiVnUKw==",
+        deps = {
+            "glob": "10.3.3",
+            "jasmine-core": "5.1.0",
+        },
+        transitive_closure = {
+            "jasmine": ["5.1.0"],
+            "glob": ["10.3.3"],
+            "jasmine-core": ["5.1.0"],
+            "foreground-child": ["3.1.1"],
+            "jackspeak": ["2.2.3"],
+            "minimatch": ["9.0.3"],
+            "minipass": ["7.0.3"],
+            "path-scurry": ["1.10.1"],
+            "lru-cache": ["10.0.1"],
+            "brace-expansion": ["2.0.1"],
+            "balanced-match": ["1.0.2"],
+            "@isaacs/cliui": ["8.0.2"],
+            "@pkgjs/parseargs": ["0.11.0"],
+            "string-width": ["4.2.3", "5.1.2"],
+            "strip-ansi": ["6.0.1", "7.1.0"],
+            "wrap-ansi": ["7.0.0", "8.1.0"],
+            "ansi-styles": ["6.2.1", "4.3.0"],
+            "color-convert": ["2.0.1"],
+            "color-name": ["1.1.4"],
+            "ansi-regex": ["6.0.1", "5.0.1"],
+            "emoji-regex": ["9.2.2", "8.0.0"],
+            "is-fullwidth-code-point": ["3.0.0"],
+            "eastasianwidth": ["0.2.0"],
+            "cross-spawn": ["7.0.3"],
+            "signal-exit": ["4.1.0"],
+            "path-key": ["3.1.1"],
+            "shebang-command": ["2.0.0"],
+            "which": ["2.0.2"],
+            "isexe": ["2.0.0"],
+            "shebang-regex": ["3.0.0"],
+        },
+    )
+
+    npm_import(
         name = "npm__javascript-natural-sort__0.7.1",
         root_package = "",
         link_workspace = "",
@@ -13290,6 +13583,8 @@ def npm_repositories():
         transitive_closure = {
             "jose": ["4.12.0"],
         },
+        lifecycle_hooks = ["preinstall", "install", "postinstall"],
+        lifecycle_hooks_execution_requirements = ["no-sandbox"],
     )
 
     npm_import(
@@ -13928,6 +14223,22 @@ def npm_repositories():
         integrity = "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
         transitive_closure = {
             "lowercase-keys": ["2.0.0"],
+        },
+    )
+
+    npm_import(
+        name = "npm__lru-cache__10.0.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "lru-cache",
+        version = "10.0.1",
+        url = "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+        transitive_closure = {
+            "lru-cache": ["10.0.1"],
         },
     )
 
@@ -14703,6 +15014,27 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__minimatch__9.0.3",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "minimatch",
+        version = "9.0.3",
+        url = "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+        deps = {
+            "brace-expansion": "2.0.1",
+        },
+        transitive_closure = {
+            "minimatch": ["9.0.3"],
+            "brace-expansion": ["2.0.1"],
+            "balanced-match": ["1.0.2"],
+        },
+    )
+
+    npm_import(
         name = "npm__minimist__0.0.10",
         root_package = "",
         link_workspace = "",
@@ -14910,6 +15242,22 @@ def npm_repositories():
         integrity = "sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==",
         transitive_closure = {
             "minipass": ["4.2.4"],
+        },
+    )
+
+    npm_import(
+        name = "npm__minipass__7.0.3",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "minipass",
+        version = "7.0.3",
+        url = "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+        transitive_closure = {
+            "minipass": ["7.0.3"],
         },
     )
 
@@ -15627,23 +15975,6 @@ def npm_repositories():
     )
 
     npm_import(
-        name = "npm__ms__0.7.2",
-        root_package = "",
-        link_workspace = "",
-        link_packages = {},
-        package = "ms",
-        version = "0.7.2",
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-        npm_translate_lock_repo = "npm",
-        dev = True,
-        generate_bzl_library_targets = True,
-        integrity = "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
-        transitive_closure = {
-            "ms": ["0.7.2"],
-        },
-    )
-
-    npm_import(
         name = "npm__ms__0.7.3",
         root_package = "",
         link_workspace = "",
@@ -15896,6 +16227,29 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__node-fetch__2.6.12",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "node-fetch",
+        version = "2.6.12",
+        url = "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+        npm_translate_lock_repo = "npm",
+        dev = True,
+        generate_bzl_library_targets = True,
+        integrity = "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+        deps = {
+            "whatwg-url": "5.0.0",
+        },
+        transitive_closure = {
+            "node-fetch": ["2.6.12"],
+            "whatwg-url": ["5.0.0"],
+            "tr46": ["0.0.3"],
+            "webidl-conversions": ["3.0.1"],
+        },
+    )
+
+    npm_import(
         name = "npm__node-fetch__2.6.7",
         root_package = "",
         link_workspace = "",
@@ -15912,29 +16266,6 @@ def npm_repositories():
         },
         transitive_closure = {
             "node-fetch": ["2.6.7"],
-            "whatwg-url": ["5.0.0"],
-            "tr46": ["0.0.3"],
-            "webidl-conversions": ["3.0.1"],
-        },
-    )
-
-    npm_import(
-        name = "npm__node-fetch__2.6.9",
-        root_package = "",
-        link_workspace = "",
-        link_packages = {},
-        package = "node-fetch",
-        version = "2.6.9",
-        url = "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-        npm_translate_lock_repo = "npm",
-        dev = True,
-        generate_bzl_library_targets = True,
-        integrity = "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-        deps = {
-            "whatwg-url": "5.0.0",
-        },
-        transitive_closure = {
-            "node-fetch": ["2.6.9"],
             "whatwg-url": ["5.0.0"],
             "tr46": ["0.0.3"],
             "webidl-conversions": ["3.0.1"],
@@ -16745,6 +17076,8 @@ def npm_repositories():
         transitive_closure = {
             "object-hash": ["2.2.0"],
         },
+        lifecycle_hooks = ["preinstall", "install", "postinstall"],
+        lifecycle_hooks_execution_requirements = ["no-sandbox"],
     )
 
     npm_import(
@@ -16779,6 +17112,8 @@ def npm_repositories():
         transitive_closure = {
             "oidc-token-hash": ["5.0.1"],
         },
+        lifecycle_hooks = ["preinstall", "install", "postinstall"],
+        lifecycle_hooks_execution_requirements = ["no-sandbox"],
     )
 
     npm_import(
@@ -17390,6 +17725,28 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__path-scurry__1.10.1",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "path-scurry",
+        version = "1.10.1",
+        url = "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+        deps = {
+            "lru-cache": "10.0.1",
+            "minipass": "7.0.3",
+        },
+        transitive_closure = {
+            "path-scurry": ["1.10.1"],
+            "lru-cache": ["10.0.1"],
+            "minipass": ["7.0.3"],
+        },
+    )
+
+    npm_import(
         name = "npm__path-type__4.0.0",
         root_package = "",
         link_workspace = "",
@@ -17794,8 +18151,8 @@ def npm_repositories():
             "lodash.merge": ["4.6.2"],
             "needle": ["2.9.1"],
             "stream-parser": ["0.3.1"],
-            "debug": ["3.2.7", "2.6.3"],
-            "ms": ["2.1.3", "0.7.2"],
+            "debug": ["3.2.7", "2.6.9"],
+            "ms": ["2.1.3", "2.0.0"],
             "iconv-lite": ["0.4.24"],
             "sax": ["1.2.4"],
             "safer-buffer": ["2.1.2"],
@@ -18175,8 +18532,8 @@ def npm_repositories():
             "lodash.merge": ["4.6.2"],
             "needle": ["2.9.1"],
             "stream-parser": ["0.3.1"],
-            "debug": ["3.2.7", "2.6.3"],
-            "ms": ["2.1.3", "0.7.2"],
+            "debug": ["3.2.7", "2.6.9"],
+            "ms": ["2.1.3", "2.0.0"],
             "iconv-lite": ["0.4.24"],
             "sax": ["1.2.4"],
             "safer-buffer": ["2.1.2"],
@@ -20574,6 +20931,22 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__signal-exit__4.1.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "signal-exit",
+        version = "4.1.0",
+        url = "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+        transitive_closure = {
+            "signal-exit": ["4.1.0"],
+        },
+    )
+
+    npm_import(
         name = "npm__signum__1.0.0",
         root_package = "",
         link_workspace = "",
@@ -20911,12 +21284,12 @@ def npm_repositories():
         generate_bzl_library_targets = True,
         integrity = "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
         deps = {
-            "debug": "2.6.3",
+            "debug": "2.6.9",
         },
         transitive_closure = {
             "stream-parser": ["0.3.1"],
-            "debug": ["2.6.3"],
-            "ms": ["0.7.2"],
+            "debug": ["2.6.9"],
+            "ms": ["2.0.0"],
         },
     )
 
@@ -21056,6 +21429,31 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__string-width__5.1.2",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "string-width",
+        version = "5.1.2",
+        url = "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+        deps = {
+            "eastasianwidth": "0.2.0",
+            "emoji-regex": "9.2.2",
+            "strip-ansi": "7.1.0",
+        },
+        transitive_closure = {
+            "string-width": ["5.1.2"],
+            "eastasianwidth": ["0.2.0"],
+            "emoji-regex": ["9.2.2"],
+            "strip-ansi": ["7.1.0"],
+            "ansi-regex": ["6.0.1"],
+        },
+    )
+
+    npm_import(
         name = "npm__string_decoder__0.10.31",
         root_package = "",
         link_workspace = "",
@@ -21152,6 +21550,26 @@ def npm_repositories():
         transitive_closure = {
             "strip-ansi": ["6.0.1"],
             "ansi-regex": ["5.0.1"],
+        },
+    )
+
+    npm_import(
+        name = "npm__strip-ansi__7.1.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "strip-ansi",
+        version = "7.1.0",
+        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+        deps = {
+            "ansi-regex": "6.0.1",
+        },
+        transitive_closure = {
+            "strip-ansi": ["7.1.0"],
+            "ansi-regex": ["6.0.1"],
         },
     )
 
@@ -24061,6 +24479,33 @@ def npm_repositories():
     )
 
     npm_import(
+        name = "npm__wrap-ansi__8.1.0",
+        root_package = "",
+        link_workspace = "",
+        link_packages = {},
+        package = "wrap-ansi",
+        version = "8.1.0",
+        url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+        npm_translate_lock_repo = "npm",
+        generate_bzl_library_targets = True,
+        integrity = "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+        deps = {
+            "ansi-styles": "6.2.1",
+            "string-width": "5.1.2",
+            "strip-ansi": "7.1.0",
+        },
+        transitive_closure = {
+            "wrap-ansi": ["8.1.0"],
+            "ansi-styles": ["6.2.1"],
+            "string-width": ["5.1.2"],
+            "strip-ansi": ["7.1.0"],
+            "ansi-regex": ["6.0.1"],
+            "eastasianwidth": ["0.2.0"],
+            "emoji-regex": ["9.2.2"],
+        },
+    )
+
+    npm_import(
         name = "npm__wrappy__1.0.2",
         root_package = "",
         link_workspace = "",
@@ -24627,7 +25072,7 @@ def npm_repositories():
             "detect-libc": ["2.0.1"],
             "https-proxy-agent": ["5.0.1"],
             "make-dir": ["3.1.0"],
-            "node-fetch": ["2.6.9"],
+            "node-fetch": ["2.6.12"],
             "nopt": ["5.0.0"],
             "npmlog": ["5.0.1"],
             "rimraf": ["3.0.2"],
@@ -24702,7 +25147,7 @@ def npm_repositories():
             "@types/node": "registry.npmjs.org/@types/node@18.11.18",
             "@types/request": "registry.npmjs.org/@types/request@2.48.8",
             "@types/underscore": "registry.npmjs.org/@types/underscore@1.11.4",
-            "@types/ws": "registry.npmjs.org/@types/ws@8.5.4",
+            "@types/ws": "registry.npmjs.org/@types/ws@8.5.5",
             "byline": "5.0.0",
             "isomorphic-ws": "5.0.0_ws_8.13.0",
             "js-yaml": "4.1.0",
@@ -24723,7 +25168,7 @@ def npm_repositories():
             "@types/node": ["registry.npmjs.org/@types/node@18.11.18"],
             "@types/request": ["registry.npmjs.org/@types/request@2.48.8"],
             "@types/underscore": ["registry.npmjs.org/@types/underscore@1.11.4"],
-            "@types/ws": ["registry.npmjs.org/@types/ws@8.5.4"],
+            "@types/ws": ["registry.npmjs.org/@types/ws@8.5.5"],
             "byline": ["5.0.0"],
             "isomorphic-ws": ["5.0.0_ws_8.13.0"],
             "js-yaml": ["4.1.0"],
@@ -25154,12 +25599,12 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "": ["@types/node"],
+            "js/private/test/js_run_devserver": ["@types/node"],
         },
         package = "@types/node",
         version = "registry.npmjs.org/@types/node@16.18.11",
         url = "https://registry.yarnpkg.com/@types/node/-/node-16.18.11.tgz",
         npm_translate_lock_repo = "npm",
-        dev = True,
         generate_bzl_library_targets = True,
         integrity = "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
         transitive_closure = {
@@ -25332,22 +25777,22 @@ def npm_repositories():
     )
 
     npm_import(
-        name = "npm__at_types_ws__registry.npmjs.org_at_types_ws_8.5.4",
+        name = "npm__at_types_ws__registry.npmjs.org_at_types_ws_8.5.5",
         root_package = "",
         link_workspace = "",
         link_packages = {},
         package = "@types/ws",
-        version = "registry.npmjs.org/@types/ws@8.5.4",
-        url = "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz",
+        version = "registry.npmjs.org/@types/ws@8.5.5",
+        url = "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.5.tgz",
         npm_translate_lock_repo = "npm",
         dev = True,
         generate_bzl_library_targets = True,
-        integrity = "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+        integrity = "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
         deps = {
             "@types/node": "registry.npmjs.org/@types/node@18.11.18",
         },
         transitive_closure = {
-            "@types/ws": ["registry.npmjs.org/@types/ws@8.5.4"],
+            "@types/ws": ["registry.npmjs.org/@types/ws@8.5.5"],
             "@types/node": ["registry.npmjs.org/@types/node@18.11.18"],
         },
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -9,7 +9,7 @@ overrides:
   semver-max: file:./npm/private/test/vendored/semver-max
   is-odd: file:./npm/private/test/vendored/is-odd
 
-packageExtensionsChecksum: 60d08949101fc004c7564f98037b7764
+packageExtensionsChecksum: 2748cb8b0b0bbbc1945ad41d572bc9af
 
 patchedDependencies:
   meaning-of-life@1.0.0:
@@ -206,6 +206,15 @@ importers:
       tar-stream:
         specifier: 3.0.0
         version: 3.0.0
+
+  js/private/test/js_run_devserver:
+    dependencies:
+      '@types/node':
+        specifier: 16.18.11
+        version: registry.npmjs.org/@types/node@16.18.11
+      jasmine:
+        specifier: 5.1.0
+        version: 5.1.0
 
   js/private/worker/src:
     dependencies:
@@ -835,6 +844,18 @@ packages:
       '@gregmagolan/test-a': 0.0.1
     dev: true
 
+  /@isaacs/cliui@8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: /strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: false
+
   /@istanbuljs/schema@0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
@@ -911,7 +932,7 @@ packages:
       detect-libc: 2.0.1
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
-      node-fetch: 2.6.9
+      node-fetch: 2.6.12
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
@@ -961,6 +982,13 @@ packages:
       mkdirp: 1.0.4
       rimraf: 3.0.2
     dev: true
+
+  /@pkgjs/parseargs@0.11.0:
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@plotly/d3-sankey-circular@0.33.1:
     resolution: {integrity: sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==}
@@ -1623,6 +1651,11 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  /ansi-regex@6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
+    dev: false
+
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -1635,6 +1668,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+    dev: false
 
   /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -1817,7 +1855,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -2450,15 +2487,15 @@ packages:
       - supports-color
     dev: true
 
-  /debug@2.6.3:
-    resolution: {integrity: sha512-9k275CFA9z/NW+7nojeyxyOCFYsc+Dfiq4Sg8CBP5WjzmJT5K1utEepahY7wuWhlsumHgmAqnwAnxPCgOOyAHA==}
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
     dependencies:
-      ms: 0.7.2
+      ms: 2.0.0
     dev: true
 
   /debug@3.1.0:
@@ -2622,6 +2659,10 @@ packages:
     resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
     dev: true
 
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: false
+
   /ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
     dependencies:
@@ -2644,6 +2685,10 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  /emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: false
 
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -3186,6 +3231,14 @@ packages:
       signal-exit: 3.0.7
     dev: false
 
+  /foreground-child@3.1.1:
+    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.1.0
+    dev: false
+
   /forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
@@ -3395,6 +3448,18 @@ packages:
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  /glob@10.3.3:
+    resolution: {integrity: sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 2.2.3
+      minimatch: 9.0.3
+      minipass: 7.0.3
+      path-scurry: 1.10.1
+    dev: false
 
   /glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
@@ -3702,6 +3767,7 @@ packages:
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
     dev: true
@@ -3998,6 +4064,27 @@ packages:
       istanbul-lib-report: 3.0.0
     dev: false
 
+  /jackspeak@2.2.3:
+    resolution: {integrity: sha512-pF0kfjmg8DJLxDrizHoCZGUFz4P4czQ3HyfW4BU0ffebYkzAVlBywp5zaxW/TM+r0sGbmrQdi8EQQVTJFxnGsQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+    dev: false
+
+  /jasmine-core@5.1.0:
+    resolution: {integrity: sha512-bFMMwpKuTZXCuGd51yClFobw5SOtad1kmdWnYO8dNwYV8i01Xj0C2+nyQpSKl1EKxiPfyd1ZgBl/rsusL3aS6w==}
+    dev: false
+
+  /jasmine@5.1.0:
+    resolution: {integrity: sha512-prmJlC1dbLhti4nE4XAPDWmfJesYO15sjGXVp7Cs7Ym5I9Xtwa/hUHxxJXjnpfLO72+ySttA0Ztf8g/RiVnUKw==}
+    hasBin: true
+    dependencies:
+      glob: 10.3.3
+      jasmine-core: 5.1.0
+    dev: false
+
   /javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
     dev: false
@@ -4016,6 +4103,7 @@ packages:
 
   /jose@4.12.0:
     resolution: {integrity: sha512-wW1u3cK81b+SFcHjGC8zw87yuyUweEFe0UJirrXEw1NasW00eF7sZjeG3SLBGz001ozxQ46Y9sofDvhBmWFtXQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -4197,6 +4285,11 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
     dev: true
+
+  /lru-cache@10.0.1:
+    resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
+    engines: {node: 14 || >=16.14}
+    dev: false
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -4400,6 +4493,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimist@0.0.10:
     resolution: {integrity: sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==}
     dev: true
@@ -4463,6 +4563,11 @@ packages:
   /minipass@4.2.4:
     resolution: {integrity: sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==}
     engines: {node: '>=8'}
+
+  /minipass@7.0.3:
+    resolution: {integrity: sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dev: false
 
   /minizlib@1.3.3:
     resolution: {integrity: sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==}
@@ -4648,10 +4753,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /ms@0.7.2:
-    resolution: {integrity: sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==}
-    dev: true
-
   /ms@0.7.3:
     resolution: {integrity: sha512-lrKNzMWqQZgwJahtrtrM+9NgOoDUveDrVmm5aGXrf3BdtL0mq7X6IVzoZaw+TfNti29eHd1/8GI+h45K5cQ6/w==}
     dev: true
@@ -4723,8 +4824,8 @@ packages:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
     dev: true
 
-  /node-fetch@2.6.7:
-    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+  /node-fetch@2.6.12:
+    resolution: {integrity: sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -4735,8 +4836,8 @@ packages:
       whatwg-url: 5.0.0
     dev: true
 
-  /node-fetch@2.6.9:
-    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+  /node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -4925,6 +5026,7 @@ packages:
   /object-hash@2.2.0:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -4936,6 +5038,7 @@ packages:
   /oidc-token-hash@5.0.1:
     resolution: {integrity: sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==}
     engines: {node: ^10.13.0 || >=12.0.0}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -5113,6 +5216,14 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  /path-scurry@1.10.1:
+    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      lru-cache: 10.0.1
+      minipass: 7.0.3
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -5873,6 +5984,11 @@ packages:
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /signum@1.0.0:
     resolution: {integrity: sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==}
     dev: true
@@ -5975,7 +6091,7 @@ packages:
   /stream-parser@0.3.1:
     resolution: {integrity: sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==}
     dependencies:
-      debug: 2.6.3
+      debug: 2.6.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6021,6 +6137,15 @@ packages:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+    dev: false
+
   /string_decoder@0.10.31:
     resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
     dev: true
@@ -6049,6 +6174,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
+
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.0.1
+    dev: false
 
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -6830,6 +6962,15 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+    dev: false
+
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -6977,7 +7118,6 @@ packages:
   file:npm/private/test/vendored/is-odd:
     resolution: {directory: npm/private/test/vendored/is-odd, type: directory}
     name: is-odd
-    version: 3.0.1
     engines: {node: '>=4'}
     dependencies:
       is-number: 6.0.0
@@ -6992,7 +7132,6 @@ packages:
   file:npm/private/test/vendored/semver-max:
     resolution: {directory: npm/private/test/vendored/semver-max, type: directory}
     name: semver-max
-    version: 1.0.0
     dependencies:
       is-odd: file:npm/private/test/vendored/is-odd
       semver: 5.7.1
@@ -7059,7 +7198,7 @@ packages:
       '@types/node': registry.npmjs.org/@types/node@18.11.18
       '@types/request': registry.npmjs.org/@types/request@2.48.8
       '@types/underscore': registry.npmjs.org/@types/underscore@1.11.4
-      '@types/ws': registry.npmjs.org/@types/ws@8.5.4
+      '@types/ws': registry.npmjs.org/@types/ws@8.5.5
       byline: 5.0.0
       isomorphic-ws: 5.0.0(ws@8.13.0)
       js-yaml: 4.1.0
@@ -7206,7 +7345,6 @@ packages:
     resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz}
     name: '@types/node'
     version: 16.18.11
-    dev: true
 
   registry.npmjs.org/@types/node@18.11.11:
     resolution: {integrity: sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz}
@@ -7264,10 +7402,10 @@ packages:
     version: 1.11.4
     dev: true
 
-  registry.npmjs.org/@types/ws@8.5.4:
-    resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz}
+  registry.npmjs.org/@types/ws@8.5.5:
+    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz}
     name: '@types/ws'
-    version: 8.5.4
+    version: 8.5.5
     dependencies:
       '@types/node': registry.npmjs.org/@types/node@18.11.18
     dev: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,5 +10,6 @@ packages:
     - 'js/private/worker/src'
     - 'js/private/image'
     - 'js/private/test/image'
+    - 'js/private/test/js_run_devserver'
     - 'npm/private/test'
     - 'npm/private/test/npm_package'


### PR DESCRIPTION
…l-out instead of runfiles (unscoped node_modules are already linked to bazel-out) (#1210)" (#1230)"

Roll-forward #1210 with fixes.
This reverts commit 06ad18633563cfe7fe643b3f52cc95add247ee41.
