### PR TITLE
refactor: provide specific names for rule implementations

### DIFF
--- a/js/private/coverage/merger.bzl
+++ b/js/private/coverage/merger.bzl
@@ -20,7 +20,7 @@ _ATTRS = {
 def _target_tool_short_path(workspace_name, path):
     return (workspace_name + "/../" + path[len("external/"):]) if path.startswith("external/") else path
 
-def _impl(ctx):
+def _coverage_merger_impl(ctx):
     is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
     node_bin = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo
 
@@ -51,7 +51,7 @@ def _impl(ctx):
     )
 
 coverage_merger = rule(
-    implementation = _impl,
+    implementation = _coverage_merger_impl,
     attrs = _ATTRS,
     executable = True,
     toolchains = [

--- a/js/private/expand_template.bzl
+++ b/js/private/expand_template.bzl
@@ -13,7 +13,7 @@ def _expand_substitutions(ctx, substitutions):
         ])
     return result
 
-def _impl(ctx):
+def _expand_template_impl(ctx):
     substitutions = _expand_substitutions(ctx, ctx.attr.substitutions)
 
     stamp = maybe_stamp(ctx)
@@ -67,7 +67,7 @@ such as `$(BINDIR)`, `$(TARGET_CPU)`, and `$(COMPILATION_MODE)` as documented in
 
 If stamp attribute is True, stamp variable substitutions are supported with {{STAMP_VAR}} tokens.
 """,
-    implementation = _impl,
+    implementation = _expand_template_impl,
     attrs = dict({
         "data": attr.label_list(
             doc = "List of targets for additional lookup information.",

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -551,7 +551,7 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
         runfiles = runfiles,
     )
 
-def _impl(ctx):
+def _js_binary_impl(ctx):
     launcher = _create_launcher(
         ctx,
         log_prefix_rule_set = "aspect_rules_js",
@@ -599,7 +599,7 @@ def _impl(ctx):
 js_binary_lib = struct(
     attrs = _ATTRS,
     create_launcher = _create_launcher,
-    implementation = _impl,
+    implementation = _js_binary_impl,
     toolchains = [
         # TODO: on Windows this toolchain is never referenced
         "@bazel_tools//tools/sh:toolchain_type",

--- a/js/private/js_filegroup.bzl
+++ b/js/private/js_filegroup.bzl
@@ -7,7 +7,7 @@ _DOC = """Gathers files from the JsInfo providers from targets in srcs and provi
 This helper rule is used by the `js_run_binary` macro.
 """
 
-def _impl(ctx):
+def _js_filegroup_impl(ctx):
     return DefaultInfo(files = _gather_files_from_js_providers(
         targets = ctx.attr.srcs,
         include_transitive_sources = ctx.attr.include_transitive_sources,
@@ -19,7 +19,7 @@ def _impl(ctx):
 #            rename include_declarations to include_transitive declarations & include_npm_linked_packages to include_transitive_npm_linked_packages.
 js_filegroup = rule(
     doc = _DOC,
-    implementation = _impl,
+    implementation = _js_filegroup_impl,
     attrs = {
         "srcs": attr.label_list(
             doc = """List of targets to gather files from.""",

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -21,7 +21,7 @@ _attrs = dicts.add(js_binary_lib.attrs, {
     "command": attr.string(),
 })
 
-def _impl(ctx):
+def _js_run_devserver_impl(ctx):
     config_file = ctx.actions.declare_file("{}_config.json".format(ctx.label.name))
 
     launcher = js_binary_lib.create_launcher(
@@ -97,7 +97,7 @@ def _impl(ctx):
 
 js_run_devserver_lib = struct(
     attrs = _attrs,
-    implementation = _impl,
+    implementation = _js_run_devserver_impl,
     toolchains = js_binary_lib.toolchains,
 )
 

--- a/npm/private/list_sources.bzl
+++ b/npm/private/list_sources.bzl
@@ -1,6 +1,6 @@
 "Output a list of source files to a file"
 
-def _impl(ctx):
+def _list_sources_impl(ctx):
     output = ctx.actions.declare_file(ctx.label.name)
     content = "\n".join([file.path for file in ctx.files.srcs]) + "\n"
 
@@ -15,5 +15,5 @@ list_sources = rule(
     attrs = {
         "srcs": attr.label_list(allow_files = True),
     },
-    implementation = _impl,
+    implementation = _list_sources_impl,
 )

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -71,7 +71,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 exec node "$basedir/{bin_path}" "$@"
 """
 
-def _impl(ctx):
+def _npm_link_package_store_impl(ctx):
     store_info = ctx.attr.src[NpmPackageStoreInfo]
 
     virtual_store_directory = store_info.virtual_store_directory
@@ -144,7 +144,7 @@ def _impl(ctx):
 
 npm_link_package_store = rule(
     doc = _DOC,
-    implementation = _impl,
+    implementation = _npm_link_package_store_impl,
     attrs = _ATTRS,
     provides = [DefaultInfo, JsInfo],
 )

--- a/npm/private/npm_package_internal.bzl
+++ b/npm/private/npm_package_internal.bzl
@@ -18,7 +18,7 @@ _ATTRS = {
     ),
 }
 
-def _impl(ctx):
+def _npm_package_internal_impl(ctx):
     if ctx.file.src.is_source or ctx.file.src.is_directory:
         # pass the source directory or TreeArtifact through
         dst = ctx.file.src
@@ -39,7 +39,7 @@ def _impl(ctx):
     ]
 
 npm_package_internal = rule(
-    implementation = _impl,
+    implementation = _npm_package_internal_impl,
     attrs = _ATTRS,
     provides = [DefaultInfo, NpmPackageInfo],
 )

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -157,7 +157,7 @@ If set, takes precendance over the package version in the NpmPackageInfo src.
     ),
 }
 
-def _impl(ctx):
+def _npm_package_store_impl(ctx):
     package = ctx.attr.package if ctx.attr.package else ctx.attr.src[NpmPackageInfo].package
     version = ctx.attr.version if ctx.attr.version else ctx.attr.src[NpmPackageInfo].version
 
@@ -317,7 +317,7 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
 
 npm_package_store_lib = struct(
     attrs = _ATTRS,
-    implementation = _impl,
+    implementation = _npm_package_store_impl,
     provides = [DefaultInfo, NpmPackageStoreInfo],
     toolchains = ["@aspect_bazel_lib//lib:copy_directory_toolchain_type"],
 )


### PR DESCRIPTION
I found this annoying when viewing profiles in chrome and the only info is `Starlark user function call _impl`