### PR TITLE
fix(bzlmod): npm_translate_lock should read registry from npmrc

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -134,7 +134,7 @@ WARNING: Cannot determine home directory in order to load home `.npmrc` file in 
         all_lifecycle_hooks_execution_requirements = lifecycle_hooks_execution_requirements,
         all_lifecycle_hooks_use_default_shell_env = lifecycle_hooks_use_default_shell_env,
         registries = registries,
-        default_registry = utils.default_registry(),
+        default_registry = state.default_registry(),
         npm_auth = npm_auth,
     )
 


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_js/issues/1479

Thanks to @hunshcn for pointing on the fix in https://github.com/aspect-build/rules_js/pull/1716.