### PR TITLE
fix: propogate npm package store deps from srcs in js_library

### DIFF
--- a/js/private/js_library.bzl
+++ b/js/private/js_library.bzl
@@ -195,7 +195,7 @@ def _js_library_impl(ctx):
     )
 
     npm_package_store_deps = gather_npm_package_store_deps(
-        targets = ctx.attr.data + ctx.attr.deps,
+        targets = ctx.attr.srcs + ctx.attr.data + ctx.attr.deps,
     )
 
     runfiles = gather_runfiles(


### PR DESCRIPTION
Users may add npm deps to `srcs` and the generated catch-all `:node_modules` targets has npm packages in `srcs`.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- New test cases added

TODO