### PR TITLE
chore: test some e2es against bazel-lib 2.x

### DIFF
--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
-bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
+bazel_dep(name = "aspect_bazel_lib", version = "2.0.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace/WORKSPACE
+++ b/e2e/pnpm_workspace/WORKSPACE
@@ -1,7 +1,22 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 local_repository(
     name = "aspect_rules_js",
     path = "../..",
 )
+
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "4b32cf6feab38b887941db022020eea5a49b848e11e3d6d4d18433594951717a",
+    strip_prefix = "bazel-lib-2.0.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_coreutils_toolchains")
+
+aspect_bazel_lib_dependencies()
+
+register_coreutils_toolchains()
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 

--- a/e2e/pnpm_workspace_deps/MODULE.bazel
+++ b/e2e/pnpm_workspace_deps/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
+bazel_dep(name = "aspect_bazel_lib", version = "2.0.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace_deps/WORKSPACE
+++ b/e2e/pnpm_workspace_deps/WORKSPACE
@@ -1,7 +1,22 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 local_repository(
     name = "aspect_rules_js",
     path = "../..",
 )
+
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "4b32cf6feab38b887941db022020eea5a49b848e11e3d6d4d18433594951717a",
+    strip_prefix = "bazel-lib-2.0.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_coreutils_toolchains")
+
+aspect_bazel_lib_dependencies()
+
+register_coreutils_toolchains()
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 


### PR DESCRIPTION
Switch two e2es to test against bazel-lib 2.x. The bzlmod e2e already tests against 2.x.

Closes #1363 

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases

