### PR TITLE
Bump rules_nodejs back to 5.8.4

### DIFF
--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -15,8 +15,8 @@ def rules_js_dependencies():
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
+        sha256 = "8fc8e300cb67b89ceebd5b8ba6896ff273c84f6099fc88d23f24e7102319d8fd",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.4/rules_nodejs-core-5.8.4.tar.gz"],
     )
 
     http_archive(


### PR DESCRIPTION
### Type of change


https://github.com/aspect-build/rules_js/pull/1311 reverted the rules_nodejs version back to 5.8.2. This drops support for Node.js v18.17.0. This PR re-reverts the rules_nodejs version to 5.8.4


### Test plan

- Covered by existing test cases
