### PR TITLE
refactor: remove references to pnpm-lock specifiers field

### DIFF
--- a/npm/private/test/parse_pnpm_lock_tests.bzl
+++ b/npm/private/test/parse_pnpm_lock_tests.bzl
@@ -84,9 +84,6 @@ packages:
     expected = (
         {
             ".": {
-                "specifiers": {
-                    "@aspect-test/a": "5.0.0",
-                },
                 "dependencies": {
                     "@aspect-test/a": "5.0.0",
                 },
@@ -169,7 +166,6 @@ packages:
     expected = (
         {
             ".": {
-                "specifiers": {},
                 "dependencies": {
                     "@aspect-test/a": "5.0.0",
                 },

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -110,16 +110,13 @@ def _convert_v6_importers(importers):
     # Convert pnpm lockfile v6 importers to a rules_js compatible format.
     result = {}
     for import_path, importer in importers.items():
-        result[import_path] = {
-            "specifiers": {},
-            "dependencies": {},
-            "optionalDependencies": {},
-            "devDependencies": {},
-        }
+        result[import_path] = {}
         for key in ["dependencies", "optionalDependencies", "devDependencies"]:
-            deps = importer.get(key, {})
-            for name, attributes in deps.items():
-                result[import_path][key][name] = _convert_pnpm_v6_package_name(attributes.get("version"))
+            deps = importer.get(key, None)
+            if deps != None:
+                result[import_path][key] = {}
+                for name, attributes in deps.items():
+                    result[import_path][key][name] = _convert_pnpm_v6_package_name(attributes.get("version"))
     return result
 
 def _convert_v6_packages(packages):
@@ -192,7 +189,6 @@ def _parse_pnpm_lock_common(parsed, err):
 
     importers = parsed.get("importers", {
         ".": {
-            "specifiers": parsed.get("specifiers", {}),
             "dependencies": parsed.get("dependencies", {}),
             "optionalDependencies": parsed.get("optionalDependencies", {}),
             "devDependencies": parsed.get("devDependencies", {}),


### PR DESCRIPTION
This seems unused?