### PR TITLE
fix: also gather npm_package_store_deps from srcs in js_library

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2065072158
-pnpm-lock.yaml=-1732975623
+pnpm-lock.yaml=915811237
 examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch=-442666336
 package.json=-275319675
 pnpm-workspace.yaml=-871530930
@@ -10,13 +10,10 @@ examples/js_binary/package.json=-41174383
 examples/macro/package.json=857146175
 examples/npm_deps/package.json=283109008
 examples/npm_package/libs/lib_a/package.json=-1377103079
-examples/npm_package/packages/pkg_a/package.json=-1053875011
-examples/npm_package/packages/pkg_b/package.json=-994654274
+examples/npm_package/packages/pkg_a/package.json=1006424040
+examples/npm_package/packages/pkg_b/package.json=1041247977
 examples/webpack_cli/package.json=1911342006
 js/private/coverage/bundle/package.json=-1543718929
-js/private/image/package.json=-1260474848
-js/private/test/image/package.json=1286417612
-js/private/test/js_run_devserver/package.json=-260856079
 js/private/worker/src/package.json=1608383745
 npm/private/test/package.json=1756993924
 npm/private/test/vendored/lodash-4.17.21.tgz=-1206623349
@@ -24,3 +21,6 @@ npm/private/test/npm_package/package.json=-1991705133
 npm/private/test/vendored/is-odd/package.json=1041695223
 npm/private/test/vendored/semver-max/package.json=578664053
 examples/linked_empty_node_modules/package.json=-1039372825
+js/private/image/package.json=-1260474848
+js/private/test/image/package.json=1286417612
+js/private/test/js_run_devserver/package.json=-260856079

--- a/examples/npm_package/packages/pkg_a/package.json
+++ b/examples/npm_package/packages/pkg_a/package.json
@@ -2,7 +2,9 @@
     "name": "@mycorp/pkg-a",
     "private": true,
     "dependencies": {
-        "uuid": "8.3.2",
-        "acorn": "8.7.1"
+        "uuid": "8.3.2"
+    },
+    "peerDependencies": {
+        "acorn": "8.x.x"
     }
 }

--- a/examples/npm_package/packages/pkg_b/BUILD.bazel
+++ b/examples/npm_package/packages/pkg_b/BUILD.bazel
@@ -1,30 +1,21 @@
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages(name = "node_modules")
-
-# Use js_library so that npm_package picks up our transitive sources from deps
-# via the JsInfo provider.
-js_library(
-    name = "lib",
-    srcs = [
-        "index.js",
-        "package.json",
-    ],
-    data = [
-        # Runtime non-dev dependencies propagate to downstream binary and npm_link_package (via npm_package) targets
-        ":node_modules/acorn",
-        ":node_modules/uuid",
-    ],
-)
 
 # The terminal npm_package target for this package. This target is linked
 # manually in the root of the pnpm workspace with `npm_link_package`.
 npm_package(
     name = "pkg_b",
-    srcs = [":lib"],
-    include_runfiles = False,
+    srcs = [
+        "index.js",
+        "package.json",
+    ],
+    data = [
+        # npm deps must be added explicitly as this package is linked manually
+        # so deps are _not_ picked up from the pnpm lock file
+        ":node_modules",
+    ],
     package = "@mycorp/pkg-b",
     visibility = ["//visibility:public"],
 )

--- a/examples/npm_package/packages/pkg_b/README.md
+++ b/examples/npm_package/packages/pkg_b/README.md
@@ -1,3 +1,3 @@
-# @mycorp/pkg-a package
+# @mycorp/pkg-b package
 
 '@mycorp/pkg-b' is an example of a package that is linked manually with `npm_link_package` where it is used.

--- a/examples/npm_package/packages/pkg_b/package.json
+++ b/examples/npm_package/packages/pkg_b/package.json
@@ -2,7 +2,9 @@
     "name": "@mycorp/pkg-b",
     "private": true,
     "dependencies": {
-        "uuid": "8.3.2",
-        "acorn": "8.7.1"
+        "uuid": "8.3.2"
+    },
+    "peerDependencies": {
+        "acorn": "8.x.x"
     }
 }

--- a/js/private/js_library.bzl
+++ b/js/private/js_library.bzl
@@ -196,7 +196,7 @@ def _js_library_impl(ctx):
     )
 
     npm_package_store_deps = gather_npm_package_store_deps(
-        targets = ctx.attr.data + ctx.attr.deps,
+        targets = ctx.attr.srcs + ctx.attr.data + ctx.attr.deps,
     )
 
     runfiles = gather_runfiles(

--- a/npm/private/test/snapshots/bzlmod/npm_defs.bzl
+++ b/npm/private/test/snapshots/bzlmod/npm_defs.bzl
@@ -2156,7 +2156,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_900(name = "{}/uuid".format(name))
             link_targets.append("//{}:{}/uuid".format(bazel_package, name))
         elif bazel_package == "examples/npm_package/packages/pkg_b":
-            link_142(name = "{}/acorn".format(name))
+            link_143(name = "{}/acorn".format(name))
             link_targets.append("//{}:{}/acorn".format(bazel_package, name))
             link_900(name = "{}/uuid".format(name))
             link_targets.append("//{}:{}/uuid".format(bazel_package, name))

--- a/npm/private/test/snapshots/bzlmod/repositories.bzl
+++ b/npm/private/test/snapshots/bzlmod/repositories.bzl
@@ -4634,7 +4634,6 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "examples/npm_package/packages/pkg_a": ["acorn"],
-            "examples/npm_package/packages/pkg_b": ["acorn"],
         },
         package = "acorn",
         version = "8.7.1",
@@ -4652,6 +4651,7 @@ def npm_repositories():
         root_package = "",
         link_workspace = "",
         link_packages = {
+            "examples/npm_package/packages/pkg_b": ["acorn"],
             "js/private/test/image": ["acorn"],
         },
         package = "acorn",

--- a/npm/private/test/snapshots/wksp/npm_defs.bzl
+++ b/npm/private/test/snapshots/wksp/npm_defs.bzl
@@ -2156,7 +2156,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_900(name = "{}/uuid".format(name))
             link_targets.append("//{}:{}/uuid".format(bazel_package, name))
         elif bazel_package == "examples/npm_package/packages/pkg_b":
-            link_142(name = "{}/acorn".format(name))
+            link_143(name = "{}/acorn".format(name))
             link_targets.append("//{}:{}/acorn".format(bazel_package, name))
             link_900(name = "{}/uuid".format(name))
             link_targets.append("//{}:{}/uuid".format(bazel_package, name))

--- a/npm/private/test/snapshots/wksp/repositories.bzl
+++ b/npm/private/test/snapshots/wksp/repositories.bzl
@@ -4634,7 +4634,6 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "examples/npm_package/packages/pkg_a": ["acorn"],
-            "examples/npm_package/packages/pkg_b": ["acorn"],
         },
         package = "acorn",
         version = "8.7.1",
@@ -4652,6 +4651,7 @@ def npm_repositories():
         root_package = "",
         link_workspace = "",
         link_packages = {
+            "examples/npm_package/packages/pkg_b": ["acorn"],
             "js/private/test/image": ["acorn"],
         },
         package = "acorn",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   semver-max: file:./npm/private/test/vendored/semver-max
   is-odd: file:./npm/private/test/vendored/is-odd
 
-packageExtensionsChecksum: e978e3e510efb71c3833e1915611f5d9
+packageExtensionsChecksum: 4368ccb508aca4e83892ade0753603ce
 
 patchedDependencies:
   meaning-of-life@1.0.0:
@@ -104,7 +104,7 @@ importers:
   examples/npm_package/packages/pkg_a:
     dependencies:
       acorn:
-        specifier: 8.7.1
+        specifier: 8.x.x
         version: 8.7.1
       uuid:
         specifier: 8.3.2
@@ -113,8 +113,8 @@ importers:
   examples/npm_package/packages/pkg_b:
     dependencies:
       acorn:
-        specifier: 8.7.1
-        version: 8.7.1
+        specifier: 8.x.x
+        version: 8.8.2
       uuid:
         specifier: 8.3.2
         version: 8.3.2


### PR DESCRIPTION
Update `examples/npm_package/packages/pkg_b` to use `:node_modules` for transitive deps instead of explicitly stating the deps. Gather `npm_package_store_deps` from `srcs`, which this PR fixes, is needed for that to work.

Update `examples/npm_package/packages/pkg_a` to show that in some cases, peer deps of 1p deps are handled correctly in rules_js. In other cases such as peer deps on other 1p deps they are not (https://github.com/aspect-build/rules_js/issues/1092).

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- New test cases added
