### PR TITLE
chore: remove redundant bazelrc flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,6 @@ common --noincompatible_disallow_empty_glob
 
 # Don't try and auto detect the cc toolchain, as we use our llvm.
 build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build --incompatible_strict_action_env=true
 build --incompatible_enable_cc_toolchain_resolution
 
 # Disable lockfile for now. It is unstable.


### PR DESCRIPTION
`--incompatible_strict_action_env1` is already set in `import %workspace%/.aspect/bazelrc/correctness.bazelrc`