### PR TITLE
chore: test against latest rules_nodejs release 6.1.0 to ensure backward compat that release with rules_js 1.x

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "rules_nodejs", version = "5.8.2")
 # Override rules_nodejs to v6 to test the latest and recommended version internally.
 single_version_override(
     module_name = "rules_nodejs",
-    version = "6.0.5",
+    version = "6.1.0",
 )
 
 bazel_dep(name = "platforms", version = "0.0.5")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,9 +10,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # TODO(2.0): change minimum to v6 in repositories.bzl
 http_archive(
     name = "rules_nodejs",
-    sha256 = "a50986c7d2f2dc43a5b9b81a6245fd89bdc4866f1d5e316d9cef2782dd859292",
-    strip_prefix = "rules_nodejs-6.0.5",
-    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.0.5/rules_nodejs-v6.0.5.tar.gz",
+    sha256 = "dddd60acc3f2f30359bef502c9d788f67e33814b0ddd99aa27c5a15eb7a41b8c",
+    strip_prefix = "rules_nodejs-6.1.0",
+    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.0/rules_nodejs-v6.1.0.tar.gz",
 )
 
 load("//js:dev_repositories.bzl", "rules_js_dev_dependencies")

--- a/e2e/pnpm_repo_install/MODULE.bazel
+++ b/e2e/pnpm_repo_install/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_nodejs", version = "6.0.5")
+bazel_dep(name = "rules_nodejs", version = "6.1.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",

--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "rules_nodejs", version = "6.0.5")
+bazel_dep(name = "rules_nodejs", version = "6.1.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.6.1")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/pnpm_workspace_rerooted/MODULE.bazel
+++ b/e2e/pnpm_workspace_rerooted/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_nodejs", version = "6.0.5")
+bazel_dep(name = "rules_nodejs", version = "6.1.0")
 bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(

--- a/e2e/vendored_node/MODULE.bazel
+++ b/e2e/vendored_node/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.42.2")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
-bazel_dep(name = "rules_nodejs", version = "6.0.5")
+bazel_dep(name = "rules_nodejs", version = "6.1.0")
 bazel_dep(name = "platforms", version = "0.0.4")
 
 local_path_override(

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_nodejs", version = "6.0.5")
+bazel_dep(name = "rules_nodejs", version = "6.1.0")
 bazel_dep(name = "aspect_rules_js", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_js",


### PR DESCRIPTION
Does not bump the minimum version of rules_nodejs for rules_js 1.x. That will come soon with rules_js 2.0.