### PR TITLE
fix: change order of node_modules and app in `js_image_layer`

### DIFF
--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -284,7 +284,7 @@ def _js_image_layer_impl(ctx):
     node_modules = _build_layer(ctx, type = "node_modules", entries = node_modules_entries, inputs = node_modules_inputs)
 
     return [
-        DefaultInfo(files = depset([app, node_modules])),
+        DefaultInfo(files = depset([node_modules, app])),
         OutputGroupInfo(app = depset([app]), node_modules = depset([node_modules])),
     ]
 


### PR DESCRIPTION
Usually, application's `node_modules` don't change often, as a application `code`, so I suggest to provide "strong" default: `[node_modules, app]`


### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

Suggested release notes are provided below:

Make the `node_modules` layer the first in the `js_image_layer` rule, as the `node_module` don't change often.


### Test plan

- Covered by existing test cases
