### PR TITLE
test: add node20 toolchain tests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,6 +73,13 @@ node_dev = use_extension(
     dev_dependency = True,
 )
 use_repo(node_dev, "nodejs_toolchains")
+use_repo(node_dev, "node20_linux_amd64")
+use_repo(node_dev, "node20_darwin_arm64")
+use_repo(node_dev, "node20_darwin_amd64")
+use_repo(node_dev, "node20_linux_arm64")
+use_repo(node_dev, "node20_linux_s390x")
+use_repo(node_dev, "node20_linux_ppc64le")
+use_repo(node_dev, "node20_windows_amd64")
 use_repo(node_dev, "node18_linux_amd64")
 use_repo(node_dev, "node18_darwin_arm64")
 use_repo(node_dev, "node18_darwin_amd64")
@@ -95,6 +102,10 @@ node_dev.toolchain(
 node_dev.toolchain(
     name = "node18",
     node_version = "18.13.0",
+)
+node_dev.toolchain(
+    name = "node20",
+    node_version = "20.11.1",
 )
 
 ############################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,6 +49,11 @@ nodejs_register_toolchains(
     node_version = "18.13.0",
 )
 
+nodejs_register_toolchains(
+    name = "node20",
+    node_version = "20.11.1",
+)
+
 load("@bazel_skylib//lib:unittest.bzl", "register_unittest_toolchains")
 
 register_unittest_toolchains()

--- a/js/private/test/node-patches/BUILD.bazel
+++ b/js/private/test/node-patches/BUILD.bazel
@@ -14,6 +14,7 @@ TESTS = [
 TOOLCHAINS_NAMES = [
     "node16",
     "node18",
+    "node20",
 ]
 
 TOOLCHAINS_VERSIONS = [
@@ -26,6 +27,11 @@ TOOLCHAINS_VERSIONS = [
         "@bazel_tools//src/conditions:linux_x86_64": "@node18_linux_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:darwin": "@node18_darwin_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:windows": "@node18_windows_amd64//:node_toolchain",
+    }),
+    select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@node20_linux_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:darwin": "@node20_darwin_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:windows": "@node20_windows_amd64//:node_toolchain",
     }),
 ]
 

--- a/js/private/test/node-patches_legacy/BUILD.bazel
+++ b/js/private/test/node-patches_legacy/BUILD.bazel
@@ -14,6 +14,7 @@ TESTS = [
 TOOLCHAINS_NAMES = [
     "node16",
     "node18",
+    "node20",
 ]
 
 TOOLCHAINS_VERSIONS = [
@@ -26,6 +27,11 @@ TOOLCHAINS_VERSIONS = [
         "@bazel_tools//src/conditions:linux_x86_64": "@node18_linux_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:darwin": "@node18_darwin_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:windows": "@node18_windows_amd64//:node_toolchain",
+    }),
+    select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@node20_linux_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:darwin": "@node20_darwin_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:windows": "@node20_windows_amd64//:node_toolchain",
     }),
 ]
 


### PR DESCRIPTION
I don't recall what originally prompted adding node v20 tests, but we probably should have basic node20 tests since it is LTS now.