### PR TITLE
fix: bump minimum aspect_bazel_lib version to 2.2.0 for is_bazel_7_or_greater function

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 # Lower-bounds for runtime dependencies.
 # Do not bump these unless rules_js requires a newer version to function.
-bazel_dep(name = "aspect_bazel_lib", version = "1.40.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.2.0")
 bazel_dep(name = "aspect_rules_lint", version = "0.9.1")
 bazel_dep(name = "bazel_features", version = "0.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.2.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.3.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 
 local_path_override(

--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
-bazel_dep(name = "aspect_bazel_lib", version = "2.2.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.3.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace_deps/MODULE.bazel
+++ b/e2e/pnpm_workspace_deps/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.2.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.3.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/stamped_package_json/MODULE.bazel
+++ b/e2e/stamped_package_json/MODULE.bazel
@@ -4,7 +4,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.2.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.3.0")
 
 local_path_override(
     module_name = "aspect_rules_js",

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -58,6 +58,7 @@ bzl_library(
         "@aspect_bazel_lib//lib:expand_make_vars",
         "@aspect_bazel_lib//lib:paths",
         "@aspect_bazel_lib//lib:windows_utils",
+        "@bazel_skylib//lib:dicts",
     ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if is_bazel_7_or_greater() else []),
 )
 


### PR DESCRIPTION
The current minimum of 1.40.0 is fine for the 1.x branch but this breaks things for users that have a version >= 2.0.0 and < 2.2.0. This doesn't change the WORKSPACE version pulled in `rules_js_dependencies` which remains as 1.40.0.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
