### PR TITLE
[bzlmod] Mark npm extension as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 # Do not bump these unless rules_js requires a newer version to function.
 bazel_dep(name = "aspect_bazel_lib", version = "1.40.3")
 bazel_dep(name = "aspect_rules_lint", version = "0.12.0")
-bazel_dep(name = "bazel_features", version = "0.1.0")
+bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 
 # Keep v5 in to avoid breaking changes.

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -2,6 +2,7 @@
 See https://bazel.build/docs/bzlmod#extension-definition
 """
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
 load("//npm:repositories.bzl", "npm_import", "pnpm_repository", _LATEST_PNPM_VERSION = "LATEST_PNPM_VERSION")
 load("//npm/private:npm_translate_lock.bzl", "npm_translate_lock", "npm_translate_lock_lib")
@@ -212,6 +213,12 @@ WARNING: Cannot determine home directory in order to load home `.npmrc` file in 
                 register_copy_directory_toolchains = False,  # this registration is handled elsewhere with bzlmod
                 register_copy_to_directory_toolchains = False,  # this registration is handled elsewhere with bzlmod
             )
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(
+            reproducible = True,
+        )
+    return module_ctx.extension_metadata()
 
 def _npm_translate_lock_attrs():
     attrs = dict(**npm_translate_lock_lib.attrs)


### PR DESCRIPTION
This stops duplicating all the info from the pnpm lockfile into the Bazel one. Tested by upgrading to Bazel 7.1.1 and `bazel test --lockfile_mode=update //...`. Lockfile dropped from 79K lines to 4.4K.

There are still some gains to be had from python and go rules also using deterministic node, but that's outside the scope of this PR.