### PR TITLE
WIP Use yq to parse yaml file

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,7 @@ host.host()
 use_repo(host, "aspect_bazel_lib_host")
 
 bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
-use_repo(bazel_lib_toolchains, "coreutils_toolchains")
+use_repo(bazel_lib_toolchains, "coreutils_toolchains", "yq_toolchains")
 
 node_dev = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -63,7 +63,11 @@ def _extension_impl(module_ctx):
             if not attr.pnpm_lock:
                 continue
 
-            lock_importers, lock_packages, lock_patched_dependencies = utils.parse_pnpm_lock(module_ctx.read(attr.pnpm_lock))
+            result = module_ctx.execute(["/opt/homebrew/bin/yq", attr.pnpm_lock, "-o=json"])
+            if result.return_code != 0:
+                fail(result.stderr)
+
+            lock_importers, lock_packages, lock_patched_dependencies = utils.parse_pnpm_lock(result.stdout)
             importers, packages = translate_to_transitive_closure(lock_importers, lock_packages, attr.prod, attr.dev, attr.no_optional)
             registries = {}
             npm_auth = {}

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -134,7 +134,7 @@ def _parse_pnpm_lock(content):
     Returns:
         A tuple of (importers dict, packages dict)
     """
-    parsed = _parse_yaml(content)
+    parsed = json.decode(content)
 
     if parsed == None:
         return {}, {}, {}


### PR DESCRIPTION
This reduces parsing of the Airtable lockfile from ~10s to <.5s. This clearly needs a bit of work, I wasn't fully sure how to get a toolchain usable inside repo rules or module extensions. The `Label(@@yq)` does work, but requires the userspace repo to declare the yq toolchain, which is undesirable. The homebrew yq was just a quick hack to validate that what we want here is fast.

### Type of change
- Performance (a code change that improves performance)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
- Relevant documentation has been updated
- Suggested release notes are provided below:

### Test plan

**- Covered by existing test cases**
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
