### PR TITLE
chore: bump bazel-lib to 2.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ rules_js_dependencies()
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_coreutils_toolchains", "register_jq_toolchains")
 
-aspect_bazel_lib_dependencies(override_local_config_platform = True)
+aspect_bazel_lib_dependencies()
 
 register_jq_toolchains()
 

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
+bazel_dep(name = "aspect_bazel_lib", version = "2.0.0-rc0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 
 local_path_override(

--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -13,7 +13,7 @@ js_image_layer(
 ```
 """
 
-load("@aspect_bazel_lib//lib:paths.bzl", "to_manifest_path")
+load("@aspect_bazel_lib//lib:paths.bzl", "to_rlocation_path")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@aspect_bazel_lib//lib:utils.bzl", "is_bazel_6_or_greater")
 
@@ -189,7 +189,7 @@ def _write_laucher(ctx, executable_path):
     return launcher
 
 def _runfile_path(ctx, file, runfiles_dir):
-    return paths.join(runfiles_dir, to_manifest_path(ctx, file))
+    return paths.join(runfiles_dir, to_rlocation_path(ctx, file))
 
 def _runfiles_dir(root, default_info):
     manifest = default_info.files_to_run.runfiles_manifest

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -9,14 +9,14 @@ load("//js/private:maybe.bzl", http_archive = "maybe_http_archive")
 def rules_js_dependencies():
     http_archive(
         name = "bazel_skylib",
-        sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
+        sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
     )
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "8fc8e300cb67b89ceebd5b8ba6896ff273c84f6099fc88d23f24e7102319d8fd",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.4/rules_nodejs-core-5.8.4.tar.gz"],
+        sha256 = "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
     )
 
     http_archive(

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -19,7 +19,11 @@ load(":npm_package_info.bzl", "NpmPackageInfo")
 
 # Pull in all copy_to_directory attributes except for exclude_prefixes
 copy_to_directory_lib_attrs = dict(copy_to_directory_lib.attrs)
-copy_to_directory_lib_attrs.pop("exclude_prefixes")
+copy_to_directory_lib_attrs.pop(
+    "exclude_prefixes",
+    # It was removed in bazel-lib 2.0, so default to ignoring.
+    None,
+)
 
 _NPM_PACKAGE_ATTRS = dicts.add(copy_to_directory_lib_attrs, {
     "data": attr.label_list(),


### PR DESCRIPTION
Note: users might still bring 1.x version of bazel-lib, and we permit that to the extent that it still works.
