### PR TITLE
fix: add package_visibility support to npm_translate_lock and npm_import on bzlmod

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -169,6 +169,7 @@ WARNING: Cannot determine home directory in order to load home `.npmrc` file in 
                     npm_auth_password = i.npm_auth_password,
                     npm_auth_username = i.npm_auth_username,
                     package = i.package,
+                    package_visibility = i.package_visibility,
                     patch_args = i.patch_args,
                     patches = i.patches,
                     replace_package = i.replace_package,
@@ -202,6 +203,7 @@ WARNING: Cannot determine home directory in order to load home `.npmrc` file in 
                 npm_auth_username = i.npm_auth_username,
                 npm_auth_password = i.npm_auth_password,
                 package = i.package,
+                package_visibility = i.package_visibility,
                 patch_args = i.patch_args,
                 patches = i.patches,
                 replace_package = i.replace_package,
@@ -251,6 +253,7 @@ def _npm_import_attrs():
     # Args defaulted differently by the macro
     attrs["lifecycle_hooks_execution_requirements"] = attr.string_list(default = ["no-sandbox"])
     attrs["patch_args"] = attr.string_list(default = ["-p0"])
+    attrs["package_visibility"] = attr.string_list(default = ["//visibility:public"])
 
     return attrs
 

--- a/npm/private/test/snapshots/bzlmod/unused_links_defs.bzl
+++ b/npm/private/test/snapshots/bzlmod/unused_links_defs.bzl
@@ -116,7 +116,7 @@ def npm_link_imported_package_store(name):
         name = name,
         package = link_alias,
         src = "//:{}".format(store_target_name),
-        visibility = ["//visibility:public"],
+        visibility = ["//visibility:private"],
         tags = ["manual"],
         use_declare_symlink = select({
             "@aspect_rules_js//js:allow_unresolved_symlinks": True,
@@ -130,11 +130,11 @@ def npm_link_imported_package_store(name):
         name = "{}/dir".format(name),
         srcs = [":{}".format(name)],
         output_group = "package_directory",
-        visibility = ["//visibility:public"],
+        visibility = ["//visibility:private"],
         tags = ["manual"],
     )
 
-    return [":{}".format(name)] if True else []
+    return [":{}".format(name)] if False else []
 
 # Generated npm_package_store and npm_link_package_store targets for npm package unused@0.2.2
 # buildifier: disable=function-docstring
@@ -169,7 +169,7 @@ def npm_link_imported_package(
         for link_alias in link_aliases:
             link_target_name = "{}/{}".format(name, link_alias)
             npm_link_imported_package_store(name = link_target_name)
-            if True:
+            if False:
                 link_targets.append(":{}".format(link_target_name))
                 if len(link_alias.split("/", 1)) > 1:
                     link_scope = link_alias.split("/", 1)[0]


### PR DESCRIPTION
This was missed when `package_visibility` support was added

---

### Type of change`

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
