### PR TITLE
Update the npm_import documentation to have the correct self-reference.

### DIFF
--- a/docs/npm_import.md
+++ b/docs/npm_import.md
@@ -66,7 +66,7 @@ To consume the downloaded package in rules, it must be "linked" into the link pa
 package's `BUILD.bazel` file:
 
 ```
-load("@npm__at_types_node__15.12.2__links//:defs.bzl", npm_link_types_node = "npm_link_imported_package")
+load("@npm__at_types_node_15.12.2__links//:defs.bzl", npm_link_types_node = "npm_link_imported_package")
 
 npm_link_types_node(name = "node_modules")
 ```

--- a/docs/npm_import.md
+++ b/docs/npm_import.md
@@ -46,7 +46,7 @@ or some `.bzl` file loaded from it. For example, with this code in `WORKSPACE`:
 
 ```starlark
 npm_import(
-    name = "npm__at_types_node_15.12.2",
+    name = "npm__at_types_node__15.12.2",
     package = "@types/node",
     version = "15.12.2",
     integrity = "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
@@ -66,7 +66,7 @@ To consume the downloaded package in rules, it must be "linked" into the link pa
 package's `BUILD.bazel` file:
 
 ```
-load("@npm__at_types_node_15.12.2__links//:defs.bzl", npm_link_types_node = "npm_link_imported_package")
+load("@npm__at_types_node__15.12.2__links//:defs.bzl", npm_link_types_node = "npm_link_imported_package")
 
 npm_link_types_node(name = "node_modules")
 ```


### PR DESCRIPTION
See the reference just above, it has one less underscore.

---

### Type of change

- Documentation (updates to documentation or READMEs)