### PR TITLE
perf: reduce size of npm_package_store transitive_files depset

### DIFF
--- a/examples/genrule/BUILD.bazel
+++ b/examples/genrule/BUILD.bazel
@@ -67,7 +67,9 @@ genrule(
     name = "require_acorn",
     srcs = [
         ":require_acorn_js",
+        # reference the location where the "acorn" npm package was linked in our root Bazel package.
         "//:node_modules/acorn",
+        "//:node_modules/acorn/dir",
     ],
     outs = ["out2"],
     cmd = """

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -80,7 +80,7 @@ def _npm_link_package_store_impl(ctx):
     # "node_modules/{package}" so it is available as a direct dependency
     root_symlink_path = paths.join("node_modules", package)
 
-    files = utils.make_symlink(ctx, root_symlink_path, virtual_store_directory)
+    files = [utils.make_symlink(ctx, root_symlink_path, virtual_store_directory)]
 
     for bin_name, bin_path in ctx.attr.bins.items():
         bin_file = ctx.actions.declare_file(paths.join("node_modules", ".bin", bin_name))

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -253,7 +253,6 @@ def _virtual_store_name(name, version):
         return "%s@%s" % (escaped_name, escaped_version)
 
 def _make_symlink(ctx, symlink_path, target_file):
-    files = []
     if not is_bazel_6_or_greater():
         # ctx.actions.declare_symlink was added in Bazel 6
         fail("A minimum version of Bazel 6 required to use rules_js")
@@ -262,9 +261,7 @@ def _make_symlink(ctx, symlink_path, target_file):
         output = symlink,
         target_path = relative_file(target_file.path, symlink.path),
     )
-    files.append(target_file)
-    files.append(symlink)
-    return files
+    return symlink
 
 def _parse_package_name(package):
     # Parse a @scope/name string and return a (scope, name) tuple


### PR DESCRIPTION
I've been waiting to make this optimization for a long time

BREAKING CHANGES:

If using npm packages with genrule, the default output of a target such as `//:node_modules/foo` is _only_ the link directory so if you will also need to add `//:node_modules/foo/dir` which is the virtual store directory to the genrule srcs.