### PR TITLE
chore: enable branch_freshsness rebase strategy

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -227,7 +227,7 @@ workspaces:
     # e2e/webpack_devserver_esm:
 tasks:
     - branch_freshness:
-          update_strategy: none
+          update_strategy: rebase
     - test:
           hooks:
               - type: before_task


### PR DESCRIPTION
Latest 5.10 alpha version of Workflows running on rules_js has fixes to the rebase stategy.
