### PR TITLE
refactor: don't gather files from NpmPackageStoreInfo providers in gather_files_from_js_info

### DIFF
--- a/js/private/js_helpers.bzl
+++ b/js/private/js_helpers.bzl
@@ -2,7 +2,6 @@
 """
 
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_file_to_bin_action")
-load("//npm:providers.bzl", "NpmPackageStoreInfo")
 load(":js_info.bzl", "JsInfo")
 
 def gather_transitive_sources(sources, targets):
@@ -131,8 +130,8 @@ def gather_runfiles(
     """Creates a runfiles object containing files in `sources`, default outputs from `data` and transitive runfiles from `data` & `deps`.
 
     As a defense in depth against `data` & `deps` targets not supplying all required runfiles, also
-    gathers the transitive sources & transitive npm sources from the `JsInfo` &
-    `NpmPackageStoreInfo` providers of `data` & `deps` targets.
+    gathers the transitive sources & transitive npm sources from the `JsInfo` providers of
+    `data` & `deps` targets.
 
     See https://bazel.build/extending/rules#runfiles for more info on providing runfiles in build rules.
 
@@ -259,7 +258,7 @@ def gather_files_from_js_info(
         include_transitive_sources,
         include_transitive_types,
         include_npm_sources):
-    """Gathers files from JsInfo and NpmPackageStoreInfo providers.
+    """Gathers files from JsInfo providers.
 
     Args:
         targets: list of target to gather from
@@ -302,10 +301,5 @@ def gather_files_from_js_info(
             target[JsInfo].npm_sources
             for target in targets
             if JsInfo in target and hasattr(target[JsInfo], "npm_sources")
-        ])
-        files_depsets.extend([
-            target[NpmPackageStoreInfo].transitive_files
-            for target in targets
-            if NpmPackageStoreInfo in target and hasattr(target[NpmPackageStoreInfo], "transitive_files")
         ])
     return depset([], transitive = files_depsets)

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -4,7 +4,7 @@ load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory_bin_action")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 # buildifier: disable=bzl-visibility
-load("//js/private:js_info.bzl", "JsInfo")
+load("//js/private:js_info.bzl", "JsInfo", "js_info")
 load(":npm_package_info.bzl", "NpmPackageInfo")
 load(":npm_package_store_info.bzl", "NpmPackageStoreInfo")
 load(":utils.bzl", "utils")
@@ -340,8 +340,6 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
         for target in ctx.attr.deps
     ])
 
-    files_depset = depset(files)
-
     for transitive_package_store_infos_depset in transitive_package_store_infos_depsets:
         for npm_package_store_info in transitive_package_store_infos_depset.to_list():
             npm_package_store_infos.append(npm_package_store_info)
@@ -364,9 +362,16 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
             for npm_package_store_info in npm_package_store_infos
         ])
 
+    files_depset = depset(files)
+
     providers = [
+        js_info(
+            target = ctx.label,
+            npm_sources = transitive_files_depset,
+        ),
         DefaultInfo(
             files = files_depset,
+            runfiles = ctx.runfiles(transitive_files = transitive_files_depset),
         ),
         NpmPackageStoreInfo(
             root_package = ctx.label.package,


### PR DESCRIPTION
This was a bad pattern to pull from NpmPackageStoreInfo in the helper. Instead npm_package_store should just put its transitive files closure in DefaultInfo runfiles and also provide a JsInfo for when it is used directly in a js_run_binary or other js rules.