### PR TITLE
fix: support stamped_package_json stamping with bazel-lib 2.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,8 @@ jobs:
               run: echo "folder=e2e/pnpm_workspace_deps" >> $GITHUB_OUTPUT
             - id: rules_foo
               run: echo "folder=e2e/rules_foo" >> $GITHUB_OUTPUT
+            - id: stamped_package_json
+              run: echo "folder=e2e/stamped_package_json" >> $GITHUB_OUTPUT
             - id: update_pnpm_lock
               run: echo "folder=e2e/update_pnpm_lock" >> $GITHUB_OUTPUT
             - id: update_pnpm_lock_with_import

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 # Lower-bounds for runtime dependencies.
 # Do not bump these unless rules_js requires a newer version to function.
-bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.39.0")
 bazel_dep(name = "bazel_features", version = "0.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")

--- a/e2e/js_run_devserver/MODULE.bazel
+++ b/e2e/js_run_devserver/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.39.0")
 bazel_dep(name = "rules_go", version = "0.41.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/npm_translate_lock/MODULE.bazel
+++ b/e2e/npm_translate_lock/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.39.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_empty/MODULE.bazel
+++ b/e2e/npm_translate_lock_empty/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.39.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_partial_clone/MODULE.bazel
+++ b/e2e/npm_translate_lock_partial_clone/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.39.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/stamped_package_json/.bazelignore
+++ b/e2e/stamped_package_json/.bazelignore
@@ -1,0 +1,1 @@
+node_modules

--- a/e2e/stamped_package_json/.bazelrc
+++ b/e2e/stamped_package_json/.bazelrc
@@ -1,0 +1,2 @@
+# import common bazelrc shared with e2e workspaces
+import %workspace%/../../.bazelrc.common

--- a/e2e/stamped_package_json/.bazelversion
+++ b/e2e/stamped_package_json/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/stamped_package_json/BUILD.bazel
+++ b/e2e/stamped_package_json/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@aspect_rules_js//npm:defs.bzl", "stamped_package_json")
+load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_json_matches")
+
+stamped_package_json(
+    name = "package",
+    stamp_var = "STABLE_SCM_TAG",
+)
+
+jq(
+    name = "expected",
+    srcs = [],
+    filter = "{private: true, version: \"0.0.0\"}",
+)
+
+assert_json_matches(
+    name = "stamp_test",
+    file1 = ":package",
+    file2 = ":expected",
+)

--- a/e2e/stamped_package_json/MODULE.bazel
+++ b/e2e/stamped_package_json/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    version = "0.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "aspect_rules_js", version = "0.0.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.0.1")
+
+local_path_override(
+    module_name = "aspect_rules_js",
+    path = "../..",
+)

--- a/e2e/stamped_package_json/WORKSPACE
+++ b/e2e/stamped_package_json/WORKSPACE
@@ -1,0 +1,12 @@
+local_repository(
+    name = "aspect_rules_js",
+    path = "../..",
+)
+
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains")
+
+register_jq_toolchains()

--- a/e2e/stamped_package_json/WORKSPACE.bzlmod
+++ b/e2e/stamped_package_json/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# The presence of this file causes WORKSPACE to be ignored when bzlmod is enabled.
+# See https://docs.google.com/document/d/1JtXIVnXyFZ4bmbiBCr5gsTH4-opZAFf5DMMb-54kES0/edit#heading=h.y054fjub9max

--- a/e2e/stamped_package_json/package.json
+++ b/e2e/stamped_package_json/package.json
@@ -1,0 +1,4 @@
+{
+    "private": true,
+    "version": "{STABLE_SCM_TAG}"
+}

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -22,9 +22,9 @@ def rules_js_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "262e3d6693cdc16dd43880785cdae13c64e6a3f63f75b1993c716295093d117f",
-        strip_prefix = "bazel-lib-1.38.1",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz",
+        sha256 = "4d6010ca5e3bb4d7045b071205afa8db06ec11eb24de3f023d74d77cca765f66",
+        strip_prefix = "bazel-lib-1.39.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz",
     )
 
     http_archive(

--- a/npm/private/BUILD.bazel
+++ b/npm/private/BUILD.bazel
@@ -52,7 +52,9 @@ bzl_library(
         "//js:providers",
         "@aspect_bazel_lib//lib:copy_to_directory",
         "@aspect_bazel_lib//lib:jq",
+        "@aspect_bazel_lib//tools:version",
         "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:versions",
     ],
 )
 

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -11,7 +11,9 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory_bin_action", "copy_to_directory_lib")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "DirectoryPathInfo")
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+load("@aspect_bazel_lib//tools:version.bzl", BAZEL_LIB_VERSION = "VERSION")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 load("//js:libs.bzl", "js_lib_helpers")
 load("//js:defs.bzl", "js_binary")
 load("//js:providers.bzl", "JsInfo")
@@ -530,7 +532,11 @@ def stamped_package_json(name, stamp_var, **kwargs):
             # This 'as' syntax results in $stamp being null in unstamped builds.
             "$ARGS.named.STAMP as $stamp",
             # Provide a default using the "alternative operator" in case $stamp is null.
-            ".version = ($stamp.{} // \"0.0.0\")".format(stamp_var),
+            ".version = ($stamp{}.{} // \"0.0.0\")".format(
+                # bazel-lib 1/2 require different syntax
+                "[0]" if versions.is_at_least("2.0.0", BAZEL_LIB_VERSION) else "",
+                stamp_var,
+            ),
         ]),
         **kwargs
     )


### PR DESCRIPTION
Fixes a breakage where stamping for this rule doesn't work under bazel-lib 2.x, which had some breaking changes when stamping using jq.

Closes https://github.com/aspect-build/rules_js/issues/1373

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
