### PR TITLE
fix: run e2es under bzlmod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -315,14 +315,14 @@ jobs:
               # Store the --config=bzlmod flag that we add to the test command below
               # only when we're running bzlmod in our test matrix.
               id: set_bzlmod_config
-              if: matrix.bzlmodEnabled && matrix.folder == '.'
+              if: matrix.bzlmodEnabled
               run: echo "bzlmod_config=--config=bzlmod" >> $GITHUB_OUTPUT
 
             - name: bazel test //...
               if: matrix.os != 'windows-latest'
               working-directory: ${{ matrix.folder }}
               run: |
-                  bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test --config=${{ matrix.config }} ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} ${{ steps.set_bzlmod_config.outputs.bzlmod_config }} //...
+                  bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test --config=${{ matrix.config }} ${{ steps.set_bzlmod_config.outputs.bzlmod_config }} //...
                   ls $(bazel info output_base)/external | grep -v __links | grep -vz unused
               env:
                   # Bazelisk will download bazel to here

--- a/e2e/npm_translate_lock_multi/MODULE.bazel
+++ b/e2e/npm_translate_lock_multi/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/npm_translate_lock_subdir_patch/MODULE.bazel
+++ b/e2e/npm_translate_lock_subdir_patch/MODULE.bazel
@@ -1,3 +1,4 @@
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_package_lock/MODULE.bazel
+++ b/e2e/npm_translate_package_lock/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/npm_translate_yarn_lock/MODULE.bazel
+++ b/e2e/npm_translate_yarn_lock/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/package_json_module/MODULE.bazel
+++ b/e2e/package_json_module/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/patch_from_repo/MODULE.bazel
+++ b/e2e/patch_from_repo/MODULE.bazel
@@ -1,6 +1,7 @@
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 bazel_dep(name = "local_repo", version = "0.0.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace_deps/MODULE.bazel
+++ b/e2e/pnpm_workspace_deps/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace_rerooted/MODULE.bazel
+++ b/e2e/pnpm_workspace_rerooted/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/update_pnpm_lock/MODULE.bazel
+++ b/e2e/update_pnpm_lock/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/update_pnpm_lock_with_import/MODULE.bazel
+++ b/e2e/update_pnpm_lock_with_import/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/vendored_node/MODULE.bazel
+++ b/e2e/vendored_node/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/e2e/vendored_tarfile/MODULE.bazel
+++ b/e2e/vendored_tarfile/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/verify_patches/MODULE.bazel
+++ b/e2e/verify_patches/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/webpack_devserver/MODULE.bazel
+++ b/e2e/webpack_devserver/MODULE.bazel
@@ -1,5 +1,6 @@
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_go", version = "0.41.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/webpack_devserver_esm/MODULE.bazel
+++ b/e2e/webpack_devserver_esm/MODULE.bazel
@@ -1,5 +1,6 @@
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_go", version = "0.41.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",


### PR DESCRIPTION
Apparently we weren't running the bzlmod/e2e matrix entries under bzlmod :flushed:. Many of the e2es need a direct dependency on bazel-lib because in their .bazelrc they import from the root workspace.
```
import %workspace%/../../.bazelrc.common
```
The root .bazelrc contains a reference to the `@aspect_bazel_lib//lib:flag_bzlmod` flag from bazel-lib.

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases

