### PR TITLE
fix: exit with message when pnpm-lock.yaml updated in bzlmod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,12 @@ jobs:
                     # Don't run workspace smoke test under bzlmod
                     - bzlmod: 1
                       folder: e2e/workspace
+                    # Don't run update_pnpm_lock under bzlmod
+                    - bzlmod: 1
+                      folder: e2e/update_pnpm_lock
+                    # Don't run update_pnpm_lock under bzlmod
+                    - bzlmod: 1
+                      folder: e2e/npm_translate_lock_auth
                     # rules_docker is not compatible with Bazel 7
                     - bazel-version:
                           major: 7


### PR DESCRIPTION
Exit with a message instead of crashing. Maybe we'll fix this in the future, maybe we'll completely remove the `reload_lockfile()` in v2?

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
