### PR TITLE
fix: align bzlmod and workspace patch_args default

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -244,6 +244,7 @@ def _npm_translate_lock_attrs():
 
     # Args defaulted differently by the macro
     attrs["npm_package_target_name"] = attr.string(default = "{dirname}")
+    attrs["patch_args"] = attr.string_list_dict(default = {"*": ["-p0"]})
 
     return attrs
 


### PR DESCRIPTION
Align bzlmod and workspace default values.

### Test plan

- Manual testing; removing `patch_args = [...]` from tests such as `e2e/npm_translate_lock_subdir_patch` should fail the same with bzlmod and workspace.
