### PR TITLE
chore: disable windows tests on BCR pre-submit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
     module_path: 'e2e/bzlmod'
     matrix:
         bazel: ['7.x', '6.x']
-        platform: ['debian10', 'macos', 'ubuntu2004', 'windows']
+        platform: ['debian10', 'macos', 'ubuntu2004']
     tasks:
         run_tests:
             name: 'Run test module'


### PR DESCRIPTION
Currently broken in the BCR tho we have coverage for Windows on rules_js itself.

Failures on BCR running bsdtar.exe
```
(15:23:57) ERROR: C:/b/bk-windows-jcc1/bazel-org-repo-root/output/rules_js-1.41.0/e2e/bzlmod/BUILD.bazel:14:22: Extracting npm package semver@5.7.1 failed: (Exit -1073741515): bsdtar.exe failed: error executing command (from target //:.aspect_rules_js/node_modules/semver@5.7.1/pkg)
  cd /d C:/b/fcl55ko6/execroot/_main
external\aspect_bazel_lib~2.6.1~toolchains~bsd_tar_windows_amd64\libarchive\bin\bsdtar.exe --extract --no-same-owner --no-same-permissions --strip-components 1 --file external/aspect_rules_js~override~npm~npm__semver__5.7.1/package.tgz --directory bazel-out/x64_windows-fastbuild/bin/node_modules/.aspect_rules_js/semver@5.7.1/node_modules/semver
# Configuration: a4106bc7ddb7cd662fedb2c003cda6c3ad47b53fa65630739820561d06bbc036
# Execution platform: @local_config_platform//:host
```
 https://buildkite.com/bazel/bcr-presubmit/builds/4604

Not sure what is going on there since the tool runs fine on rules_js Windows CI on GitHub Actions: https://github.com/aspect-build/rules_js/actions/runs/8652713307/job/23726308777