### PR TITLE
fix: accept pnpm pkg resolution without tarball

### DIFF
--- a/npm/private/transitive_closure.bzl
+++ b/npm/private/transitive_closure.bzl
@@ -149,7 +149,7 @@ def translate_to_transitive_closure(lock_importers, lock_packages, prod = False,
         packages[package] = package_info
 
         # tarbal versions
-        if package_info["resolution"].get("tarball") and package_info["resolution"]["tarball"].startswith("file:"):
+        if package_info["resolution"].get("tarball", None) and package_info["resolution"]["tarball"].startswith("file:"):
             package_version_map[package] = package_info
 
     # Collect deps of each importer (workspace projects)


### PR DESCRIPTION
I come across a case where this property was not set. It looks like we treat it as optional in `npm/private/npm_translate_lock_helpers.bzl` so we should here as well. I have not investigated further why it might be null or if it was a lockfile issue vs rules_js issue, but we should treat it as optional consistently.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
