### PR TITLE
refactor: remove deprecated lifecycle_hooks_no_sandbox from npm_import

### DIFF
--- a/docs/npm_import.md
+++ b/docs/npm_import.md
@@ -29,8 +29,7 @@ npm_import(<a href="#npm_import-name">name</a>, <a href="#npm_import-package">pa
            <a href="#npm_import-lifecycle_hooks_env">lifecycle_hooks_env</a>, <a href="#npm_import-lifecycle_hooks_use_default_shell_env">lifecycle_hooks_use_default_shell_env</a>, <a href="#npm_import-integrity">integrity</a>, <a href="#npm_import-url">url</a>, <a href="#npm_import-commit">commit</a>,
            <a href="#npm_import-replace_package">replace_package</a>, <a href="#npm_import-package_visibility">package_visibility</a>, <a href="#npm_import-patch_args">patch_args</a>, <a href="#npm_import-patches">patches</a>, <a href="#npm_import-custom_postinstall">custom_postinstall</a>, <a href="#npm_import-npm_auth">npm_auth</a>,
            <a href="#npm_import-npm_auth_basic">npm_auth_basic</a>, <a href="#npm_import-npm_auth_username">npm_auth_username</a>, <a href="#npm_import-npm_auth_password">npm_auth_password</a>, <a href="#npm_import-bins">bins</a>, <a href="#npm_import-dev">dev</a>,
-           <a href="#npm_import-register_copy_directory_toolchains">register_copy_directory_toolchains</a>, <a href="#npm_import-register_copy_to_directory_toolchains">register_copy_to_directory_toolchains</a>,
-           <a href="#npm_import-lifecycle_hooks_no_sandbox">lifecycle_hooks_no_sandbox</a>, <a href="#npm_import-kwargs">kwargs</a>)
+           <a href="#npm_import-register_copy_directory_toolchains">register_copy_directory_toolchains</a>, <a href="#npm_import-register_copy_to_directory_toolchains">register_copy_to_directory_toolchains</a>, <a href="#npm_import-kwargs">kwargs</a>)
 </pre>
 
 Import a single npm package into Bazel.
@@ -164,7 +163,6 @@ Read more about the downloader config: &lt;https://blog.aspect.dev/configuring-b
 | <a id="npm_import-dev"></a>dev |  Whether this npm package is a dev dependency   |  <code>False</code> |
 | <a id="npm_import-register_copy_directory_toolchains"></a>register_copy_directory_toolchains |  if True, <code>@aspect_bazel_lib//lib:repositories.bzl</code> <code>register_copy_directory_toolchains()</code> is called if the toolchain is not already registered   |  <code>True</code> |
 | <a id="npm_import-register_copy_to_directory_toolchains"></a>register_copy_to_directory_toolchains |  if True, <code>@aspect_bazel_lib//lib:repositories.bzl</code> <code>register_copy_to_directory_toolchains()</code> is called if the toolchain is not already registered   |  <code>True</code> |
-| <a id="npm_import-lifecycle_hooks_no_sandbox"></a>lifecycle_hooks_no_sandbox |  If True, adds "no-sandbox" to <code>lifecycle_hooks_execution_requirements</code>.<br><br>Deprecated. Add "no-sandbox" to <code>lifecycle_hooks_execution_requirements</code> instead.   |  <code>None</code> |
 | <a id="npm_import-kwargs"></a>kwargs |  Internal use only   |  none |
 
 

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -193,7 +193,6 @@ WARNING: Cannot determine home directory in order to load home `.npmrc` file in 
                 lifecycle_hooks = i.lifecycle_hooks,
                 lifecycle_hooks_env = i.lifecycle_hooks_env,
                 lifecycle_hooks_execution_requirements = i.lifecycle_hooks_execution_requirements,
-                lifecycle_hooks_no_sandbox = i.lifecycle_hooks_no_sandbox,
                 lifecycle_hooks_use_default_shell_env = i.lifecycle_hooks_use_default_shell_env,
                 link_packages = i.link_packages,
                 link_workspace = i.link_workspace,

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -914,8 +914,6 @@ def npm_import(
         dev = False,
         register_copy_directory_toolchains = True,
         register_copy_to_directory_toolchains = True,
-        # TODO(2.0): remove lifecycle_hooks_no_sandbox from npm_import
-        lifecycle_hooks_no_sandbox = None,
         **kwargs):
     """Import a single npm package into Bazel.
 
@@ -1164,10 +1162,6 @@ def npm_import(
 
         register_copy_to_directory_toolchains: if True, `@aspect_bazel_lib//lib:repositories.bzl` `register_copy_to_directory_toolchains()` is called if the toolchain is not already registered
 
-        lifecycle_hooks_no_sandbox: If True, adds "no-sandbox" to `lifecycle_hooks_execution_requirements`.
-
-            Deprecated. Add "no-sandbox" to `lifecycle_hooks_execution_requirements` instead.
-
         **kwargs: Internal use only
     """
 
@@ -1209,10 +1203,6 @@ def npm_import(
         generate_bzl_library_targets = generate_bzl_library_targets,
         extract_full_archive = extract_full_archive,
     )
-
-    if lifecycle_hooks_no_sandbox:
-        if "no-sandbox" not in lifecycle_hooks_execution_requirements:
-            lifecycle_hooks_execution_requirements.append("no-sandbox")
 
     has_custom_postinstall = not (not custom_postinstall)
     has_lifecycle_hooks = not (not lifecycle_hooks)


### PR DESCRIPTION
NB: `lifecycle_hooks_no_sandbox` still exists on `npm_translate_lock`. This changes only removes it from `npm_import` where it is deprecated.