### PR TITLE
fix: make releases smaller

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,7 +9,8 @@ TAG=${GITHUB_REF_NAME}
 PREFIX="rules_js-${TAG:1}"
 ARCHIVE="rules_js-$TAG.tar.gz"
 # Don't include e2e or examples in the distribution artifact, to reduce size
-echo -e "e2e export-ignore\nexamples export-ignore" > .git/info/attributes
+echo >>.git/info/attributes "e2e export-ignore"
+echo >>.git/info/attributes "examples export-ignore" 
 git archive --format=tar --prefix="${PREFIX}/" "${TAG}" | gzip > "$ARCHIVE"
 SHA=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
 

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,7 +9,7 @@ TAG=${GITHUB_REF_NAME}
 PREFIX="rules_js-${TAG:1}"
 ARCHIVE="rules_js-$TAG.tar.gz"
 # Don't include e2e or examples in the distribution artifact, to reduce size
-echo -n "e2e export-ignore\nexamples export-ignore" > .git/info/attributes
+echo -e "e2e export-ignore\nexamples export-ignore" > .git/info/attributes
 git archive --format=tar --prefix="${PREFIX}/" "${TAG}" | gzip > "$ARCHIVE"
 SHA=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
 


### PR DESCRIPTION
Fixes a copy-paste mistake, somehow between testing this and making the PR I used the wrong flag. Was distracted in the Vancouver office!

# Test plan

```

echo -n "e2e export-ignore\nexamples export-ignore" > .git/info/attributes
cat .git/info/attributes
e2e export-ignore\nexamples export-ignore

echo -e "e2e export-ignore\nexamples export-ignore" > .git/info/attributes
cat .git/info/attributes
e2e export-ignore
examples export-ignore

```