### PR TITLE
docs: fix the npm_import documentation to have the correct self-reference

### DIFF
--- a/docs/npm_import.md
+++ b/docs/npm_import.md
@@ -44,7 +44,7 @@ or some `.bzl` file loaded from it. For example, with this code in `WORKSPACE`:
 
 ```starlark
 npm_import(
-    name = "npm__at_types_node_15.12.2",
+    name = "npm__at_types_node__15.12.2",
     package = "@types/node",
     version = "15.12.2",
     integrity = "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -906,7 +906,7 @@ def npm_import(
 
     ```starlark
     npm_import(
-        name = "npm__at_types_node_15.12.2",
+        name = "npm__at_types_node__15.12.2",
         package = "@types/node",
         version = "15.12.2",
         integrity = "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",


### PR DESCRIPTION
See the reference just above, it has one more underscore.

Closes #1265