### PR TITLE
chore: export npm_import /package folder in BUILD file

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -598,7 +598,7 @@ bin = bin_factory("node_modules")
                     name = link_package.split("/")[-1] or package_name_no_scope,
                     src = _PACKAGE_JSON_BZL_FILENAME,
                 ))
-            rctx_files[build_file].append("""exports_files(["{}"])""".format(_PACKAGE_JSON_BZL_FILENAME))
+            rctx_files[build_file].append("""exports_files(["{}", "{}"])""".format(_PACKAGE_JSON_BZL_FILENAME, _EXTRACT_TO_DIRNAME))
 
     rules_js_metadata = {}
     if rctx.attr.lifecycle_hooks:


### PR DESCRIPTION
The file is already an input to the graph via an alias but it should be in exports_files incase the alias is removed in the future.

---

### Type of change

- Chore

### Test plan

- Covered by existing test cases