### PR TITLE
fix: bump minimum bazel-lib version to 1.42.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 # Lower-bounds for runtime dependencies.
 # Do not bump these unless rules_js requires a newer version to function.
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_lint", version = "0.12.0")
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.6.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.6.1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 
 local_path_override(

--- a/e2e/gyp_no_install_script/MODULE.bazel
+++ b/e2e/gyp_no_install_script/MODULE.bazel
@@ -1,4 +1,4 @@
-bazel_dep(name = "aspect_bazel_lib", version = "2.6.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.6.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/gyp_no_install_script/WORKSPACE
+++ b/e2e/gyp_no_install_script/WORKSPACE
@@ -7,9 +7,9 @@ local_repository(
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "3e0a430ada9b8f0f845767a267cf584bc94b8ec642d6093f31dca3938b18f6a1",
-    strip_prefix = "bazel-lib-2.6.0",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.6.0/bazel-lib-v2.6.0.tar.gz",
+    sha256 = "ac6392cbe5e1cc7701bbd81caf94016bae6f248780e12af4485d4a7127b4cb2b",
+    strip_prefix = "bazel-lib-2.6.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")

--- a/e2e/js_run_devserver/MODULE.bazel
+++ b/e2e/js_run_devserver/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_go", version = "0.46.0")

--- a/e2e/npm_translate_lock/MODULE.bazel
+++ b/e2e/npm_translate_lock/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_auth/MODULE.bazel
+++ b/e2e/npm_translate_lock_auth/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_empty/MODULE.bazel
+++ b/e2e/npm_translate_lock_empty/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_git+ssh/MODULE.bazel
+++ b/e2e/npm_translate_lock_git+ssh/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_multi/MODULE.bazel
+++ b/e2e/npm_translate_lock_multi/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/npm_translate_lock_partial_clone/MODULE.bazel
+++ b/e2e/npm_translate_lock_partial_clone/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_lock_subdir_patch/MODULE.bazel
+++ b/e2e/npm_translate_lock_subdir_patch/MODULE.bazel
@@ -1,4 +1,4 @@
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/npm_translate_package_lock/MODULE.bazel
+++ b/e2e/npm_translate_package_lock/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/npm_translate_yarn_lock/MODULE.bazel
+++ b/e2e/npm_translate_yarn_lock/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/package_json_module/MODULE.bazel
+++ b/e2e/package_json_module/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/patch_from_repo/MODULE.bazel
+++ b/e2e/patch_from_repo/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 bazel_dep(name = "local_repo", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_nodejs", version = "6.0.5")
-bazel_dep(name = "aspect_bazel_lib", version = "2.6.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.6.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace/WORKSPACE
+++ b/e2e/pnpm_workspace/WORKSPACE
@@ -7,9 +7,9 @@ local_repository(
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "3e0a430ada9b8f0f845767a267cf584bc94b8ec642d6093f31dca3938b18f6a1",
-    strip_prefix = "bazel-lib-2.6.0",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.6.0/bazel-lib-v2.6.0.tar.gz",
+    sha256 = "ac6392cbe5e1cc7701bbd81caf94016bae6f248780e12af4485d4a7127b4cb2b",
+    strip_prefix = "bazel-lib-2.6.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_coreutils_toolchains")

--- a/e2e/pnpm_workspace_deps/MODULE.bazel
+++ b/e2e/pnpm_workspace_deps/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.6.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.6.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace_deps/WORKSPACE
+++ b/e2e/pnpm_workspace_deps/WORKSPACE
@@ -7,9 +7,9 @@ local_repository(
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "3e0a430ada9b8f0f845767a267cf584bc94b8ec642d6093f31dca3938b18f6a1",
-    strip_prefix = "bazel-lib-2.6.0",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.6.0/bazel-lib-v2.6.0.tar.gz",
+    sha256 = "ac6392cbe5e1cc7701bbd81caf94016bae6f248780e12af4485d4a7127b4cb2b",
+    strip_prefix = "bazel-lib-2.6.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_coreutils_toolchains")

--- a/e2e/pnpm_workspace_rerooted/MODULE.bazel
+++ b/e2e/pnpm_workspace_rerooted/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "rules_nodejs", version = "6.0.5")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/stamped_package_json/MODULE.bazel
+++ b/e2e/stamped_package_json/MODULE.bazel
@@ -4,7 +4,7 @@ module(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.6.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.6.1")
 
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/update_pnpm_lock/MODULE.bazel
+++ b/e2e/update_pnpm_lock/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/update_pnpm_lock_with_import/MODULE.bazel
+++ b/e2e/update_pnpm_lock_with_import/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/vendored_node/MODULE.bazel
+++ b/e2e/vendored_node/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 bazel_dep(name = "rules_nodejs", version = "6.0.5")
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/e2e/vendored_tarfile/MODULE.bazel
+++ b/e2e/vendored_tarfile/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/verify_patches/MODULE.bazel
+++ b/e2e/verify_patches/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/webpack_devserver/MODULE.bazel
+++ b/e2e/webpack_devserver/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_go", version = "0.46.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/webpack_devserver_esm/MODULE.bazel
+++ b/e2e/webpack_devserver_esm/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_go", version = "0.46.0")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -23,9 +23,9 @@ def rules_js_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "6e729e4900695623efa5e9c73b10b0509eb1606b73cafc374a359aed4c9e6958",
-        strip_prefix = "bazel-lib-1.42.0",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.42.0/bazel-lib-v1.42.0.tar.gz",
+        sha256 = "f9a0bb072aef719859aae5ad37722e97812ffffb263fd56a36cd8614a2e5d199",
+        strip_prefix = "bazel-lib-1.42.2",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.42.2/bazel-lib-v1.42.2.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
bazel-lib 1.42.2 updates the bsdtar toolchain to use a pre-build binary that is linked against musl instead of glibc. this drops the system dep on glibc for the npm package extract action.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
