### PR TITLE
fixup! refactor: set minimum aspect_bazel_lib to 2.7.1 (#1580)

### DIFF
--- a/e2e/pnpm_workspace/WORKSPACE
+++ b/e2e/pnpm_workspace/WORKSPACE
@@ -3,10 +3,6 @@ local_repository(
     path = "../..",
 )
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
-
-aspect_bazel_lib_dependencies()
-
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 
 rules_js_dependencies()

--- a/e2e/pnpm_workspace_deps/WORKSPACE
+++ b/e2e/pnpm_workspace_deps/WORKSPACE
@@ -3,10 +3,6 @@ local_repository(
     path = "../..",
 )
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
-
-aspect_bazel_lib_dependencies()
-
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 
 rules_js_dependencies()


### PR DESCRIPTION
When you upgraded to 2.7.1 `aspect_bazel_lib` was removed as a direct dep of these so we shouldn't be invoking `aspect_bazel_lib_dependencies` anymore.

This is a `!fixup` on that commit, assuming we'll rebase/squash and `push -f` at some point still?