### PR TITLE
Remove non-quoted ALL_ARGS access; fixes passing multi-word arguments through to a js_binary

### DIFF
--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -339,7 +339,7 @@ JS_BINARY__NODE_OPTIONS=()
 
 ARGS=()
 ALL_ARGS=({{fixed_args}} "$@")
-for ARG in ${ALL_ARGS[@]+"${ALL_ARGS[@]}"}; do
+for ARG in "${ALL_ARGS[@]}"}; do
     case "$ARG" in
     # Let users pass through arguments to node itself
     --node_options=*) JS_BINARY__NODE_OPTIONS+=("${ARG#--node_options=}") ;;


### PR DESCRIPTION
### Type of change

- Bug fix (change which fixes an issue)

It's impossible to pass multi-word arguments to a `js_binary` target. For example, I have this `bin/BUILD.bazel` file that defines a target to run the [concurrently npm module](https://www.npmjs.com/package/concurrently):

````py
load("@npm//:concurrently/package_json.bzl", concurrently_bin = "bin")

concurrently_bin.concurrently_binary(name = "concurrently")
````

If I pass a multi-word argument (quoted or backslashed), the components of that multi-word argument ultimately gets passed as separate arguments to the underlying node invocation:

````sh
$ # Here we expect concurrently to receive two arguments: "date" and  "date +%s"
$ bazel run //bin:concurrently -- date "date +%s"
...some lines elided...
# Here you can see that it has passed in the arguments "date", "date", and "%s", rather than what I originally provided:
INFO: Running command line: .bazel/bin/bin/concurrently.sh date date +%s
````

([Full transcript here](https://gist.github.com/shinypb/ed7d7f1605cd3a0f39659d30fa345ce7))

The problem originates with this line in js_binary.sh.tpl:

````sh
ALL_ARGS=({{fixed_args}} "$@")
for ARG in ${ALL_ARGS[@]+"${ALL_ARGS[@]}"}; do
````

This accesses `ALL_ARGS` both with and without quotes. Accessing it without quotes breaks the multi-word arguments into their individual words, making it impossible for uses to pass multi-word arguments into a `js_binary` target.

**For changes visible to end-users**

In theory, this shouldn't affect end users, but it's possible that someone may be relying on the previous behavior.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
