### PR TITLE
fix: drop .sh extension from js_binary, merger and js_image_layer launchers

### DIFF
--- a/e2e/worker/BUILD.bazel
+++ b/e2e/worker/BUILD.bazel
@@ -16,7 +16,7 @@ copy_file(
 )
 
 js_binary(
-    name = "worker",
+    name = "worker_binary",
     data = [":copy_worker_js"],
     entry_point = ":copy_dummy_worker",
     visibility = ["//visibility:public"],

--- a/e2e/worker/defs.bzl
+++ b/e2e/worker/defs.bzl
@@ -31,7 +31,7 @@ pi_rule = rule(
         "worker": attr.label(
             executable = True,
             cfg = "exec",
-            default = ":worker",
+            default = ":worker_binary",
         ),
     },
 )

--- a/examples/coverage/BUILD.bazel
+++ b/examples/coverage/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_test")
 
 js_test(
-    name = "coverage",
+    name = "coverage_test",
     data = [
         "coverage.js",
         "//:node_modules/@types/node",

--- a/examples/js_binary/BUILD.bazel
+++ b/examples/js_binary/BUILD.bazel
@@ -471,7 +471,7 @@ write_file(
         { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
         # --- end runfiles.bash initialization v2 ---
 
-        $(rlocation aspect_rules_js/examples/js_binary/bin10-js_binary.sh) "$@"
+        $(rlocation aspect_rules_js/examples/js_binary/bin10-js_binary) "$@"
 """],
 )
 

--- a/js/private/coverage/merger.bzl
+++ b/js/private/coverage/merger.bzl
@@ -25,7 +25,7 @@ def _coverage_merger_impl(ctx):
     node_bin = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo
 
     # Create launcher
-    bash_launcher = ctx.actions.declare_file("%s.sh" % ctx.label.name)
+    bash_launcher = ctx.actions.declare_file(ctx.label.name)
     node_path = _target_tool_path_to_short_path(ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo.target_tool_path)
     ctx.actions.expand_template(
         template = ctx.file._launcher_template,

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -445,7 +445,7 @@ def _bash_launcher(ctx, node_toolchain, entry_point_path, log_prefix_rule_set, l
         "{{workspace_name}}": ctx.workspace_name,
     }
 
-    launcher = ctx.actions.declare_file("%s.sh" % ctx.label.name)
+    launcher = ctx.actions.declare_file(ctx.label.name)
     ctx.actions.expand_template(
         template = ctx.file._launcher_template,
         output = launcher,

--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -180,7 +180,7 @@ source {executable_path}
 
 def _write_laucher(ctx, executable_path):
     "Creates a call-through shell entrypoint which sets BAZEL_BINDIR to '.' then immediately invokes the original entrypoint."
-    launcher = ctx.actions.declare_file("%s_launcher.sh" % ctx.label.name)
+    launcher = ctx.actions.declare_file("%s_launcher" % ctx.label.name)
     ctx.actions.write(
         output = launcher,
         content = _LAUNCHER_TMPL.format(executable_path = executable_path),

--- a/js/private/test/image/checksum.expected
+++ b/js/private/test/image/checksum.expected
@@ -1,2 +1,2 @@
-2bba6ae0e3552778539f8abf49d6589b0b638ccb1ac5a9b8b816ab18b5adb12b  js/private/test/image/cksum_app.tar
+6477f43b8663b593b7eb3ba50f7b617849eca2d2ecccdba37a92b0c9faf1226c  js/private/test/image/cksum_app.tar
 813d54ae63067f19103e13f616726ff1f32cf8d51e27789b8d31415300f0a69e  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/custom_owner_app.listing
+++ b/js/private/test/image/custom_owner_app.listing
@@ -3,14 +3,14 @@ drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image
--r-xr-xr-x 100/0           134 1970-01-01 00:00 app/js/private/test/image/bin
+-r-xr-xr-x 100/0           131 1970-01-01 00:00 app/js/private/test/image/bin
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image
--r-xr-xr-x 100/0         23993 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin.sh
+-r-xr-xr-x 100/0         24130 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin
 -r-xr-xr-x 100/0           133 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x 100/0            20 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/main.js

--- a/js/private/test/image/default_app.listing
+++ b/js/private/test/image/default_app.listing
@@ -3,14 +3,14 @@ drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image
--r-xr-xr-x 0/0             134 1970-01-01 00:00 app/js/private/test/image/bin
+-r-xr-xr-x 0/0             131 1970-01-01 00:00 app/js/private/test/image/bin
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image
--r-xr-xr-x 0/0           23993 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin.sh
+-r-xr-xr-x 0/0           24130 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin
 -r-xr-xr-x 0/0             133 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x 0/0              20 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/main.js


### PR DESCRIPTION
Fixes #845