### PR TITLE
fix: do not use npm_translate_lock patch_args without patches

### DIFF
--- a/e2e/npm_translate_lock_subdir_patch/MODULE.bazel
+++ b/e2e/npm_translate_lock_subdir_patch/MODULE.bazel
@@ -12,9 +12,6 @@ npm.npm_translate_lock(
         "//subdir:package.json",
         "//subdir:patches/debug@4.3.4.patch",
     ],
-    patch_args = {
-        "*": ["-p1"],
-    },
     pnpm_lock = "//subdir:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
 )

--- a/e2e/npm_translate_lock_subdir_patch/WORKSPACE
+++ b/e2e/npm_translate_lock_subdir_patch/WORKSPACE
@@ -22,9 +22,6 @@ npm_translate_lock(
         "//subdir:package.json",
         "//subdir:patches/debug@4.3.4.patch",
     ],
-    patch_args = {
-        "*": ["-p1"],
-    },
     pnpm_lock = "//subdir:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
 )

--- a/e2e/pnpm_lockfiles/MODULE.bazel
+++ b/e2e/pnpm_lockfiles/MODULE.bazel
@@ -31,7 +31,6 @@ npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
             "//:pnpm-workspace.yaml",
         ],
         npmrc = "//:.npmrc",
-        patch_args = {"*": ["-p1"]},
         pnpm_lock = "//%s:pnpm-lock.yaml" % version,
         verify_node_modules_ignored = "//:.bazelignore",
     )

--- a/e2e/pnpm_lockfiles/WORKSPACE
+++ b/e2e/pnpm_lockfiles/WORKSPACE
@@ -25,7 +25,6 @@ load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock")
             "//:pnpm-workspace.yaml",
         ],
         npmrc = "//:.npmrc",
-        patch_args = {"*": ["-p1"]},
         pnpm_lock = "//%s:pnpm-lock.yaml" % version,
         verify_node_modules_ignored = "//:.bazelignore",
     )


### PR DESCRIPTION
Fix #1427
An alternative to #837 from @kormide 

This makes pure `pnpm.patchedDependencies` nicer like #837, normally having the same effect, I think?

I think the main difference is that #837 removes `-p0` if there are no `npm_translate_lock(patches)` but still applies the rest of `npm_translate_lock(patch_args)`. While this PR does not apply `npm_translate_lock(patch_args)` when there are no `npm_translate_lock(patches)`. 

Maybe this PR is actually more confusing? 🤦 
Maybe we should just drop support for mixing these 2 types of patches in 2.x? See #1694

---

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce: