### PR TITLE
chore: update bcr maintainer list

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -2,9 +2,19 @@
     "homepage": "https://docs.aspect.build/rules/aspect_rules_js",
     "maintainers": [
         {
-            "email": "hello@aspect.dev",
-            "github": "aspect-build",
-            "name": "Aspect team"
+            "name": "Alex Eagle",
+            "email": "alex@aspect.dev",
+            "github": "alexeagle"
+        },
+        {
+            "name": "Greg Magolan",
+            "email": "greg@aspect.dev",
+            "github": "gregmagolan"
+        },
+        {
+            "name": "Jason Bedard",
+            "email": "jason@aspect.dev",
+            "github": "jbedard"
         }
     ],
     "repository": ["github:aspect-build/rules_js"],


### PR DESCRIPTION
Publish to BCR will now [tag and notify maintainers](https://github.com/bazel-contrib/publish-to-bcr/pull/75). I suspect we don't want error emails going to our "hello" email. The github handle being a non-user is [not documented](https://docs.google.com/document/d/1moQfNcEIttsk6vYanNKIy3ZuK53hQUFq1b1r0rmsYVg/edit#bookmark=id.1i90c6c14zvx) but might still be okay? I figured I'd remove it unless you wanted to keep it for marketing purposes.

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)
