### PR TITLE
chore: remove Go

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@acorn__8.4.0__links//:defs.bzl", npm_link_acorn = "npm_link_imported_package")
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
-load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@npm//:defs.bzl", "npm_link_all_packages", "npm_link_targets")
@@ -81,16 +80,6 @@ npm_link_package(
 npm_link_package(
     name = "node_modules/@mycorp/pkg-c2",
     src = "//examples/npm_package/packages/pkg_c:pkg_c2",
-)
-
-gazelle_binary(
-    name = "gazelle_bin",
-    languages = ["@bazel_skylib_gazelle_plugin//bzl"],
-)
-
-gazelle(
-    name = "gazelle",
-    gazelle = "gazelle_bin",
 )
 
 buildifier(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,10 +44,7 @@ use_repo(bazel_lib_toolchains, "yq_windows_amd64")
 
 ####### Dev dependencies ########
 
-bazel_dep(name = "gazelle", version = "0.33.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "buildifier_prebuilt", version = "6.3.3", dev_dependency = True)
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.41.0", dev_dependency = True)
 
 host = use_extension(
     "@aspect_bazel_lib//lib:extensions.bzl",
@@ -208,15 +205,3 @@ npm.npm_import(
 )
 use_repo(npm, "acorn__8.4.0")
 use_repo(npm, "acorn__8.4.0__links")
-
-# Used by formatter
-go_sdk = use_extension(
-    "@rules_go//go:extensions.bzl",
-    "go_sdk",
-    dev_dependency = True,
-)
-go_sdk.download(
-    name = "go_sdk",
-    version = "1.20.3",
-)
-use_repo(go_sdk, "go_sdk")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,18 +46,6 @@ load("@aspect_bazel_lib//lib:host_repo.bzl", "host_repo")
 host_repo(name = "aspect_bazel_lib_host")
 
 ############################################
-# Gazelle, for generating bzl_library targets
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.20.5")
-
-gazelle_dependencies()
-
-############################################
 # Example npm dependencies
 
 load("@aspect_rules_js//npm:repositories.bzl", "npm_import", "npm_translate_lock")

--- a/js/dev_repositories.bzl
+++ b/js/dev_repositories.bzl
@@ -10,27 +10,9 @@ load("//js/private:maybe.bzl", http_archive = "maybe_http_archive")
 def rules_js_dev_dependencies():
     "Fetch repositories used for developing the rules"
     http_archive(
-        name = "io_bazel_rules_go",
-        sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
-    )
-
-    http_archive(
-        name = "bazel_gazelle",
-        sha256 = "d3fa66a39028e97d76f9e2db8f1b0c11c099e8e01bf363a923074784e451f809",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
-    )
-
-    http_archive(
         name = "bazel_skylib",
         sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
         urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
-    )
-
-    http_archive(
-        name = "bazel_skylib_gazelle_plugin",
-        sha256 = "3327005dbc9e49cc39602fb46572525984f7119a9c6ffe5ed69fbe23db7c1560",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-gazelle-plugin-1.4.2.tar.gz"],
     )
 
     http_archive(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -28,7 +28,6 @@ alias(
 
 multi_formatter_binary(
     name = "format",
-    go = "@go_sdk//:bin/gofmt",
     sh = ":shfmt",
     starlark = "@buildifier_prebuilt//:buildifier",
     terraform = ":terraform",


### PR DESCRIPTION
We don't have any Go sources in rules_js, so there's no reason we should install a Go toolchain or worry about upgrading it. 'aspect configure' provides the auto-generation for bzl_library targets so we don't need Gazelle either.
