### PR TITLE
fix: add coreutils toolchain to rules that use copy file actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bazel-*
+!js/bazel-lib-2.0-compat.patch
 **/.terraform/*
 node_modules/
 .pnpm-*

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,11 +8,24 @@ module(
 
 # Lower-bounds for runtime dependencies.
 # Do not bump these unless rules_js requires a newer version to function.
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.37.0")
 bazel_dep(name = "bazel_features", version = "0.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "platforms", version = "0.0.5")
+
+# Maintain compatibility with pre bazel-lib 2.X versions which do not use the coreutils
+# toolchain for copy actions. To do this we need to make use of version.bzl in bazel-lib
+# to conditionally depend on the coreutils toolchain. Depending on version.bzl has several
+# side effects which we need to correct for until rules_js has a min version dependecy on
+# bazel-lib 2.X.
+archive_override(
+    module_name = "aspect_bazel_lib",
+    integrity = "sha256-ziWcusLpSm3/Aa/5RV3MhEyK8UFQOwKgnCZCaVt7hz4=",
+    patches = ["@//js:bazel-lib-2.0-compat.patch"],
+    strip_prefix = "bazel-lib-1.37.0",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.37.0/bazel-lib-v1.37.0.tar.gz"],
+)
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 use_repo(node, "nodejs_linux_amd64")

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.0.0-rc0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 
 local_path_override(

--- a/js/bazel-lib-2.0-compat.patch
+++ b/js/bazel-lib-2.0-compat.patch
@@ -1,0 +1,26 @@
+diff --git MODULE.bazel MODULE.bazel
+index 271bd09..d321835 100644
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -40,6 +40,6 @@ use_repo(
+ 
+ # Development-only dependencies
+ 
+-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
++bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1")
+ bazel_dep(name = "buildifier_prebuilt", version = "6.3.3", dev_dependency = True)
+-bazel_dep(name = "gazelle", version = "0.33.0", dev_dependency = True)
++bazel_dep(name = "gazelle", version = "0.33.0")
+diff --git tools/BUILD.bazel tools/BUILD.bazel
+index 6f86f0a..3058f94 100644
+--- tools/BUILD.bazel
++++ tools/BUILD.bazel
+@@ -17,7 +17,7 @@ bzl_library(
+ bzl_library(
+     name = "version",
+     srcs = [":version.bzl"],
+-    visibility = ["//lib/private/docs:__pkg__"],
++    visibility = ["//visibility:public"],
+ )
+ 
+ bzl_library(

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -10,6 +10,11 @@ exports_files(
     visibility = ["//docs:__pkg__"],
 )
 
+exports_files(
+    ["bazel-lib-2.0-compat.patch"],
+    visibility = ["//visibility:public"],
+)
+
 exports_files([
     "js_binary.sh.tpl",
     "node_wrapper.bat",
@@ -57,6 +62,7 @@ bzl_library(
         "@aspect_bazel_lib//lib:expand_make_vars",
         "@aspect_bazel_lib//lib:paths",
         "@aspect_bazel_lib//lib:windows_utils",
+        "@aspect_bazel_lib//tools:version",
     ],
 )
 
@@ -85,6 +91,7 @@ bzl_library(
         ":js_helpers",
         ":js_info",
         "@aspect_bazel_lib//lib:copy_to_bin",
+        "@aspect_bazel_lib//tools:version",
         "@bazel_skylib//lib:dicts",
     ],
 )

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -19,6 +19,7 @@ load("@aspect_bazel_lib//lib:windows_utils.bzl", "create_windows_native_launcher
 load("@aspect_bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "DirectoryPathInfo")
 load("@aspect_bazel_lib//lib:utils.bzl", "is_bazel_6_or_greater")
+load("@aspect_bazel_lib//tools:version.bzl", _BAZEL_LIB_VERSION = "VERSION")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":js_helpers.bzl", "LOG_LEVELS", "envs_for_log_level", "gather_runfiles")
 load(":bash.bzl", "BASH_INITIALIZE_RUNFILES")
@@ -604,7 +605,9 @@ js_binary_lib = struct(
         # TODO: on Windows this toolchain is never referenced
         "@bazel_tools//tools/sh:toolchain_type",
         "@rules_nodejs//nodejs:toolchain_type",
-    ],
+    ] + ([
+        "@aspect_bazel_lib//lib:coreutils_toolchain_type",
+    ] if _BAZEL_LIB_VERSION.startswith("2") else []),
 )
 
 js_binary = rule(

--- a/js/private/js_library.bzl
+++ b/js/private/js_library.bzl
@@ -25,6 +25,7 @@ js_library(
 
 load(":js_info.bzl", "JsInfo", "js_info")
 load(":js_helpers.bzl", "DOWNSTREAM_LINKED_NPM_DEPS_DOCSTRING", "JS_LIBRARY_DATA_ATTR", "copy_js_file_to_bin_action", "gather_npm_linked_packages", "gather_npm_package_store_deps", "gather_runfiles", "gather_transitive_declarations", "gather_transitive_sources")
+load("@aspect_bazel_lib//tools:version.bzl", _BAZEL_LIB_VERSION = "VERSION")
 
 _DOC = """A library of JavaScript sources. Provides JsInfo, the primary provider used in rules_js
 and derivative rule sets.
@@ -244,4 +245,5 @@ js_library = rule(
     implementation = js_library_lib.implementation,
     attrs = js_library_lib.attrs,
     provides = js_library_lib.provides,
+    toolchains = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"] if _BAZEL_LIB_VERSION.startswith("2") else [],
 )

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -21,9 +21,11 @@ def rules_js_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "44f4f6d1ea1fc5a79ed6ca83f875038fee0a0c47db4f9c9beed097e56f8fad03",
-        strip_prefix = "bazel-lib-1.34.0",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.34.0/bazel-lib-v1.34.0.tar.gz",
+        sha256 = "ce259cbac2e94a6dff01aff9455dcc844c8af141503b02a09c2642695b7b873e",
+        strip_prefix = "bazel-lib-1.37.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.37.0/bazel-lib-v1.37.0.tar.gz",
+        patches = ["@aspect_rules_js//js:bazel-lib-2.0-compat.patch"],
+        patch_args = ["-p0"],
     )
 
     http_archive(


### PR DESCRIPTION
In bazel-lib 2.0 the copy actions now require the coreutils toolchains, so for compatibility with 2.0 we need to declare this.

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
- Tested locally by swapping the bazel-lib dep with 2.0 and running `test //...`.
