### PR TITLE
chore: upgrade to Aspect Workflows 5.8.0-rc9

### DIFF
--- a/.aspect/workflows/terraform/main.tf
+++ b/.aspect/workflows/terraform/main.tf
@@ -7,7 +7,9 @@ terraform {
   }
 }
 
-provider "google" {
+locals {
+  # Project & region of the Workflows deployment. Alternately, you may configure a global `provider
+  # "google"` with the desired project & region and the Workflows module will default to that.
   project = "aw-deployment-rules-js"
   region  = "us-west2"
 }

--- a/.aspect/workflows/terraform/vpc.tf
+++ b/.aspect/workflows/terraform/vpc.tf
@@ -1,17 +1,21 @@
 resource "google_compute_network" "workflows_network" {
   name                    = "workflows-network"
+  project                 = local.project
   auto_create_subnetworks = false
   routing_mode            = "REGIONAL"
 }
 
 resource "google_compute_subnetwork" "workflows_subnet" {
   name          = "workflows-subnet"
+  project       = local.project
+  region        = local.region
   ip_cidr_range = "10.2.0.0/16"
   network       = google_compute_network.workflows_network.id
 }
 
 resource "google_compute_firewall" "ssh" {
   name        = "allow-ssh"
+  project     = local.project
   description = "Enable SSHing into VM instances"
   allow {
     ports    = ["22"]
@@ -25,6 +29,8 @@ resource "google_compute_firewall" "ssh" {
 
 resource "google_compute_router" "router" {
   name    = "router"
+  project = local.project
+  region  = local.region
   network = google_compute_network.workflows_network.id
 
   bgp {
@@ -34,6 +40,8 @@ resource "google_compute_router" "router" {
 
 resource "google_compute_router_nat" "nat" {
   name                               = "router-nat"
+  project                            = local.project
+  region                             = local.region
   router                             = google_compute_router.router.name
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"

--- a/.aspect/workflows/terraform/workflows.tf
+++ b/.aspect/workflows/terraform/workflows.tf
@@ -10,8 +10,13 @@ data "google_compute_image" "runner_image" {
 }
 
 module "aspect_workflows" {
+  # Project & region configuration. This is optional. Alternately, you may configure a global
+  # provider project & region and the Workflows module will default to that.
+  project = local.project
+  region  = local.region
+
   # Aspect Workflows terraform module
-  source = "https://s3.us-east-2.amazonaws.com/static.aspect.build/aspect/5.8.0-rc8/workflows-gcp/terraform-gcp-aspect-workflows.zip"
+  source = "https://s3.us-east-2.amazonaws.com/static.aspect.build/aspect/5.8.0-rc9/workflows-gcp/terraform-gcp-aspect-workflows.zip"
 
   # Network properties
   network    = google_compute_network.workflows_network.id
@@ -19,8 +24,10 @@ module "aspect_workflows" {
 
   # Number of nodes & machine type in the kubernetes cluster where the remote cache & observability
   # services run.
-  cluster_standard_node_count        = 3
-  cluster_standard_node_machine_type = "e2-standard-2"
+  k8s_cluster = {
+    node_count   = 3
+    machine_type = "e2-standard-2"
+  }
 
   # Remote cache configuration
   remote = {


### PR DESCRIPTION
Also switch to using local vars for the `project` and `region` instead of a global provider so we assert that the `project` and `region` passed to the Workflows module is routed to all GCP resources.