### PR TITLE
feat: add generate_empty_layers attribute to js_image_layer

### DIFF
--- a/docs/js_image_layer.md
+++ b/docs/js_image_layer.md
@@ -19,7 +19,7 @@ js_image_layer(
 ## js_image_layer
 
 <pre>
-js_image_layer(<a href="#js_image_layer-name">name</a>, <a href="#js_image_layer-binary">binary</a>, <a href="#js_image_layer-compression">compression</a>, <a href="#js_image_layer-owner">owner</a>, <a href="#js_image_layer-platform">platform</a>, <a href="#js_image_layer-root">root</a>)
+js_image_layer(<a href="#js_image_layer-name">name</a>, <a href="#js_image_layer-binary">binary</a>, <a href="#js_image_layer-compression">compression</a>, <a href="#js_image_layer-generate_empty_layers">generate_empty_layers</a>, <a href="#js_image_layer-owner">owner</a>, <a href="#js_image_layer-platform">platform</a>, <a href="#js_image_layer-root">root</a>)
 </pre>
 
 Create container image layers from js_binary targets.
@@ -269,6 +269,7 @@ container_image(
 | <a id="js_image_layer-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="js_image_layer-binary"></a>binary |  Label to an js_binary target   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="js_image_layer-compression"></a>compression |  Compression algorithm. Can be one of `gzip`, `none`.   | String | optional |  `"gzip"`  |
+| <a id="js_image_layer-generate_empty_layers"></a>generate_empty_layers |  Generate layers even if they are empty.<br><br>Helpful when using js_image_layer with rules_docker. See https://github.com/aspect-build/rules_js/pull/1714 for more info   | Boolean | optional |  `False`  |
 | <a id="js_image_layer-owner"></a>owner |  Owner of the entries, in `GID:UID` format. By default `0:0` (root, root) is used.   | String | optional |  `"0:0"`  |
 | <a id="js_image_layer-platform"></a>platform |  Platform to transition.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="js_image_layer-root"></a>root |  Path where the files from js_binary will reside in. eg: /apps/app1 or /app   | String | optional |  `""`  |

--- a/e2e/js_image_docker/BUILD.bazel
+++ b/e2e/js_image_docker/BUILD.bazel
@@ -42,6 +42,7 @@ js_binary(
 js_image_layer(
     name = "layers",
     binary = ":bin",
+    generate_empty_layers = True,
     root = "/app",
     visibility = ["//visibility:__pkg__"],
 )
@@ -66,6 +67,17 @@ filegroup(
 container_layer(
     name = "package_store_3p_layer",
     tars = [":package_store_3p_tar"],
+)
+
+filegroup(
+    name = "package_store_1p_tar",
+    srcs = [":layers"],
+    output_group = "package_store_1p",
+)
+
+container_layer(
+    name = "package_store_1p_layer",
+    tars = [":package_store_1p_tar"],
 )
 
 filegroup(
@@ -101,6 +113,7 @@ container_image(
     layers = [
         ":node_layer",
         ":package_store_3p_layer",
+        ":package_store_1p_layer",
         ":node_modules_layer",
         ":app_layer",
     ],

--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -279,7 +279,7 @@ def _runfile_path(ctx, file, runfiles_dir):
     return paths.join(runfiles_dir, to_rlocation_path(ctx, file))
 
 def _build_layer(ctx, type, all_entries_json, entries, inputs):
-    if not entries:
+    if not entries and not ctx.attr.generate_empty_layers:
         return None
 
     entries_json = ctx.actions.declare_file("{}_{}_entries.json".format(ctx.label.name, type))
@@ -489,6 +489,12 @@ js_image_layer_lib = struct(
         ),
         "platform": attr.label(
             doc = "Platform to transition.",
+        ),
+        "generate_empty_layers": attr.bool(
+            doc = """Generate layers even if they are empty.
+
+Helpful when using js_image_layer with rules_docker.
+See https://github.com/aspect-build/rules_js/pull/1714 for more info""",
         ),
     },
 )


### PR DESCRIPTION
Useful for when using js_image_layer with rules_docker in consistent manner for all images regardless of which layers are empty:

```
RULES_JS_LAYERS = [
    "node",
    "package_store_3p",
    "package_store_1p",
    "node_modules",
    "app",
]

def js_container_layers(name, binary, root, tags = []):
    js_image_layer(
        name = "{}/layers".format(name),
        binary = binary,
        generate_empty_layers = True,
        root = root,
        visibility = ["//visibility:__pkg__"],
    )

    [
        [
            native.filegroup(
                name = "{}/layers/{}.tar".format(name, layer),
                srcs = ["{}/layers".format(name)],
                output_group = layer,
            ),
            container_layer(
                name = "{}/{}_layer".format(name, layer),
                tars = [":{}/layers/{}.tar".format(name, layer)],
                tags = tags + ["manual"],
            ),
        ]
        for layer in RULES_JS_LAYERS
    ]
```

with `generate_empty_layers = False` the above example may fail with a message such as:

```
(18:01:23) ERROR: /home/runner/work/rules_js/rules_js/e2e/js_image_docker/BUILD.bazel:78:16: in tars attribute of container_layer_ rule //:package_store_1p_layer: '//:package_store_1p_tar' does not produce any container_layer_ tars files (expected .tar, .tar.xz, .tar.gz or .tgz). Since this rule was created by the macro 'container_layer', the error might have been caused by the macro implementation
```

if there are empty layers