### PR TITLE
refactor: renamed gather_files_from_js_providers to gather_files_from_js_info

### DIFF
--- a/js/libs.bzl
+++ b/js/libs.bzl
@@ -14,7 +14,7 @@ load(
     _JS_LIBRARY_DATA_ATTR = "JS_LIBRARY_DATA_ATTR",
     _LOG_LEVELS = "LOG_LEVELS",
     _envs_for_log_level = "envs_for_log_level",
-    _gather_files_from_js_providers = "gather_files_from_js_providers",
+    _gather_files_from_js_info = "gather_files_from_js_info",
     _gather_npm_linked_packages = "gather_npm_linked_packages",
     _gather_npm_package_store_deps = "gather_npm_package_store_deps",
     _gather_runfiles = "gather_runfiles",
@@ -27,7 +27,7 @@ js_library_lib = _js_library_lib
 
 js_lib_helpers = struct(
     envs_for_log_level = _envs_for_log_level,
-    gather_files_from_js_providers = _gather_files_from_js_providers,
+    gather_files_from_js_info = _gather_files_from_js_info,
     gather_npm_linked_packages = _gather_npm_linked_packages,
     gather_npm_package_store_deps = _gather_npm_package_store_deps,
     gather_runfiles = _gather_runfiles,

--- a/js/private/js_helpers.bzl
+++ b/js/private/js_helpers.bzl
@@ -219,7 +219,7 @@ def gather_runfiles(
     ])
 
     # Gather files from JsInfo providers of data & deps
-    transitive_files_depsets.append(gather_files_from_js_providers(
+    transitive_files_depsets.append(gather_files_from_js_info(
         targets = data + deps,
         include_sources = include_sources,
         include_transitive_sources = include_transitive_sources,
@@ -282,7 +282,7 @@ def envs_for_log_level(log_level):
         envs.append("JS_BINARY__LOG_DEBUG")
     return envs
 
-def gather_files_from_js_providers(
+def gather_files_from_js_info(
         targets,
         include_sources,
         include_transitive_sources,

--- a/js/private/js_info_files.bzl
+++ b/js/private/js_info_files.bzl
@@ -1,6 +1,6 @@
 """Helper rule to gather files from JsInfo providers of targets and provide them as default outputs"""
 
-load("//js/private:js_helpers.bzl", _gather_files_from_js_providers = "gather_files_from_js_providers")
+load("//js/private:js_helpers.bzl", _gather_files_from_js_info = "gather_files_from_js_info")
 
 _DOC = """Gathers files from the JsInfo providers from targets in srcs and provides them as default outputs.
 
@@ -8,7 +8,7 @@ This helper rule is used by the `js_run_binary` macro.
 """
 
 def _js_info_files_impl(ctx):
-    return DefaultInfo(files = _gather_files_from_js_providers(
+    return DefaultInfo(files = _gather_files_from_js_info(
         targets = ctx.attr.srcs,
         include_sources = ctx.attr.include_sources,
         include_transitive_sources = ctx.attr.include_transitive_sources,

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -1,7 +1,7 @@
 "Implementation details for js_run_devserver rule"
 
 load(":js_binary.bzl", "js_binary_lib")
-load(":js_helpers.bzl", _gather_files_from_js_providers = "gather_files_from_js_providers")
+load(":js_helpers.bzl", _gather_files_from_js_info = "gather_files_from_js_info")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 _attrs = dicts.add(js_binary_lib.attrs, {
@@ -40,7 +40,7 @@ def _js_run_devserver_impl(ctx):
     if use_tool and ctx.attr.command:
         fail("Only one of tool or command may be specified")
 
-    transitive_runfiles = [_gather_files_from_js_providers(
+    transitive_runfiles = [_gather_files_from_js_info(
         targets = ctx.attr.data,
         include_sources = True,
         include_transitive_sources = ctx.attr.include_transitive_sources,

--- a/js/private/test/create_launcher/custom_test.bzl
+++ b/js/private/test/create_launcher/custom_test.bzl
@@ -19,7 +19,7 @@ def _custom_test_impl(ctx):
 
     runfiles = ctx.runfiles(
         files = ctx.files.data,
-        transitive_files = js_lib_helpers.gather_files_from_js_providers(
+        transitive_files = js_lib_helpers.gather_files_from_js_info(
             targets = ctx.attr.data,
             include_sources = True,
             include_transitive_sources = ctx.attr.include_transitive_sources,


### PR DESCRIPTION
`gather_files_from_js_info` is more descriptive since the function only gathers files from JsInfo and not from other providers