### PR TITLE
refactor: remove aspect_rules_js.npm. repo-name logic

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -701,8 +701,6 @@ def _npm_import_links_rule_impl(rctx):
 
     # strip _links post-fix to get the repository name of the npm sources
     npm_import_sources_repo_name = rctx.name[:-len(utils.links_repo_suffix)]
-    if npm_import_sources_repo_name.startswith("aspect_rules_js.npm."):
-        npm_import_sources_repo_name = npm_import_sources_repo_name[len("aspect_rules_js.npm."):]
 
     if rctx.attr.replace_package:
         npm_package_target = rctx.attr.replace_package

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -372,8 +372,6 @@ ERROR: patch_args for package {package} contains a strip prefix that is incompat
         custom_postinstall = " && ".join([c for c in custom_postinstalls if c])
 
         repo_name = "{}__{}".format(attr.name, utils.bazel_name(name, version))
-        if repo_name.startswith("aspect_rules_js.npm."):
-            repo_name = repo_name[len("aspect_rules_js.npm."):]
 
         # gather package visibility
         package_visibility, _ = _gather_values_from_matching_names(True, attr.package_visibility, "*", name, friendly_name, unfriendly_name)


### PR DESCRIPTION
This seems unused now?

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases
