### PR TITLE
refactor: always read pnpm.patchedDependencies from lockfile

### DIFF
--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -39,14 +39,6 @@ WARNING: `update_pnpm_lock` attribute in `npm_translate_lock(name = "{rctx_name}
 
     _init_root_package(priv, rctx, label_store)
 
-    root_package_json_declared = label_store.has("package_json_root")
-    if root_package_json_declared and _should_update_pnpm_lock(priv):
-        # If we need to read the patches list from the package.json since
-        # update_pnpm_lock is enabled and the user has declared the root package.json
-        # as an input file then we can read it right away.
-        _init_patched_dependencies_labels(priv, rctx, label_store)
-        priv["patched_dependencies_labels_initialized"] = True
-
     if _should_update_pnpm_lock(priv) or not rctx.attr.pnpm_lock:
         # labels only needed when updating or bootstrapping the pnpm lock file
         _init_pnpm_labels(label_store, rctx)
@@ -62,12 +54,6 @@ WARNING: `update_pnpm_lock` attribute in `npm_translate_lock(name = "{rctx_name}
     pnpm_lock_exists = is_windows or utils.exists(rctx, label_store.path("pnpm_lock"))
     if pnpm_lock_exists:
         _load_lockfile(priv, rctx, label_store)
-
-    if not priv["patched_dependencies_labels_initialized"]:
-        # If we didn't initialize the patched dependency labels above then try again now. We'll either
-        # read the list of patches from the lock file now that it has been read or, if update_pnpm_lock
-        # is enabled, we can derive the existance of a root package.json by looking for a `.` importer
-        # in the `importers` list.
         _init_patched_dependencies_labels(priv, rctx, label_store)
 
     if _should_update_pnpm_lock(priv):
@@ -180,19 +166,13 @@ def _init_patches_labels(priv, rctx, label_store):
         label_store.add("patches_{}".format(i), d)
 
     priv["num_patches"] = len(patches)
-    priv["patched_dependencies_labels_initialized"] = False
 
 ################################################################################
 def _init_patched_dependencies_labels(priv, rctx, label_store):
-    if rctx.attr.update_pnpm_lock:
-        # Read patches from package.json `pnpm.patchedDependencies`
-        root_package_json = _root_package_json(priv)
-        patches = ["//%s:%s" % (label_store.label("pnpm_lock").package, patch) for patch in root_package_json.get("pnpm", {}).get("patchedDependencies", {}).values()]
-    else:
-        # Read patches from pnpm-lock.yaml `patchedDependencies`
-        patches = []
-        for patch_info in priv["patched_dependencies"].values():
-            patches.append("//%s:%s" % (label_store.label("pnpm_lock").package, patch_info.get("path")))
+    # Read patches from pnpm-lock.yaml `patchedDependencies`
+    patches = []
+    for patch_info in priv["patched_dependencies"].values():
+        patches.append("//%s:%s" % (label_store.label("pnpm_lock").package, patch_info.get("path")))
 
     # Convert patch label strings to labels
     patches = [rctx.attr.pnpm_lock.relative(p) for p in patches]
@@ -351,15 +331,10 @@ WARNING: Implicitly using package.json file `{package_json}` since the `{pnpm_lo
                 fail(msg)
             _copy_input_file(priv, rctx, label_store, package_json_key)
 
-    if rctx.attr.update_pnpm_lock:
-        # Read patches from package.json `pnpm.patchedDependencies`
-        root_package_json = _root_package_json(priv)
-        pnpm_patches = root_package_json.get("pnpm", {}).get("patchedDependencies", {}).values()
-    else:
-        # Read patches from pnpm-lock.yaml `patchedDependencies`
-        pnpm_patches = []
-        for patch_info in priv["patched_dependencies"].values():
-            pnpm_patches.append(patch_info.get("path"))
+    # Read patches from pnpm-lock.yaml `patchedDependencies`
+    pnpm_patches = []
+    for patch_info in priv["patched_dependencies"].values():
+        pnpm_patches.append(patch_info.get("path"))
 
     num_patches = priv["num_patches"]
 
@@ -571,9 +546,6 @@ def _npm_auth(priv):
 
 def _root_package(priv):
     return priv["root_package"]
-
-def _root_package_json(priv):
-    return priv["root_package_json"]
 
 ################################################################################
 def _new(rctx):


### PR DESCRIPTION
Why load them different when running pnpm update? That makes it inconsistent, ~~especially with lockfile v5.3 where the lockfile vs package.json will give different results~~ (edit: but we no longer support 5.3).

Unlike other `pnpm.*` properties from the package.json this one does end up in the lockfile with additional metadata, so we will always read it from the lockfile and not package.json.

---

### Test plan

- Covered by existing test cases