### PR TITLE
feat: add special handling to js_run_devserver for 1p deps to improve watch mode performance

### DIFF
--- a/e2e/webpack_devserver/.bazelignore
+++ b/e2e/webpack_devserver/.bazelignore
@@ -1,1 +1,2 @@
 node_modules
+mylib/node_modules

--- a/e2e/webpack_devserver/BUILD.bazel
+++ b/e2e/webpack_devserver/BUILD.bazel
@@ -28,6 +28,7 @@ js_run_devserver(
         "webpack.config.js",
         ":node_modules",
     ],
+    log_level = "debug",
     tool = "webpack_binary",
 )
 
@@ -45,5 +46,6 @@ js_run_devserver(
         "webpack.config.cjs",
         ":node_modules",
     ],
+    log_level = "debug",
     tool = "webpack_binary",
 )

--- a/e2e/webpack_devserver/mylib/BUILD.bazel
+++ b/e2e/webpack_devserver/mylib/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+npm_package(
+    name = "mylib",
+    srcs = [
+        "index.js",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/webpack_devserver/mylib/index.js
+++ b/e2e/webpack_devserver/mylib/index.js
@@ -1,0 +1,5 @@
+const packageJson = require('./package.json')
+const chalk = require('chalk')
+module.exports = {
+    name: () => chalk.blue(packageJson.name),
+}

--- a/e2e/webpack_devserver/mylib/package.json
+++ b/e2e/webpack_devserver/mylib/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@mycorp/mylib",
+    "dependencies": {
+        "chalk": "^4"
+    }
+}

--- a/e2e/webpack_devserver/package.json
+++ b/e2e/webpack_devserver/package.json
@@ -7,6 +7,7 @@
         "@bazel/ibazel": "0.16.2"
     },
     "dependencies": {
-        "lodash": "4.17.21"
+        "lodash": "4.17.21",
+        "@mycorp/mylib": "workspace:*"
     }
 }

--- a/e2e/webpack_devserver/pnpm-lock.yaml
+++ b/e2e/webpack_devserver/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@mycorp/mylib':
+        specifier: workspace:*
+        version: link:mylib
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -27,6 +30,12 @@ importers:
       webpack-dev-server:
         specifier: 4.15.1
         version: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.1)
+
+  mylib:
+    dependencies:
+      chalk:
+        specifier: ^4
+        version: 4.1.2
 
 packages:
 
@@ -432,6 +441,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: false
+
   /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -551,6 +567,14 @@ packages:
     resolution: {integrity: sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==}
     dev: true
 
+  /chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: false
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -586,6 +610,17 @@ packages:
       kind-of: 6.0.3
       shallow-clone: 3.0.1
     dev: true
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: false
+
+  /color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: false
 
   /colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
@@ -1063,7 +1098,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
@@ -1987,6 +2021,13 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
+
+  /supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: false
 
   /supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}

--- a/e2e/webpack_devserver/pnpm-workspace.yaml
+++ b/e2e/webpack_devserver/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
     - '.'
+    - 'mylib'

--- a/e2e/webpack_devserver/serve_test.sh
+++ b/e2e/webpack_devserver/serve_test.sh
@@ -14,15 +14,20 @@ _sedi() {
     sed "${sedi[@]}" "$@"
 }
 
+echo ""
+echo ""
 echo "TEST - $0: $1"
 
-./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" >/dev/null 2>&1 &
+ibazel_logs=$(mktemp)
+echo "Capturing ibazel logs to $ibazel_logs"
+./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" >"$ibazel_logs" 2>&1 &
 ibazel_pid="$!"
 
 function _exit {
-    echo "Cleanup..."
     kill "$ibazel_pid"
-    git checkout src/index.html
+    git checkout src/index.html >/dev/null 2>&1
+    git checkout mylib/index.js >/dev/null 2>&1
+    rm -f "$ibazel_logs"
 }
 trap _exit EXIT
 
@@ -43,6 +48,11 @@ if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "Getting St
     exit 1
 fi
 
+if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk.blue(packageJson.name)"; then
+    echo "ERROR: Expected http://localhost:8080/main.js to contain 'chalk.blue(packageJson.name)'"
+    exit 1
+fi
+
 _sedi 's#Getting Started#Goodbye#' src/index.html
 
 echo "Waiting 5 seconds for ibazel rebuild after change to src/index.html..."
@@ -50,6 +60,48 @@ sleep 5
 
 if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "Goodbye"; then
     echo "ERROR: Expected http://localhost:8080/index.html to contain 'Goodbye'"
+    exit 1
+fi
+
+_sedi 's#blue#red#' mylib/index.js
+
+echo "Waiting 5 seconds for ibazel rebuild after change to mylib/index.js..."
+sleep 5
+
+if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk.red(packageJson.name)"; then
+    echo "ERROR: Expected http://localhost:8080/main.js to contain 'chalk.red(packageJson.name)'"
+    exit 1
+fi
+
+echo "Checking log file $ibazel_logs"
+
+count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/index.js" "$ibazel_logs" || true)
+if [[ "$count" -ne 2 ]]; then
+    echo "ERROR: expected to have synced @mycorp/mylib/index.js 2 times but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/index.js since its timestamp has not changed" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have skipped @mycorp/mylib/index.js due to timestamp 1 time but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have synced @mycorp/mylib/package.json 1 time but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json since its timestamp has not changed" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have skipped @mycorp/mylib/package.json due to timestamp 1 time but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json since contents have not changed" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have skipped @mycorp/mylib/package.json due to contents 1 time but found ${count}"
     exit 1
 fi
 

--- a/e2e/webpack_devserver/src/index.js
+++ b/e2e/webpack_devserver/src/index.js
@@ -1,10 +1,11 @@
 import _ from 'lodash'
+import { name } from '@mycorp/mylib'
 
 function component() {
     const element = document.createElement('div')
 
     // Lodash, currently included via a script, is required for this line to work
-    element.innerHTML = _.join(['Hello', 'webpack'], ' ')
+    element.innerHTML = _.join(['Hello', 'webpack', name()], ' ')
 
     return element
 }

--- a/e2e/webpack_devserver_esm/.bazelignore
+++ b/e2e/webpack_devserver_esm/.bazelignore
@@ -1,1 +1,2 @@
 node_modules
+mylib/node_modules

--- a/e2e/webpack_devserver_esm/BUILD.bazel
+++ b/e2e/webpack_devserver_esm/BUILD.bazel
@@ -28,5 +28,6 @@ js_run_devserver(
         "webpack.config.mjs",
         ":node_modules",
     ],
+    log_level = "debug",
     tool = "webpack_binary",
 )

--- a/e2e/webpack_devserver_esm/mylib/BUILD.bazel
+++ b/e2e/webpack_devserver_esm/mylib/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+npm_package(
+    name = "mylib",
+    srcs = [
+        "index.js",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/webpack_devserver_esm/mylib/index.js
+++ b/e2e/webpack_devserver_esm/mylib/index.js
@@ -1,0 +1,5 @@
+import packageJson from './package.json'
+import chalk from 'chalk'
+export function name() {
+    return chalk.blue(packageJson.name)
+}

--- a/e2e/webpack_devserver_esm/mylib/package.json
+++ b/e2e/webpack_devserver_esm/mylib/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@mycorp/mylib",
+    "dependencies": {
+        "chalk": "^4"
+    }
+}

--- a/e2e/webpack_devserver_esm/package.json
+++ b/e2e/webpack_devserver_esm/package.json
@@ -8,6 +8,7 @@
         "@bazel/ibazel": "0.16.2"
     },
     "dependencies": {
-        "lodash": "4.17.21"
+        "lodash": "4.17.21",
+        "@mycorp/mylib": "workspace:*"
     }
 }

--- a/e2e/webpack_devserver_esm/pnpm-lock.yaml
+++ b/e2e/webpack_devserver_esm/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@mycorp/mylib':
+        specifier: workspace:*
+        version: link:mylib
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -27,6 +30,12 @@ importers:
       webpack-dev-server:
         specifier: 4.15.1
         version: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.1)
+
+  mylib:
+    dependencies:
+      chalk:
+        specifier: ^4
+        version: 4.1.2
 
 packages:
 
@@ -432,6 +441,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: false
+
   /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -551,6 +567,14 @@ packages:
     resolution: {integrity: sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==}
     dev: true
 
+  /chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: false
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -586,6 +610,17 @@ packages:
       kind-of: 6.0.3
       shallow-clone: 3.0.1
     dev: true
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: false
+
+  /color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: false
 
   /colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
@@ -1063,7 +1098,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
@@ -1987,6 +2021,13 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
+
+  /supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: false
 
   /supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}

--- a/e2e/webpack_devserver_esm/pnpm-workspace.yaml
+++ b/e2e/webpack_devserver_esm/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
     - '.'
+    - 'mylib'

--- a/e2e/webpack_devserver_esm/serve_test.sh
+++ b/e2e/webpack_devserver_esm/serve_test.sh
@@ -16,13 +16,16 @@ _sedi() {
 
 echo "TEST - $0: $1"
 
-./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" >/dev/null 2>&1 &
+ibazel_logs=$(mktemp)
+echo "Capturing ibazel logs to $ibazel_logs"
+./node_modules/.bin/ibazel run "$1" "$BZLMOD_FLAG" >"$ibazel_logs" 2>&1 &
 ibazel_pid="$!"
 
 function _exit {
-    echo "Cleanup..."
     kill "$ibazel_pid"
-    git checkout src/index.html
+    git checkout src/index.html >/dev/null 2>&1
+    git checkout mylib/index.js >/dev/null 2>&1
+    rm -f "$ibazel_logs"
 }
 trap _exit EXIT
 
@@ -43,6 +46,11 @@ if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "Getting St
     exit 1
 fi
 
+if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk__WEBPACK_IMPORTED_MODULE_1___default().blue(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)"; then
+    echo "ERROR: http://localhost:8080/main.js to contain 'chalk__WEBPACK_IMPORTED_MODULE_1___default().blue(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)'"
+    exit 1
+fi
+
 _sedi 's#Getting Started#Goodbye#' src/index.html
 
 echo "Waiting 5 seconds for ibazel rebuild after change to src/index.html..."
@@ -50,6 +58,46 @@ sleep 5
 
 if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "Goodbye"; then
     echo "ERROR: Expected http://localhost:8080/index.html to contain 'Goodbye'"
+    exit 1
+fi
+
+_sedi 's#blue#red#' mylib/index.js
+
+echo "Waiting 5 seconds for ibazel rebuild after change to mylib/index.js..."
+sleep 5
+
+if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk__WEBPACK_IMPORTED_MODULE_1___default().red(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)"; then
+    echo "ERROR: Expected http://localhost:8080/main.js to contain 'chalk__WEBPACK_IMPORTED_MODULE_1___default().red(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)'"
+    exit 1
+fi
+
+count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/index.js" "$ibazel_logs" || true)
+if [[ "$count" -ne 2 ]]; then
+    echo "ERROR: expected to have synced @mycorp/mylib/index.js 2 times but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/index.js since its timestamp has not changed" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have skipped @mycorp/mylib/index.js due to timestamp 1 time but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have synced @mycorp/mylib/package.json 1 time but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json since its timestamp has not changed" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have skipped @mycorp/mylib/package.json due to timestamp 1 time but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json since contents have not changed" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have skipped @mycorp/mylib/package.json due to contents 1 time but found ${count}"
     exit 1
 fi
 

--- a/e2e/webpack_devserver_esm/src/index.js
+++ b/e2e/webpack_devserver_esm/src/index.js
@@ -1,10 +1,11 @@
 import _ from 'lodash'
+import { name } from '@mycorp/mylib'
 
 function component() {
     const element = document.createElement('div')
 
     // Lodash, currently included via a script, is required for this line to work
-    element.innerHTML = _.join(['Hello', 'webpack'], ' ')
+    element.innerHTML = _.join(['Hello', 'webpack', name()], ' ')
 
     return element
 }

--- a/js/private/test/js_run_devserver/BUILD.bazel
+++ b/js/private/test/js_run_devserver/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//js/private/test/js_run_devserver:jasmine/package_json.bzl", jasmine_bin = "bin")
 load(":js_run_devserver_test.bzl", "js_run_devserver_test")
@@ -31,4 +32,13 @@ js_run_devserver_test(
 
 jasmine_bin.jasmine_binary(
     name = "jasmine",
+)
+
+js_test(
+    name = "js_run_devserver_test",
+    data = ["//js/private:js_devserver_entrypoint"],
+    entry_point = "js_run_devserver.spec.mjs",
+    env = {
+        "__RULES_JS_UNIT_TEST__": "1",
+    },
 )

--- a/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
+++ b/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
@@ -1,0 +1,80 @@
+import {
+    isNodeModulePath,
+    is1pVirtualStoreDep,
+    friendlyFileSize,
+} from '../../js_run_devserver.mjs'
+
+// isNodeModulePath
+const isNodeModulePath_true = [
+    '/private/var/some/path/node_modules/@babel/core',
+    '/private/var/some/path/node_modules/lodash',
+]
+for (const p of isNodeModulePath_true) {
+    if (!isNodeModulePath(p)) {
+        console.error(`ERROR: expected ${p} to be a node_modules path`)
+        process.exit(1)
+    }
+}
+const isNodeModulePath_false = ['/private/var/some/path/some-file.js']
+for (const p of isNodeModulePath_false) {
+    if (isNodeModulePath(p)) {
+        console.error(`ERROR: expected ${p} to not be a node_modules path`)
+        process.exit(1)
+    }
+}
+
+// is1pVirtualStoreDep
+const is1pVirtualStoreDep_true = [
+    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/@mycorp/pkg',
+    'some/path/node_modules/.aspect_rules_js/mycorp-pkg@0.0.0/node_modules/mycorp-pkg',
+]
+for (const p of is1pVirtualStoreDep_true) {
+    if (!is1pVirtualStoreDep(p)) {
+        console.error(`ERROR: expected ${p} to be a 1p virtual store dep`)
+        process.exit(1)
+    }
+}
+const is1pVirtualStoreDep_false = [
+    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/mycorp/pkg',
+    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg0.0.0/node_modules/@mycorp/pkg',
+    'some/path/node_modules/.aspect_rules_js/mycorp+pkg@0.0.0/node_modules/@mycorp/pkg',
+    'some/path/node_modules/.aspect_rules_js/mycorp-pkg0.0.0/node_modules/mycorp-pkg',
+    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/acorn',
+    'some/path/node_modules/.aspect_rules_js/mycorp-pkg@0.0.0/node_modules/acorn',
+    'some/path/node_modules/.aspect_rules_js/@babel+runtime@7.21.0/node_modules/@babel/runtime',
+    'some/path/node_modules/.aspect_rules_js/@babel+runtime@7.21.0/node_modules/acorn',
+    'some/path/node_modules/.aspect_rules_js/eval@0.1.6/node_modules/eval',
+    'some/path/node_modules/.aspect_rules_js/eval@0.1.6/node_modules/acorn',
+]
+for (const p of is1pVirtualStoreDep_false) {
+    if (is1pVirtualStoreDep(p)) {
+        console.error(`ERROR: expected ${p} to not be a 1p virtual store dep`)
+        process.exit(1)
+    }
+}
+
+// friendlyFileSize
+const friendlyFileSize_cases = new Map()
+friendlyFileSize_cases.set(0, '0 B')
+friendlyFileSize_cases.set(1, '1 B')
+friendlyFileSize_cases.set(100, '100 B')
+friendlyFileSize_cases.set(1023, '1023 B')
+friendlyFileSize_cases.set(1024, '1.0 KiB')
+friendlyFileSize_cases.set(1300, '1.3 KiB')
+friendlyFileSize_cases.set(1024 * 1024, '1.0 MiB')
+friendlyFileSize_cases.set(1024 * 1024 * 1024, '1.0 GiB')
+friendlyFileSize_cases.set(1024 * 1024 * 1024 * 1024, '1.0 TiB')
+friendlyFileSize_cases.set(1024 * 1024 * 1024 * 1024 * 1024, '1.0 PiB')
+friendlyFileSize_cases.set(
+    1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+    '1024.0 PiB'
+)
+for (const [k, v] of friendlyFileSize_cases) {
+    const a = friendlyFileSize(k)
+    if (a !== v) {
+        console.error(
+            `Expected friendlyFileSize(${k}) to be '${v}' but got '${a}'`
+        )
+        process.exit(1)
+    }
+}


### PR DESCRIPTION
Customer request to optimize js_run_devserver watch mode for first-party linked dependencies.

Adds special handling to copy 1p linked deps into the js_run_devserver custom sandbox instead of just symlinking the link symlink. We keep the symlinking the link symlink for 3p deps since coping those would add signifiant overhead for large graphs.

Adds further handling to checksum files before copying so even if their timestamps have changed the will not be copied if their contents have not. This is required since 1p linked deps under rules_js are directory artifacts so if any one file changes within the linked package then bazel re-creates the entire folder which makes any watchers think that all files have changed.

---

### Type of change

- New feature or functionality (change which adds functionality)

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:

Manually tested by `ibazel run //:dev` in `e2e/webpack_devserver`:

- Initial sync (with debug logs):

```
Starting js_run_devserver //:dev
Syncing 13 files && folders...
Syncing 1 first party virtual store dep(s)
Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/index.js (144 B)
Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json (83 B)
Syncing 12 other files && folders...
Syncing symlink node_modules/@bazel/ibazel (bazel-out)
Syncing symlink node_modules/lodash (bazel-out)
Syncing symlink node_modules/html-webpack-plugin (bazel-out)
Syncing symlink node_modules/webpack-dev-server (bazel-out)
Syncing symlink node_modules/webpack-cli (bazel-out)
Syncing symlink node_modules/webpack (bazel-out)
Syncing symlink node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/chalk (bazel-out)
Syncing symlink node_modules/@mycorp/mylib (1p)
Syncing file package.json (307 B)
Syncing file webpack.config.js (554 B)
Syncing file src/index.html (189 B)
Syncing file src/index.js (345 B)
14 files syncedTime in 14 ms
```

- Subsequent sync after modifying just `e2e/webpack_devserver/lib/mylib/index.js`:

```
Syncing 13 files && folders...
Syncing 1 first party virtual store dep(s)
Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/index.js (145 B)
Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json since contents have not changed
Syncing 12 other files && folders...
Skipping file node_modules/@bazel/ibazel since its timestamp has not changed
Skipping file node_modules/html-webpack-plugin since its timestamp has not changed
Skipping file node_modules/lodash since its timestamp has not changed
Skipping file node_modules/webpack-cli since its timestamp has not changed
Skipping file node_modules/webpack-dev-server since its timestamp has not changed
Skipping file node_modules/webpack since its timestamp has not changed
Skipping file node_modules/@mycorp/mylib since its timestamp has not changed
Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/chalk since its timestamp has not changed
Skipping file package.json since its timestamp has not changed
Skipping file src/index.html since its timestamp has not changed
Skipping file src/index.js since its timestamp has not changed
Skipping file webpack.config.js since its timestamp has not changed
1 file syncedTime in 3 ms
```
