### PR TITLE
refactor: rename JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT to JS_BINARY__USE_EXECROOT_ENTRY_POINT

### DIFF
--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -176,8 +176,8 @@ elif [[ "$PWD" == *"/bazel-~1/"* ]]; then
 fi
 
 if [[ "${bazel_out_segment:-}" ]]; then
-    if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
-        logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
+    if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
+        logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
     else
         # We in runfiles and we don't yet know the execroot
         rest="${PWD#*"$bazel_out_segment"}"
@@ -189,8 +189,8 @@ if [[ "${bazel_out_segment:-}" ]]; then
         JS_BINARY__EXECROOT="${PWD:0:$index}"
     fi
 else
-    if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
-        logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
+    if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
+        logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
     else
         # We are in execroot or in some other context all together such as a nodejs_image or a manually run js_binary
         JS_BINARY__EXECROOT="$PWD"
@@ -218,9 +218,9 @@ aspect_rules_js README https://github.com/aspect-build/rules_js/tree/dbb5af0d2a9
 fi
 export JS_BINARY__EXECROOT
 
-if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
+if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
     if [ -z "${BAZEL_BINDIR:-}" ]; then
-        logf_fatal "Expected BAZEL_BINDIR to be set when JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT is set"
+        logf_fatal "Expected BAZEL_BINDIR to be set when JS_BINARY__USE_EXECROOT_ENTRY_POINT is set"
         exit 1
     fi
     if [ -z "${JS_BINARY__COPY_DATA_TO_BIN:-}" ] && [ -z "${JS_BINARY__ALLOW_EXECROOT_ENTRY_POINT_WITH_NO_COPY_DATA_TO_BIN:-}" ]; then
@@ -238,7 +238,7 @@ To disable this validation you can set allow_execroot_entry_point_with_no_copy_d
     fi
 fi
 
-if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] || [ "${JS_BINARY__NO_RUNFILES:-}" ]; then
+if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] || [ "${JS_BINARY__NO_RUNFILES:-}" ]; then
     entry_point=$(resolve_execroot_bin_path "{{entry_point_path}}")
 else
     entry_point="$JS_BINARY__RUNFILES/{{workspace_name}}/{{entry_point_path}}"
@@ -415,8 +415,8 @@ if [ "${JS_BINARY__LOG_DEBUG:-}" ]; then
     logf_debug "JS_BINARY__TARGET_NAME %s" "${JS_BINARY__TARGET_NAME:-}"
     logf_debug "JS_BINARY__WORKSPACE %s" "${JS_BINARY__WORKSPACE:-}"
     logf_debug "js_binary entry point %s" "$entry_point"
-    if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
-        logf_debug "JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT %s" "$JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT"
+    if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
+        logf_debug "JS_BINARY__USE_EXECROOT_ENTRY_POINT %s" "$JS_BINARY__USE_EXECROOT_ENTRY_POINT"
     fi
 fi
 

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -337,7 +337,7 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
 
     # Configure run from execroot
     if use_execroot_entry_point:
-        fixed_env["JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT"] = "1"
+        fixed_env["JS_BINARY__USE_EXECROOT_ENTRY_POINT"] = "1"
 
         # hoist all runfiles to srcs when running from execroot
         js_runfiles_lib_name = "{}_runfiles_lib".format(name)

--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -339,7 +339,7 @@ async function main(args, sandbox) {
             // to determine the execroot entry point but since the tool is running
             // in a custom sandbox we don't want to cd into the BAZEL_BINDIR in the launcher
             // (JS_BINARY__NO_CD_BINDIR is set above)
-            env['JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT'] = '1'
+            env['JS_BINARY__USE_EXECROOT_ENTRY_POINT'] = '1'
             env['BAZEL_BINDIR'] = config.bazel_bindir
             if (config.allow_execroot_entry_point_with_no_copy_data_to_bin) {
                 env[

--- a/js/private/test/image/checksum.expected
+++ b/js/private/test/image/checksum.expected
@@ -1,2 +1,2 @@
-2bba6ae0e3552778539f8abf49d6589b0b638ccb1ac5a9b8b816ab18b5adb12b  js/private/test/image/cksum_app.tar
+02fec6c845b4f8277d6664c269a90f5016436bda728fae57e7b3ee113f8b6381  js/private/test/image/cksum_app.tar
 813d54ae63067f19103e13f616726ff1f32cf8d51e27789b8d31415300f0a69e  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/custom_owner_app.listing
+++ b/js/private/test/image/custom_owner_app.listing
@@ -10,7 +10,7 @@ drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.ru
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image
--r-xr-xr-x 100/0         23993 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin.sh
+-r-xr-xr-x 100/0         23953 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin.sh
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin
 -r-xr-xr-x 100/0           133 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x 100/0            20 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/main.js

--- a/js/private/test/image/default_app.listing
+++ b/js/private/test/image/default_app.listing
@@ -10,7 +10,7 @@ drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.ru
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image
--r-xr-xr-x 0/0           23993 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin.sh
+-r-xr-xr-x 0/0           23953 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin.sh
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin
 -r-xr-xr-x 0/0             133 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x 0/0              20 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/main.js

--- a/js/private/test/shellcheck_launcher.sh
+++ b/js/private/test/shellcheck_launcher.sh
@@ -293,8 +293,8 @@ elif [[ "$PWD" == *"/bazel-~1/"* ]]; then
 fi
 
 if [[ "${bazel_out_segment:-}" ]]; then
-    if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
-        logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
+    if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
+        logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
     else
         # We in runfiles and we don't yet know the execroot
         rest="${PWD#*"$bazel_out_segment"}"
@@ -306,8 +306,8 @@ if [[ "${bazel_out_segment:-}" ]]; then
         JS_BINARY__EXECROOT="${PWD:0:$index}"
     fi
 else
-    if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
-        logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
+    if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
+        logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
     else
         # We are in execroot or in some other context all together such as a nodejs_image or a manually run js_binary
         JS_BINARY__EXECROOT="$PWD"
@@ -335,9 +335,9 @@ aspect_rules_js README https://github.com/aspect-build/rules_js/tree/dbb5af0d2a9
 fi
 export JS_BINARY__EXECROOT
 
-if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
+if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
     if [ -z "${BAZEL_BINDIR:-}" ]; then
-        logf_fatal "Expected BAZEL_BINDIR to be set when JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT is set"
+        logf_fatal "Expected BAZEL_BINDIR to be set when JS_BINARY__USE_EXECROOT_ENTRY_POINT is set"
         exit 1
     fi
     if [ -z "${JS_BINARY__COPY_DATA_TO_BIN:-}" ] && [ -z "${JS_BINARY__ALLOW_EXECROOT_ENTRY_POINT_WITH_NO_COPY_DATA_TO_BIN:-}" ]; then
@@ -355,7 +355,7 @@ To disable this validation you can set allow_execroot_entry_point_with_no_copy_d
     fi
 fi
 
-if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] || [ "${JS_BINARY__NO_RUNFILES:-}" ]; then
+if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] || [ "${JS_BINARY__NO_RUNFILES:-}" ]; then
     entry_point=$(resolve_execroot_bin_path "js/private/test/shellcheck.js")
 else
     entry_point="$JS_BINARY__RUNFILES/aspect_rules_js/js/private/test/shellcheck.js"
@@ -532,8 +532,8 @@ if [ "${JS_BINARY__LOG_DEBUG:-}" ]; then
     logf_debug "JS_BINARY__TARGET_NAME %s" "${JS_BINARY__TARGET_NAME:-}"
     logf_debug "JS_BINARY__WORKSPACE %s" "${JS_BINARY__WORKSPACE:-}"
     logf_debug "js_binary entry point %s" "$entry_point"
-    if [ "${JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
-        logf_debug "JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT %s" "$JS_RUN_BINARY__USE_EXECROOT_ENTRY_POINT"
+    if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
+        logf_debug "JS_BINARY__USE_EXECROOT_ENTRY_POINT %s" "$JS_BINARY__USE_EXECROOT_ENTRY_POINT"
     fi
 fi
 


### PR DESCRIPTION
Internal attribute that is poorly named