### PR TITLE
chore: tweak delivery stamping

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -284,6 +284,9 @@ tasks:
           queue: aspect-medium
     - delivery:
           auto_deliver: true
+          stamp_flags:
+              - --stamp
+              - --workspace_status_command="${PWD}/workspace_status.sh"
           rules:
               - deliverable: 'attr("tags", "\bdeliverable\b", //...)'
                 condition:

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,9 +27,6 @@ common --lockfile_mode=off
 # Mock versioning command to test the --stamp behavior
 build --workspace_status_command="echo BUILD_SCM_VERSION 1.2.3"
 
-# Enable with --config=release
-build:release --stamp --workspace_status_command=$(pwd)/workspace_status.sh
-
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -2,4 +2,4 @@
 # See https://bazel.build/docs/user-manual#workspace-status
 
 # Starts with the STABLE_ prefix so that Bazel will always rebuild stamped outputs if the git tag changes.
-echo STABLE_BUILD_VERSION "$(git describe --long | sed -e 's/^v//;s/-/./;s/-g/+/')"
+echo STABLE_BUILD_VERSION "$(git describe --tags --long | sed -e 's/^v//;s/-/./;s/-g/+/')"


### PR DESCRIPTION
Show a simple example of setting both `--stamp` and `--workspace_status_command` in Workflows `delivery.stamp_flags`