### PR TITLE
test: move patch tests to e2e/verify-patches

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -168,12 +168,8 @@ npm.npm_translate_lock(
     },
     patch_args = {
         "*": ["-p1"],
-        "@gregmagolan/test-a": ["-p4"],
     },
     patches = {
-        "@gregmagolan/test-a": ["//examples/npm_deps:patches/test-a.patch"],
-        "@gregmagolan/test-a@0.0.1": ["//examples/npm_deps:patches/test-a@0.0.1.patch"],
-        "@gregmagolan/test-b": ["//examples/npm_deps:patches/test-b.patch"],
         "meaning-of-life@1.0.0": ["//examples/npm_deps:patches/meaning-of-life@1.0.0-after_pnpm.patch"],
     },
     pnpm_lock = "//:pnpm-lock.yaml",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -145,12 +145,8 @@ npm_translate_lock(
     },
     patch_args = {
         "*": ["-p1"],
-        "@gregmagolan/test-a": ["-p4"],
     },
     patches = {
-        "@gregmagolan/test-a": ["//examples/npm_deps:patches/test-a.patch"],
-        "@gregmagolan/test-a@0.0.1": ["//examples/npm_deps:patches/test-a@0.0.1.patch"],
-        "@gregmagolan/test-b": ["//examples/npm_deps:patches/test-b.patch"],
         "meaning-of-life@1.0.0": ["//examples/npm_deps:patches/meaning-of-life@1.0.0-after_pnpm.patch"],
     },
     pnpm_lock = "//:pnpm-lock.yaml",

--- a/examples/npm_deps/patches/patches
+++ b/examples/npm_deps/patches/patches
@@ -1,5 +1,2 @@
 examples/npm_deps/patches/meaning-of-life@1.0.0-after_pnpm.patch
 examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch
-examples/npm_deps/patches/test-a.patch
-examples/npm_deps/patches/test-a@0.0.1.patch
-examples/npm_deps/patches/test-b.patch

--- a/examples/npm_deps/patches/test-a.patch
+++ b/examples/npm_deps/patches/test-a.patch
@@ -1,5 +1,0 @@
---- a/node_modules/@gregmagolan/test-a/main.js
-+++ b/node_modules/@gregmagolan/test-a/main.js
-@@ -1 +1,2 @@
- module.exports = 'test-a-0.0.1';
-+console.log("Hello world!")

--- a/examples/npm_deps/patches/test-a@0.0.1.patch
+++ b/examples/npm_deps/patches/test-a@0.0.1.patch
@@ -1,6 +1,0 @@
---- a/node_modules/@gregmagolan/test-a/main.js
-+++ b/node_modules/@gregmagolan/test-a/main.js
-@@ -1,2 +1,3 @@
- module.exports = 'test-a-0.0.1';
- console.log("Hello world!")
-+console.log("Foobar")

--- a/examples/npm_deps/patches/test-b.patch
+++ b/examples/npm_deps/patches/test-b.patch
@@ -1,5 +1,0 @@
---- a/main.js
-+++ b/main.js
-@@ -1 +1,2 @@
- module.exports = 'test-b-0.0.1';
-+console.log("Hello world!")

--- a/npm/private/test/repositories_checked.bzl
+++ b/npm/private/test/repositories_checked.bzl
@@ -1743,8 +1743,6 @@ def npm_repositories():
         transitive_closure = {
             "@gregmagolan/test-a": ["0.0.1"],
         },
-        patches = ["@//examples/npm_deps:patches/test-a.patch", "@//examples/npm_deps:patches/test-a@0.0.1.patch"],
-        patch_args = ["-p4"],
     )
 
     npm_import(
@@ -1769,8 +1767,6 @@ def npm_repositories():
             "@gregmagolan/test-a": ["0.0.1"],
             "@gregmagolan/test-b": ["0.0.2"],
         },
-        patches = ["@//examples/npm_deps:patches/test-b.patch"],
-        patch_args = ["-p1"],
     )
 
     npm_import(


### PR DESCRIPTION
I think the e2e/verify-patches tests the exact same thing already so I don't think we also need these in the main workspace? They get quite annoying when doing testing in the repo so keeping them in e2e tests is a lot nicer.

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)
