### PR TITLE
perf: don't set JsInfo declarations and transitive_declarations in npm_link_package_store

### DIFF
--- a/js/private/test/js_library_test.bzl
+++ b/js/private/test/js_library_test.bzl
@@ -39,15 +39,9 @@ def _declarations_test_impl(ctx):
 
     # transitive_declarations should have the source declarations and transitive declarations
     transitive_declarations = target_under_test[JsInfo].transitive_declarations.to_list()
-
-    # the transitive count might be 3 or 4 depending on the type of symlink created.
-    # See utils.make_symlink()
-    asserts.true(env, len(transitive_declarations) == 3 or len(transitive_declarations) == 4)
+    asserts.true(env, len(transitive_declarations) == 2)
     asserts.true(env, transitive_declarations[0].path.find("/importing.d.ts") != -1)
     asserts.true(env, transitive_declarations[1].path.find("/data.json") != -1)
-    asserts.true(env, transitive_declarations[2].path.find("/@types/node") != -1)
-    if len(transitive_declarations) == 4:
-        asserts.true(env, transitive_declarations[3].path.find("/@types/node") != -1)
 
     # types OutputGroupInfo should be the same as direct declarations
     asserts.equals(env, declarations, target_under_test[OutputGroupInfo].types.to_list())
@@ -66,15 +60,9 @@ def _explicit_declarations_test_impl(ctx):
 
     # transitive_declarations should have the source declarations and transitive declarations
     transitive_declarations = target_under_test[JsInfo].transitive_declarations.to_list()
-
-    # the transitive count might be 3 or 4 depending on the type of symlink created.
-    # See utils.make_symlink()
-    asserts.true(env, len(transitive_declarations) == 3 or len(transitive_declarations) == 4)
+    asserts.true(env, len(transitive_declarations) == 2)
     asserts.true(env, transitive_declarations[0].path.find("/data.json") != -1)
     asserts.true(env, transitive_declarations[1].path.find("/index.js") != -1)
-    asserts.true(env, transitive_declarations[2].path.find("/@types/node") != -1)
-    if len(transitive_declarations) == 4:
-        asserts.true(env, transitive_declarations[3].path.find("/@types/node") != -1)
 
     # types OutputGroupInfo should be the same as direct declarations
     asserts.equals(env, declarations, target_under_test[OutputGroupInfo].types.to_list())

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -126,9 +126,6 @@ def _npm_link_package_store_impl(ctx):
             runfiles = ctx.runfiles(transitive_files = transitive_files_depset),
         ),
         js_info(
-            # assume a directory contains declarations since we can't know that it doesn't
-            declarations = files_depset,
-            transitive_declarations = transitive_files_depset,
             npm_linked_package_files = files_depset,
             npm_linked_packages = depset([npm_linked_package_info]),
             # only propagate non-dev npm dependencies to use as direct dependencies when linking downstream npm_package targets with npm_link_package


### PR DESCRIPTION
While working on the rules_js 2.0 branch where I thought I needed to make changes to the JsInfo provider to get this perf improvement, I realized that the source of the issue is that `npm_link_package_store` sets `declarations` and `transitive_declarations` which it does not need to set since linked npm packages are already in runfiles for runtime dependencies and ts_project doesn't need them in declarations.

The perf improvement here is that npm_package (when include_runfiles is set to False) will no longer get all npm packages in its manifest. In rules_js 2.0, npm_package include_runfiles can flip to False and this perf improvement will be the default case.

---

### Type of change

- Performance (a code change that improves performance)

### Test plan

- Covered by existing test cases
