### PR TITLE
refactor: rename gather_files_from_js_info to gather_files_from_js_infos

### DIFF
--- a/js/libs.bzl
+++ b/js/libs.bzl
@@ -8,7 +8,7 @@ load(
     "//js/private:js_helpers.bzl",
     _LOG_LEVELS = "LOG_LEVELS",
     _envs_for_log_level = "envs_for_log_level",
-    _gather_files_from_js_info = "gather_files_from_js_info",
+    _gather_files_from_js_infos = "gather_files_from_js_infos",
     _gather_npm_package_store_infos = "gather_npm_package_store_infos",
     _gather_npm_sources = "gather_npm_sources",
     _gather_runfiles = "gather_runfiles",
@@ -25,7 +25,7 @@ js_library_lib = _js_library_lib
 
 js_lib_helpers = struct(
     envs_for_log_level = _envs_for_log_level,
-    gather_files_from_js_info = _gather_files_from_js_info,
+    gather_files_from_js_infos = _gather_files_from_js_infos,
     gather_npm_sources = _gather_npm_sources,
     gather_npm_package_store_infos = _gather_npm_package_store_infos,
     gather_runfiles = _gather_runfiles,

--- a/js/private/js_helpers.bzl
+++ b/js/private/js_helpers.bzl
@@ -188,7 +188,7 @@ def gather_runfiles(
     ])
 
     # Gather files from JsInfo providers of data & deps
-    transitive_files_depsets.append(gather_files_from_js_info(
+    transitive_files_depsets.append(gather_files_from_js_infos(
         targets = data + deps,
         include_sources = include_sources,
         include_types = include_types,
@@ -251,7 +251,7 @@ def envs_for_log_level(log_level):
         envs.append("JS_BINARY__LOG_DEBUG")
     return envs
 
-def gather_files_from_js_info(
+def gather_files_from_js_infos(
         targets,
         include_sources,
         include_types,

--- a/js/private/js_info_files.bzl
+++ b/js/private/js_info_files.bzl
@@ -1,6 +1,6 @@
 """Helper rule to gather files from JsInfo providers of targets and provide them as default outputs"""
 
-load("//js/private:js_helpers.bzl", _gather_files_from_js_info = "gather_files_from_js_info")
+load("//js/private:js_helpers.bzl", _gather_files_from_js_infos = "gather_files_from_js_infos")
 
 _DOC = """Gathers files from the JsInfo providers from targets in srcs and provides them as default outputs.
 
@@ -8,7 +8,7 @@ This helper rule is used by the `js_run_binary` macro.
 """
 
 def _js_info_files_impl(ctx):
-    return DefaultInfo(files = _gather_files_from_js_info(
+    return DefaultInfo(files = _gather_files_from_js_infos(
         targets = ctx.attr.srcs,
         include_sources = ctx.attr.include_sources,
         include_types = ctx.attr.include_types,

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":js_binary.bzl", "js_binary_lib")
-load(":js_helpers.bzl", _gather_files_from_js_info = "gather_files_from_js_info")
+load(":js_helpers.bzl", _gather_files_from_js_infos = "gather_files_from_js_infos")
 
 _attrs = dicts.add(js_binary_lib.attrs, {
     "tool_exec_cfg": attr.label(
@@ -40,7 +40,7 @@ def _js_run_devserver_impl(ctx):
     if use_tool and ctx.attr.command:
         fail("Only one of tool or command may be specified")
 
-    transitive_runfiles = [_gather_files_from_js_info(
+    transitive_runfiles = [_gather_files_from_js_infos(
         targets = ctx.attr.data,
         include_sources = True,
         include_types = ctx.attr.include_types,

--- a/js/private/test/create_launcher/custom_test.bzl
+++ b/js/private/test/create_launcher/custom_test.bzl
@@ -19,7 +19,7 @@ def _custom_test_impl(ctx):
 
     runfiles = ctx.runfiles(
         files = ctx.files.data,
-        transitive_files = js_lib_helpers.gather_files_from_js_info(
+        transitive_files = js_lib_helpers.gather_files_from_js_infos(
             targets = ctx.attr.data,
             include_sources = True,
             include_types = ctx.attr.include_types,


### PR DESCRIPTION
Very much a nit but since the function was renamed already may as well get the naming right before the 2.x release.