### PR TITLE
Do not assume that linux is always GNU tar

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -405,10 +405,6 @@ def _fetch_git_repository(rctx):
         fail("Failed to delete .git folder in %s" % str(git_repo.directory))
 
 def _is_gnu_tar(rctx):
-    # We assume that any linux platform is using GNU tar.
-    if repo_utils.is_linux(rctx):
-        return True
-
     result = rctx.execute(["tar", "--version"])
     return "GNU tar" in result.stdout
 


### PR DESCRIPTION
When using a bazel distribution such as the container images distributed by chainguard [1], you end up using busybox tar. This fails the assumption of all Linux using GNU tar.

Remove the check for Linux and rely on the existing version check.

[1] https://edu.chainguard.dev/chainguard/chainguard-images/reference/bazel/

## Testing

1. Clone a repository like https://github.com/buildbarn/bb-remote-execution
2. Attempt to build it using the chainguard image ```docker run  -v $(pwd):/build -w /build/bb-remote-execution  --rm cgr.dev/chainguard/bazel  build //...```

This will result in:

```
ERROR: Skipping '//...': error loading package under directory '': no such package '@npm__purgecss__5.0.0//': tar package failed:
STDOUT:

STDERR:
tar: unrecognized option '--delay-directory-restore'
BusyBox v1.36.1 (2023-07-03 19:43:36 UTC) multi-call binary.
```

To address, update the `WORKSPACE` file to use my branch so that the workspace rule for `rules_js` looks like this:

```
http_archive(
    name = "aspect_rules_js",
    strip_prefix = "rules_js-edbaunton-gnu-tar-not-always",
    url = "https://github.com/edbaunton/rules_js/archive/refs/heads/edbaunton/gnu-tar-not-always.zip",
)
```

rerunning the build with the command above will have the tar issue addressed (although it will likely fail on some later problem).