### PR TITLE
chore: hoist more TODOS to 2.0

### DIFF
--- a/js/private/coverage/merger.bzl
+++ b/js/private/coverage/merger.bzl
@@ -16,7 +16,7 @@ _ATTRS = {
 # Do the opposite of _to_manifest_path in
 # https://github.com/bazelbuild/rules_nodejs/blob/8b5d27400db51e7027fe95ae413eeabea4856f8e/nodejs/toolchain.bzl#L50
 # to get back to the short_path.
-# TODO: fix toolchain so we don't have to do this
+# TODO(2.0): fix toolchain so we don't have to do this
 def _target_tool_path_to_short_path(tool_path):
     return ("../" + tool_path[len("external/"):]) if tool_path.startswith("external/") else tool_path
 

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -326,12 +326,12 @@ _NODE_OPTION = """JS_BINARY__NODE_OPTIONS+=(\"{value}\")"""
 # Do the opposite of _to_manifest_path in
 # https://github.com/bazelbuild/rules_nodejs/blob/8b5d27400db51e7027fe95ae413eeabea4856f8e/nodejs/toolchain.bzl#L50
 # to get back to the short_path.
-# TODO: fix toolchain so we don't have to do this
+# TODO(2.0): fix toolchain so we don't have to do this
 def _target_tool_path_to_short_path(tool_path):
     return ("../" + tool_path[len("external/"):]) if tool_path.startswith("external/") else tool_path
 
 # Generate a consistent label string between Bazel versions.
-# TODO: hoist this function to bazel-lib and use from there (as well as the dup in npm/private/utils.bzl)
+# TODO(2.0): hoist this function to bazel-lib and use from there (as well as the dup in npm/private/utils.bzl)
 def _consistent_label_str(workspace_name, label):
     # Starting in Bazel 6, the workspace name is empty for the local workspace and there's no other way to determine it.
     # This behavior differs from Bazel 5 where the local workspace name was fully qualified in str(label).

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -506,7 +506,6 @@ def _has_strip_prefix_arg(patch_args, strip_num = None):
     return False
 
 ################################################################################
-# TODO: move to bazel-lib?
 def _to_apparent_repo_name(canonical_name):
     return canonical_name[canonical_name.rfind("~") + 1:]
 

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -404,7 +404,7 @@ if [ ! -f $1 ]; then exit 42; fi
     else:
         fail(INTERNAL_ERROR_MSG)
 
-# TODO: move this to aspect_bazel_lib
+# TODO(2.0): move this to aspect_bazel_lib
 def _home_directory(rctx):
     if "HOME" in rctx.os.environ and not repo_utils.is_windows(rctx):
         return rctx.os.environ["HOME"]


### PR DESCRIPTION
Start of the rules_js 2.0 train stars with a few hoisted TODOs that are handled on the stack.