### PR TITLE
Make sure that auth is respected, even if lockfiles have ports

### DIFF
--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -235,7 +235,6 @@ def _select_npm_auth(url, npm_auth):
 
     return npm_auth_bearer, npm_auth_basic, npm_auth_username, npm_auth_password
 
-
 ################################################################################
 def _get_npm_imports(importers, packages, patched_dependencies, root_package, rctx_name, attr, all_lifecycle_hooks, all_lifecycle_hooks_execution_requirements, registries, default_registry, npm_auth):
     "Converts packages from the lockfile to a struct of attributes for npm_import"


### PR DESCRIPTION
The `_get_npm_imports` fails to account for the ports in URL, meaning it will not pass through auth if a port is specified. We work around this by checking the URL with and without ports

---


### Type of change

- Bug fix (change which fixes an issue)
- Closes #1443 

**For changes visible to end-users**

- No breaking changes

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  - Create a yarn lock with a private registry (something like `@private`)
  - Add a package with this registry with a port (like 443) in the download URL
  - In the home npmrc, make sure that the registry has auth, and no port in the URL
  - `rules_js` will now fail to download the package