### PR TITLE
refactor: update js_binary executable path to {name}_/{name}

### DIFF
--- a/e2e/worker/BUILD.bazel
+++ b/e2e/worker/BUILD.bazel
@@ -16,7 +16,7 @@ copy_file(
 )
 
 js_binary(
-    name = "worker_binary",
+    name = "worker",
     data = [":copy_worker_js"],
     entry_point = ":copy_dummy_worker",
     visibility = ["//visibility:public"],

--- a/e2e/worker/defs.bzl
+++ b/e2e/worker/defs.bzl
@@ -31,7 +31,7 @@ pi_rule = rule(
         "worker": attr.label(
             executable = True,
             cfg = "exec",
-            default = ":worker_binary",
+            default = ":worker",
         ),
     },
 )

--- a/examples/coverage/BUILD.bazel
+++ b/examples/coverage/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_test")
 
 js_test(
-    name = "coverage_test",
+    name = "coverage",
     data = [
         "coverage.js",
         "//:node_modules/@types/node",

--- a/js/private/coverage/merger.bzl
+++ b/js/private/coverage/merger.bzl
@@ -31,8 +31,10 @@ def _coverage_merger_impl(ctx):
         # TODO(3.0): drop support for deprecated toolchain attributes
         node_path = _deprecated_target_tool_path_to_short_path(nodeinfo.target_tool_path)
 
-    # Create launcher
-    bash_launcher = ctx.actions.declare_file(ctx.label.name)
+    # The '_' avoids collisions with another file matching the label name.
+    # For example, test and test/my.spec.ts. This naming scheme is borrowed from rules_go:
+    # https://github.com/bazelbuild/rules_go/blob/f3cc8a2d670c7ccd5f45434ab226b25a76d44de1/go/private/context.bzl#L144
+    bash_launcher = ctx.actions.declare_file("{}_/{}".format(ctx.label.name, ctx.label.name))
     ctx.actions.expand_template(
         template = ctx.file._launcher_template,
         output = bash_launcher,

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -467,7 +467,10 @@ def _bash_launcher(ctx, nodeinfo, entry_point_path, log_prefix_rule_set, log_pre
         "{{workspace_name}}": ctx.workspace_name,
     }
 
-    launcher = ctx.actions.declare_file(ctx.label.name)
+    # The '_' avoids collisions with another file matching the label name.
+    # For example, test and test/my.spec.ts. This naming scheme is borrowed from rules_go:
+    # https://github.com/bazelbuild/rules_go/blob/f3cc8a2d670c7ccd5f45434ab226b25a76d44de1/go/private/context.bzl#L144
+    launcher = ctx.actions.declare_file("{}_/{}".format(ctx.label.name, ctx.label.name))
     ctx.actions.expand_template(
         template = ctx.file._launcher_template,
         output = launcher,

--- a/js/private/test/image/checksum.expected
+++ b/js/private/test/image/checksum.expected
@@ -1,2 +1,2 @@
-e6a04b6344eb21154508bf246ebead12d436313739c478978cd5763262491f98  js/private/test/image/cksum_app.tar
+413693b1ad714b0dac59551b063bc33d0a4a680c9d48b71eba88c06a301cfc4a  js/private/test/image/cksum_app.tar
 7990126e5961588efd2af7cdccac3846dfffb8ca2e26206840df8c7a1c34c42e  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/custom_owner_app.listing
+++ b/js/private/test/image/custom_owner_app.listing
@@ -3,14 +3,15 @@ drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image
--r-xr-xr-x 100/0           131 1970-01-01 00:00 app/js/private/test/image/bin
+-r-xr-xr-x 100/0           136 1970-01-01 00:00 app/js/private/test/image/bin
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image
--r-xr-xr-x 100/0         23908 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin
+drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_
+-r-xr-xr-x 100/0         23908 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_/bin
 drwxr-xr-x 100/0             0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin
 -r-xr-xr-x 100/0           133 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x 100/0            20 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/main.js

--- a/js/private/test/image/default_app.listing
+++ b/js/private/test/image/default_app.listing
@@ -3,14 +3,15 @@ drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image
--r-xr-xr-x 0/0             131 1970-01-01 00:00 app/js/private/test/image/bin
+-r-xr-xr-x 0/0             136 1970-01-01 00:00 app/js/private/test/image/bin
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image
--r-xr-xr-x 0/0           23908 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin
+drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_
+-r-xr-xr-x 0/0           23908 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_/bin
 drwxr-xr-x 0/0               0 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin
 -r-xr-xr-x 0/0             133 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x 0/0              20 1970-01-01 00:00 app/js/private/test/image/bin.runfiles/aspect_rules_js/js/private/test/image/main.js


### PR DESCRIPTION
Follow-up to #1586.

The trouble with the change in #1586 with the name of the executable in the output tree the same as the target name is that a target name such as `test` could be in a BUILD file where a subdirectory named test exists which can lead to build failures such as:

```
ERROR: One of the output paths 'bazel-out/k8-fastbuild/bin/foo/test' (belonging to //foo:test) and 'bazel-out/k8-fastbuild/bin/foo/test/active_file_users_test.ts' (belonging to //foo:foo) is a prefix of the other. These actions cannot be simultaneously present; please rename one of the output files or build just one of them
```

This change resolves that issue without bringing back the `.sh` suffix that #1586 was addressing.
