### PR TITLE
chore: set --test_tag_filters on cli and not via bazelrc

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -2,10 +2,6 @@
 common:local --disk_cache=~/.cache/bazel-disk-cache
 common --repository_cache=~/.cache/bazel-repository-cache
 
-# Bazel version specific settings
-common:bazel6 --test_tag_filters=-skip-on-bazel6
-common:bazel7 --test_tag_filters=-skip-on-bazel7
-
 # Bazel-in-bazel support
 test --test_env=XDG_CACHE_HOME
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,7 +283,8 @@ jobs:
                     --bazelrc=${GITHUB_WORKSPACE//\\/\/}/.github/workflows/ci.bazelrc \
                     test \
                     --config=${{ matrix.config }} \
-                    --config=bazel${{ matrix.bazel-version.major }} \
+                    --test_tag_filters=-skip-on-${{ matrix.config }},-skip-on-bazel${{ matrix.bazel-version.major }} \
+                    --build_tag_filters=-skip-on-${{ matrix.config }},-skip-on-bazel${{ matrix.bazel-version.major }} \
                     --enable_bzlmod=${{ matrix.bzlmod }} \
                     //...
               env:


### PR DESCRIPTION
--test_tag_filters are not additive so in order to set multiple tag filters from matrix settings we need to do some on the CLI