### PR TITLE
refactor: cleanup js_image_layer impl and docs

### DIFF
--- a/e2e/js_image_docker/BUILD.bazel
+++ b/e2e/js_image_docker/BUILD.bazel
@@ -1,10 +1,10 @@
-load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_image_layer")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_image_layer")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -28,8 +28,9 @@ platform_transition_filegroup(
 )
 
 js_binary(
-    name = "main",
+    name = "bin",
     args = ["foo"],
+    chdir = package_name(),
     data = [
         "transition",
         "//:node_modules/chalk",
@@ -40,7 +41,7 @@ js_binary(
 # Image
 js_image_layer(
     name = "layers",
-    binary = ":main",
+    binary = ":bin",
     root = "/app",
     visibility = ["//visibility:__pkg__"],
 )
@@ -70,16 +71,20 @@ container_layer(
 container_image(
     name = "image",
     architecture = "amd64",  # or arm64
-
     # Since js_binary depends on bash we have to bring in a base image that has bash
     base = "@debian_amd64//image",  # or "@debian_arm64//image", if you are on an arm machine
-    # This is going to be /{root of js_image_layer}/{package_name()}/{name of js_binary}
-    cmd = ["/app/main"],
+    # This is `/[js_image_layer 'root']/[package name of js_image_layer 'binary' target]/[name of js_image_layer 'binary' target]`
+    cmd = ["/app/bin"],
     entrypoint = ["bash"],
     layers = [
         ":app_layer",
         ":node_modules_layer",
     ],
+    # This is `cmd` + `.runfiles/[workspace name]`
+    workdir = select({
+        "@aspect_bazel_lib//lib:bzlmod": "/app/src/bin.runfiles/_main",
+        "//conditions:default": "/app/src/bin.runfiles/__main__",
+    }),
 )
 
 container_test(

--- a/e2e/js_image_docker/smoketest.yaml
+++ b/e2e/js_image_docker/smoketest.yaml
@@ -3,8 +3,8 @@ schemaVersion: 2.0.0
 commandTests:
     - name: 'smoke'
       command: 'bash'
-      args: ['/app/main']
-      expectedOutput: ['.*WORKSPACE.*__main__', '.*main.*', '.*ARCH.*']
+      args: ['/app/bin']
+      expectedOutput: ['.*WORKSPACE.*__main__', '.*bin.*', '.*ARCH.*']
     - name: 'smoke2'
-      command: '/app/main'
-      expectedOutput: ['.*WORKSPACE.*__main__', '.*main.*', '.*ARCH.*']
+      command: '/app/bin'
+      expectedOutput: ['.*WORKSPACE.*__main__', '.*bin.*', '.*ARCH.*']

--- a/e2e/js_image_oci/WORKSPACE
+++ b/e2e/js_image_oci/WORKSPACE
@@ -1,5 +1,3 @@
-workspace(name = "js_image_oci")
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 ###

--- a/e2e/js_image_oci/src/BUILD.bazel
+++ b/e2e/js_image_oci/src/BUILD.bazel
@@ -24,8 +24,9 @@ filegroup(
 )
 
 js_binary(
-    name = "main",
+    name = "bin",
     args = ["foo"],
+    chdir = package_name(),
     # skip copying so we can test external source directories
     copy_data_to_bin = False,
     data = [
@@ -45,7 +46,7 @@ js_binary(
 # bazel build //src:layers --extra_toolchains=@nodejs_toolchains//:linux_arm64_toolchain_target
 js_image_layer(
     name = "layers",
-    binary = ":main",
+    binary = ":bin",
     platform = select({
         "@platforms//cpu:arm64": ":linux_arm64",
         "@platforms//cpu:x86_64": ":linux_amd64",
@@ -58,13 +59,18 @@ oci_image(
     name = "image",
     # Since js_binary depends on bash we have to bring in a base image that has bash
     base = "@debian",
-    # This is going to be /{root of js_image_layer}/{package_name()}/{name of js_binary}
-    cmd = ["/app/src/main"],
+    # This is `/[js_image_layer 'root']/[package name of js_image_layer 'binary' target]/[name of js_image_layer 'binary' target]`
+    cmd = ["/app/src/bin"],
     entrypoint = ["bash"],
     tars = [
         ":layers",
     ],
     visibility = ["//visibility:public"],
+    # This is `cmd` + `.runfiles/[workspace name]`
+    workdir = select({
+        "@aspect_bazel_lib//lib:bzlmod": "/app/src/bin.runfiles/_main",
+        "//conditions:default": "/app/src/bin.runfiles/__main__",
+    }),
 )
 
 container_structure_test(

--- a/e2e/js_image_oci/src/test.yaml
+++ b/e2e/js_image_oci/src/test.yaml
@@ -3,26 +3,30 @@ schemaVersion: 2.0.0
 commandTests:
     - name: 'smoke'
       command: 'bash'
-      args: ['/app/src/main']
+      args: ['/app/src/bin']
       expectedOutput:
           [
               'OS',
               'ARCH/CPU',
               'WORKSPACE',
-              ' TARGET    //src:main',
+              ' TARGET    //src:bin',
+              ' CWD    /app/src/bin.runfiles/',
+              ' JS_BINARY__RUNFILES    /app/src/bin.runfiles',
               ' SOURCE CHECK    true',
               ' DIRECTORY CHECK    true',
               ' PROTO CHECK    true',
               ' SOURCE DIRECTORY CHECK    true',
           ]
     - name: 'smoke2'
-      command: '/app/src/main'
+      command: '/app/src/bin'
       expectedOutput:
           [
               'OS',
               'ARCH/CPU',
               'WORKSPACE',
-              ' TARGET    //src:main',
+              ' TARGET    //src:bin',
+              ' CWD    /app/src/bin.runfiles/',
+              ' JS_BINARY__RUNFILES    /app/src/bin.runfiles',
               ' SOURCE CHECK    true',
               ' DIRECTORY CHECK    true',
               ' PROTO CHECK    true',


### PR DESCRIPTION
Non-breaking 1.x pre-factor from 2.x change https://github.com/aspect-build/rules_js/pull/1690.

With this change, the executable output path of js_binary can change without affecting the runfiles directory of js_image_layer: https://github.com/aspect-build/rules_js/pull/1690/commits/d4c87b2c500697322a4d85bf350da9a2853eb803