### PR TITLE
fix: include npm and yarn lock files in npm_translate_lock(data)

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -499,6 +499,12 @@ def npm_translate_lock(
     if not bzlmod and pnpm_version != None:
         _pnpm_repository(name = "pnpm", pnpm_version = pnpm_version)
 
+    if yarn_lock:
+        data = data + [yarn_lock]
+
+    if npm_package_lock:
+        data = data + [npm_package_lock]
+
     if package_json:
         data = data + [package_json]
 


### PR DESCRIPTION
When looking into the bzlmod pnpm-import issue it seems the import sometimes wasn't running at all which seemed to be from the `yarn.lock` not being in the `data`.

WDYT? Worth doing?

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

