### PR TITLE
chore: tweak make_symlink util to take a path instead of a File

### DIFF
--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -80,7 +80,7 @@ def _npm_link_package_store_impl(ctx):
     # "node_modules/{package}" so it is available as a direct dependency
     root_symlink_path = paths.join("node_modules", package)
 
-    files = [utils.make_symlink(ctx, root_symlink_path, package_store_directory)]
+    files = [utils.make_symlink(ctx, root_symlink_path, package_store_directory.path)]
 
     for bin_name, bin_path in ctx.attr.bins.items():
         bin_file = ctx.actions.declare_file(paths.join("node_modules", ".bin", bin_name))

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -234,7 +234,7 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
                 for dep_alias in dep_aliases:
                     # "node_modules/{package_store_root}/{package_store_name}/node_modules/{package}"
                     dep_symlink_path = paths.join("node_modules", utils.package_store_root, package_store_name, "node_modules", dep_alias)
-                    files.append(utils.make_symlink(ctx, dep_symlink_path, dep_package_store_directory))
+                    files.append(utils.make_symlink(ctx, dep_symlink_path, dep_package_store_directory.path))
             else:
                 # this is a ref npm_link_package, a downstream terminal npm_link_package
                 # for this npm dependency will create the dep symlinks for this dep;
@@ -251,7 +251,7 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
             if dep_package_store_directory not in linked_package_store_directories:
                 # "node_modules/{package_store_root}/{package_store_name}/node_modules/{package}"
                 dep_symlink_path = paths.join("node_modules", utils.package_store_root, package_store_name, "node_modules", dep_package)
-                files.append(utils.make_symlink(ctx, dep_symlink_path, dep_package_store_directory))
+                files.append(utils.make_symlink(ctx, dep_symlink_path, dep_package_store_directory.path))
                 npm_package_store_infos.append(store)
     else:
         # if ctx.attr.src is _not_ set then this is a terminal 3p package with ctx.attr.deps is
@@ -290,7 +290,7 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
                     for dep_ref_dep_alias in dep_ref_dep_aliases:
                         # "node_modules/{package_store_root}/{package_store_name}/node_modules/{package}"
                         dep_ref_dep_symlink_path = paths.join("node_modules", utils.package_store_root, dep_package_store_name, "node_modules", dep_ref_dep_alias)
-                        files.append(utils.make_symlink(ctx, dep_ref_dep_symlink_path, dep_ref_def_package_store_directory))
+                        files.append(utils.make_symlink(ctx, dep_ref_dep_symlink_path, dep_ref_def_package_store_directory.path))
 
     if package_store_directory:
         files.append(package_store_directory)

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -252,14 +252,14 @@ def _package_store_name(name, version):
         escaped_version = version.replace("/", "+")
         return "%s@%s" % (escaped_name, escaped_version)
 
-def _make_symlink(ctx, symlink_path, target_file):
+def _make_symlink(ctx, symlink_path, target_path):
     if not bazel_lib_utils.is_bazel_6_or_greater():
         # ctx.actions.declare_symlink was added in Bazel 6
         fail("A minimum version of Bazel 6 required to use rules_js")
     symlink = ctx.actions.declare_symlink(symlink_path)
     ctx.actions.symlink(
         output = symlink,
-        target_path = relative_file(target_file.path, symlink.path),
+        target_path = relative_file(target_path, symlink.path),
     )
     return symlink
 


### PR DESCRIPTION
Pre-factor from https://github.com/aspect-build/rules_js/pull/1646 where a make_symlink function that takes a path and not a File is needed.