### PR TITLE
Avoid Bazel's unsound directory dependency checking

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -357,6 +357,13 @@ def {bin_name}_binary(name, **kwargs):
 """
 
 _JS_PACKAGE_TMPL = """
+_copy_to_directory(
+    name = "package",
+    srcs = glob(["{extract_to_dirname}/**"]),
+    root_paths = ["package"],
+    visibility = ["//visibility:public"],
+)
+
 _npm_package_internal(
     name = "source_directory",
     src = ":{extract_to_dirname}",
@@ -531,7 +538,9 @@ def _npm_import_rule_impl(rctx):
 
     rctx_files = {
         "BUILD.bazel": generated_by_lines + [
-            """load("@aspect_rules_js//npm/private:npm_package_internal.bzl", _npm_package_internal = "npm_package_internal")""",
+            """\
+load("@aspect_rules_js//npm/private:npm_package_internal.bzl", _npm_package_internal = "npm_package_internal")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", _copy_to_directory = "copy_to_directory")""",
         ],
     }
 


### PR DESCRIPTION
Fixes #1408.

This PR modifies `npm_import` (and by extension `npm_translate_lock`) to mask the `package` source directory with a generated target and `TreeArtifact` (`ctx.declare_directory`) output of the same name. This allows package files to be collected with `glob(["package/**"])`, such that no source directory dependency exists (which Bazel reports as unsound).

Any rule that depends on the `package` source directory directly (there should be none) will now be depending on the `:package` target instead (this should extend to every file inside the directory as well, _I think_).

Repo rules are the exception, they cannot consume the `:package` target and so will continue to see the source directory. There are no output differences, so this is fine.

### Type of change

Bug fix (Bazel 7+).

Currently mitigated with;
* `--noincompatible_disallow_unsound_directory_outputs`, if builds are failing (observed in other rules).
* `startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1`, to hide warnings.

### Test plan

- [x] Covered by existing test cases
- [x] Manual testing; please provide instructions so we can reproduce:
  1. Clone `rules_js` repo (checking out `main`/this PR as appropriate for before/after)
  2. Remove mitigations. (`startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1` from `.aspect/bazelrc/correctness.bazelrc`)
  3. `cd e2e/pnpm_workspace`
  4. `bazel build //app/a:main`
     - Baseline: Warnings visible. e.g.
       ```
       (17:52:22) WARNING: BUILD.bazel:3:22: input 'package' to //:.aspect_rules_js/node_modules/@aspect-test+d@2.0.0_@aspect-test+c@2.0.2/pkg is a directory; dependency checking of directories is unsound
       (17:52:22) WARNING: BUILD.bazel:3:22: input 'package' to //:.aspect_rules_js/node_modules/@aspect-test+f@1.0.0/pkg is a directory; dependency checking of directories is unsound
       (17:52:22) WARNING: BUILD.bazel:3:22: input 'package' to //:.aspect_rules_js/node_modules/@aspect-test+e@1.0.0/pkg is a directory; dependency checking of directories is unsound
       (17:52:22) WARNING: BUILD.bazel:3:22: input 'package' to //:.aspect_rules_js/node_modules/@aspect-test+g@1.0.0/pkg is a directory; dependency checking of directories is unsound
       (17:52:22) WARNING: BUILD.bazel:3:22: input 'package' to //:.aspect_rules_js/node_modules/@aspect-test+a@5.0.2/pkg is a directory; dependency checking of directories is unsound
       (17:52:23) WARNING: BUILD.bazel:3:22: input 'package' to //:.aspect_rules_js/node_modules/@aspect-test+b@5.0.2/pkg is a directory; dependency checking of directories is unsound
       (17:52:23) WARNING: BUILD.bazel:3:22: input 'package' to //:.aspect_rules_js/node_modules/@aspect-test+c@2.0.2/lc is a directory; dependency checking of directories is unsound
       ```
     - PR: No warnings.
- [ ] Benchmark to ensure no performance regression (merge requirement, regressions here will be significant)