### PR TITLE
ci: run e2e/npm_translate_lock_auth with bzlmod on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,9 +154,6 @@ jobs:
                     # Don't run update_pnpm_lock under bzlmod
                     - bzlmod: 1
                       folder: e2e/update_pnpm_lock
-                    # Don't run update_pnpm_lock under bzlmod
-                    - bzlmod: 1
-                      folder: e2e/npm_translate_lock_auth
                     # rules_docker is not compatible with Bazel 7
                     - bazel-version:
                           major: 7


### PR DESCRIPTION
This e2e test was disabled on bzlmod from a while ago when we didn't have support for `use_home_npmrc` in the bzlmod extension. It should be run now.