### PR TITLE
fix: add cannonical_id to npm_import

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -467,6 +467,7 @@ def _download_and_extract_archive(rctx, package_json_only):
         url = download_url,
         integrity = rctx.attr.integrity,
         auth = auth,
+        canonical_id = download_url,
     )
 
     mkdir_args = ["mkdir", "-p", _EXTRACT_TO_DIRNAME] if not repo_utils.is_windows(rctx) else ["cmd", "/c", "if not exist {extract_to_dirname} (mkdir {extract_to_dirname})".format(extract_to_dirname = _EXTRACT_TO_DIRNAME.replace("/", "\\"))]


### PR DESCRIPTION
This prevents npm_import from pulling data with the same integrity.

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

TBD


TL;DR: @joeljeske and I discovered a situation where the SHA mismatched on a url pull through and this needed to be added to fix 

https://docs.bazel.build/versions/3.0.0/repo/http.html#http_archive-canonical_id
