### PR TITLE
refactor: reuse npm_translate_lock_state parse logic in bzlmod

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -92,7 +92,7 @@ npm_translate_lock_lib = struct(
 def _npm_translate_lock_impl(rctx):
     rctx.report_progress("Initializing")
 
-    state = npm_translate_lock_state.new(rctx)
+    state = npm_translate_lock_state.new(rctx.name, rctx, rctx.attr, rctx.attr.bzlmod)
 
     # If a pnpm lock file has not been specified then we need to bootstrap by running `pnpm
     # import` in the user's repository


### PR DESCRIPTION
This way common logic such as parsing `pnpm.*` from the package.json can live in the `npm_translate_lock_state.bzl` util.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
