### PR TITLE
chore: use canonical --remote_download_outputs=minimal flag for BwoB

### DIFF
--- a/.aspect/workflows/bazelrc
+++ b/.aspect/workflows/bazelrc
@@ -1,6 +1,6 @@
 # build without the bytes
-test --remote_download_minimal
-test --nobuild_runfile_links
+common --remote_download_outputs=minimal
+common --nobuild_runfile_links
 
 # generate build_event_log binary build event profile file
 common --build_event_binary_file=build_event_log.bin


### PR DESCRIPTION
`--remote_download_minimal` is an alias for `--remote_download_outputs=minimal`: https://bazel.build/reference/command-line-reference#flag--remote_download_minimal