### PR TITLE
refactor: set bazel_compatibility for bzlmod to >=6.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,7 @@
 module(
     name = "aspect_rules_js",
     version = "0.0.0",
+    bazel_compatibility = [">=6.0.0"],
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
We have dropped support for Bazel 5 in rules_js 2