### PR TITLE
fix: set default internal npm_translate_lock state

### DIFF
--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -549,23 +549,16 @@ def _load_root_package_json(priv, rctx, label_store):
         priv["root_package_json"] = json.decode(rctx.read(root_package_json_path))
         return priv["root_package_json"]
 
-    lockfile_is_loaded = "importers" in priv
-    if lockfile_is_loaded:
-        # Load an undeclared package.json derived from the root importer in the lockfile
-        has_root_importer = "." in priv["importers"].keys()
-        if has_root_importer:
-            label_store.add_sibling("lock", "package_json_root", PACKAGE_JSON_FILENAME)
-            root_package_json_path = label_store.path("package_json_root")
-            priv["root_package_json"] = json.decode(rctx.read(root_package_json_path))
-        else:
-            # if there is no root importer that means there is no root package.json to read; pnpm allows
-            # you to just have a pnpm-workspaces.yaml at the root and no package.json at that location
-            priv["root_package_json"] = {}
+    # Load an undeclared package.json derived from the root importer in the lockfile
+    has_root_importer = "." in priv["importers"].keys()
+    if has_root_importer:
+        label_store.add_sibling("lock", "package_json_root", PACKAGE_JSON_FILENAME)
+        root_package_json_path = label_store.path("package_json_root")
+        priv["root_package_json"] = json.decode(rctx.read(root_package_json_path))
     else:
-        # The lockfile hasn't been loaded yet so we can't check for a root importer.
-        # Don't cache anything so that this method doesn't short-circuit when run again
-        # after the lockfile has been loaded.
-        return {}
+        # if there is no root importer that means there is no root package.json to read; pnpm allows
+        # you to just have a pnpm-workspaces.yaml at the root and no package.json at that location
+        priv["root_package_json"] = {}
 
     return priv["root_package_json"]
 
@@ -619,6 +612,7 @@ def _new(rctx):
         "npm_registries": {},
         "packages": {},
         "root_package": None,
+        "patched_dependencies": {},
         "should_update_pnpm_lock": should_update_pnpm_lock,
     }
 


### PR DESCRIPTION
When no `pnpm_lock` attribute is set the `patched_dependencies` never gets initialized. This fix just sets a default initial value for `patched_dependencies`, essentially the exact same as `importers` which has a default and is only overridden if a `pnpm_lock` is set.

I'm also dropping the `lockfile_is_loaded = "importers" in priv` since `importers` is set 100% of the time. The alternative (for `importers` and `patched_dependencies`) is to set the initial value to `None` and change how this works a bit. WDYT?

The only way I can reproduce this is having an e2e test with no `pnpm-lock.yaml`, then running the test updates the lockfile in the root of the repo. I'm not sure if that's it's own bug?

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Verified manually
