### PR TITLE
feat: add backward compat handling for rules_js 1.x js_info parameters declarations, transitive_declarations, npm_package_store_deps and transitive_npm_linked_package_files

### DIFF
--- a/js/private/js_info.bzl
+++ b/js/private/js_info.bzl
@@ -16,11 +16,12 @@ JsInfo = provider(
 def js_info(
         target,
         sources = depset(),
-        types = depset(),
+        types = None,
         transitive_sources = depset(),
-        transitive_types = depset(),
-        npm_sources = depset(),
-        npm_package_store_infos = depset()):
+        transitive_types = None,
+        npm_sources = None,
+        npm_package_store_infos = None,
+        **kwargs):
     """Construct a JsInfo.
 
     Args:
@@ -31,10 +32,70 @@ def js_info(
         transitive_types: See JsInfo documentation
         npm_sources: See JsInfo documentation
         npm_package_store_infos: See JsInfo documentation
+        **kwargs: For backward compat support
 
     Returns:
         A JsInfo provider
     """
+
+    # Handle backward compat for rules_js 1.x js_info factory parameters:
+    # - declarations
+    declarations = kwargs.pop("declarations", None)
+    if declarations != None:
+        if types != None:
+            fail("Cannot set both types and declarations")
+
+        # buildifier: disable=print
+        print("""
+WARNING: js_info 'declarations' is deprecated. Use 'types' instead.""")
+        types = declarations
+
+    # - transitive_declarations
+    transitive_declarations = kwargs.pop("transitive_declarations", None)
+    if transitive_declarations != None:
+        if transitive_types != None:
+            fail("Cannot set both transitive_types and transitive_declarations")
+
+        # buildifier: disable=print
+        print("""
+WARNING: js_info 'transitive_declarations' is deprecated. Use 'transitive_types' instead.""")
+        transitive_types = transitive_declarations
+
+    # - npm_package_store_deps
+    npm_package_store_deps = kwargs.pop("npm_package_store_deps", None)
+    if npm_package_store_deps != None:
+        if npm_package_store_infos != None:
+            fail("Cannot set both npm_package_store_infos and npm_package_store_deps")
+
+        # buildifier: disable=print
+        print("""
+WARNING: js_info 'npm_package_store_deps' is deprecated. Use 'npm_package_store_infos' instead.""")
+        npm_package_store_infos = npm_package_store_deps
+
+    # - transitive_npm_linked_package_files
+    transitive_npm_linked_package_files = kwargs.pop("transitive_npm_linked_package_files", None)
+    if transitive_npm_linked_package_files != None:
+        if npm_sources != None:
+            fail("Cannot set both npm_sources and transitive_npm_linked_package_files")
+
+        # buildifier: disable=print
+        print("""
+WARNING: js_info 'transitive_npm_linked_package_files' is deprecated. Use 'npm_sources' instead.""")
+        npm_sources = transitive_npm_linked_package_files
+    if len(kwargs):
+        msg = "Invalid js_info parameter '{}'".format(kwargs.keys()[0])
+        fail(msg)
+
+    # Default to depset()
+    if types == None:
+        types = depset()
+    if transitive_types == None:
+        transitive_types = depset()
+    if npm_sources == None:
+        npm_sources = depset()
+    if npm_package_store_infos == None:
+        npm_package_store_infos = depset()
+
     if type(target) != "Label":
         msg = "Expected target to be a Label but got {}".format(type(target))
         fail(msg)


### PR DESCRIPTION
Makes it easier for custom downstream rule sets to support both rules_js 1.x and rules_js 2.x