### PR TITLE
chore: bump to buildifier 6.4.0

### DIFF
--- a/js/dev_repositories.bzl
+++ b/js/dev_repositories.bzl
@@ -41,9 +41,9 @@ def rules_js_dev_dependencies():
 
     http_archive(
         name = "buildifier_prebuilt",
-        sha256 = "72b5bb0853aac597cce6482ee6c62513318e7f2c0050bc7c319d75d03d8a3875",
-        strip_prefix = "buildifier-prebuilt-6.3.3",
-        urls = ["https://github.com/keith/buildifier-prebuilt/archive/6.3.3.tar.gz"],
+        sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
+        strip_prefix = "buildifier-prebuilt-6.4.0",
+        urls = ["http://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz"],
     )
 
     http_archive(


### PR DESCRIPTION
bzlmod is already on 6.4.0. This puts WORKSPACE in alignment.