### PR TITLE
fix: Use js_binary in macro in external repository

### DIFF
--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -29,11 +29,11 @@ load(
 def js_binary(**kwargs):
     _js_binary(
         enable_runfiles = select({
-            "@aspect_rules_js//js:enable_runfiles": True,
+            Label("@aspect_rules_js//js:enable_runfiles"): True,
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
+            Label("@aspect_rules_js//js:allow_unresolved_symlinks"): True,
             "//conditions:default": False,
         }),
         **kwargs
@@ -42,11 +42,11 @@ def js_binary(**kwargs):
 def js_test(**kwargs):
     _js_test(
         enable_runfiles = select({
-            "@aspect_rules_js//js:enable_runfiles": True,
+            Label("@aspect_rules_js//js:enable_runfiles"): True,
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
+            Label("@aspect_rules_js//js:allow_unresolved_symlinks"): True,
             "//conditions:default": False,
         }),
         **kwargs


### PR DESCRIPTION
---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

In https://github.com/vgijssel/setup/pull/601 I tried using `js_binary` from within a macro called `release_manager` which was located in the rules_release workspace. The rules_release macro was called from the main workspace which resulted in the following error:

```
ERROR: Analysis of target '//:release_manager' failed; build aborted: no such package '@[unknown repo 'aspect_rules_js' requested from @]//js': The repository '@[unknown repo 'aspect_rules_js' requested from @]' could not be resolved: No repository visible as '@aspect_rules_js' from main repository
INFO: Elapsed time: 0.188s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
ERROR: Build failed. Not running target
```

After asking in the Bazel community https://bazelbuild.slack.com/archives/C014RARENH0/p1698918118051159 `@fmeum` found the issue: the js_binary is a macro which uses labels which are not wrapped in the `Label` class, causing them to be scoped to the main repository. Wrapping these labels with Label class fixes the issue.
 