### PR TITLE
refactor: align pnpm lock v6+ with v5 target names

### DIFF
--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -55,6 +55,9 @@ def lockfile_test(name = "lockfile", node_modules = "node_modules"):
             ":.aspect_rules_js/node_modules/@aspect-test+c@2.0.2/lc",
             ":.aspect_rules_js/node_modules/@aspect-test+c@2.0.2/pkg_lc",
 
+            # TODO(2.0): normalized across lockfiles in lockfile v54+
+            # ":.aspect_rules_js/node_modules/meaning-of-life@1.0.0_o3deharooos255qt5xdujc3cuq",
+
             # TODO: differs across lockfile versions
             # Direct deps from custom registry
             # ":.aspect_rules_js/node_modules/@types+node@registry.npmjs.org+@types+node@16.18.11",

--- a/npm/private/test/snapshots/bzlmod/npm_defs.bzl
+++ b/npm/private/test/snapshots/bzlmod/npm_defs.bzl
@@ -588,7 +588,7 @@ load("@@_main~npm~npm__mapbox-gl__1.10.1__links//:defs.bzl", store_580 = "npm_im
 load("@@_main~npm~npm__math-log2__1.0.1__links//:defs.bzl", store_581 = "npm_imported_package_store")
 load("@@_main~npm~npm__mathjs__11.4.0__links//:defs.bzl", link_582 = "npm_link_imported_package_store", store_582 = "npm_imported_package_store")
 load("@@_main~npm~npm__md5__2.3.0__links//:defs.bzl", store_583 = "npm_imported_package_store")
-load("@@_main~npm~npm__meaning-of-life__1.0.0__-1287509853__links//:defs.bzl", link_584 = "npm_link_imported_package_store", store_584 = "npm_imported_package_store")
+load("@@_main~npm~npm__meaning-of-life__1.0.0__o3deharooos255qt5xdujc3cuq__links//:defs.bzl", link_584 = "npm_link_imported_package_store", store_584 = "npm_imported_package_store")
 load("@@_main~npm~npm__media-query-parser__2.0.2__links//:defs.bzl", store_585 = "npm_imported_package_store")
 load("@@_main~npm~npm__merge-stream__2.0.0__links//:defs.bzl", store_586 = "npm_imported_package_store")
 load("@@_main~npm~npm__mime-db__1.52.0__links//:defs.bzl", store_587 = "npm_imported_package_store")

--- a/npm/private/test/snapshots/bzlmod/repositories.bzl
+++ b/npm/private/test/snapshots/bzlmod/repositories.bzl
@@ -14516,21 +14516,21 @@ def npm_repositories():
     )
 
     npm_import(
-        name = "npm__meaning-of-life__1.0.0__-1287509853",
+        name = "npm__meaning-of-life__1.0.0__o3deharooos255qt5xdujc3cuq",
         root_package = "",
         link_workspace = "",
         link_packages = {
             "examples/npm_deps": ["meaning-of-life"],
         },
         package = "meaning-of-life",
-        version = "1.0.0_-1287509853",
+        version = "1.0.0_o3deharooos255qt5xdujc3cuq",
         url = "https://registry.npmjs.org/meaning-of-life/-/meaning-of-life-1.0.0.tgz",
         package_visibility = ["//visibility:public"],
         dev = True,
         generate_bzl_library_targets = True,
         integrity = "sha512-fVA4xSydqtK9owabGcYw1r4EKEsMOVVeYQLeCXPu77Z+8Y2j2B2I16UqZlKIOHnYkJ4RSvpJ00ywy9IWjmuxYw==",
         transitive_closure = {
-            "meaning-of-life": ["1.0.0_-1287509853"],
+            "meaning-of-life": ["1.0.0_o3deharooos255qt5xdujc3cuq"],
         },
         patches = ["@@//:examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch", "@@//examples/npm_deps:patches/meaning-of-life@1.0.0-after_pnpm.patch"],
         patch_args = ["-p1"],

--- a/npm/private/test/snapshots/wksp/npm_defs.bzl
+++ b/npm/private/test/snapshots/wksp/npm_defs.bzl
@@ -588,7 +588,7 @@ load("@@npm__mapbox-gl__1.10.1__links//:defs.bzl", store_580 = "npm_imported_pac
 load("@@npm__math-log2__1.0.1__links//:defs.bzl", store_581 = "npm_imported_package_store")
 load("@@npm__mathjs__11.4.0__links//:defs.bzl", link_582 = "npm_link_imported_package_store", store_582 = "npm_imported_package_store")
 load("@@npm__md5__2.3.0__links//:defs.bzl", store_583 = "npm_imported_package_store")
-load("@@npm__meaning-of-life__1.0.0__-1287509853__links//:defs.bzl", link_584 = "npm_link_imported_package_store", store_584 = "npm_imported_package_store")
+load("@@npm__meaning-of-life__1.0.0__o3deharooos255qt5xdujc3cuq__links//:defs.bzl", link_584 = "npm_link_imported_package_store", store_584 = "npm_imported_package_store")
 load("@@npm__media-query-parser__2.0.2__links//:defs.bzl", store_585 = "npm_imported_package_store")
 load("@@npm__merge-stream__2.0.0__links//:defs.bzl", store_586 = "npm_imported_package_store")
 load("@@npm__mime-db__1.52.0__links//:defs.bzl", store_587 = "npm_imported_package_store")

--- a/npm/private/test/snapshots/wksp/repositories.bzl
+++ b/npm/private/test/snapshots/wksp/repositories.bzl
@@ -14516,21 +14516,21 @@ def npm_repositories():
     )
 
     npm_import(
-        name = "npm__meaning-of-life__1.0.0__-1287509853",
+        name = "npm__meaning-of-life__1.0.0__o3deharooos255qt5xdujc3cuq",
         root_package = "",
         link_workspace = "",
         link_packages = {
             "examples/npm_deps": ["meaning-of-life"],
         },
         package = "meaning-of-life",
-        version = "1.0.0_-1287509853",
+        version = "1.0.0_o3deharooos255qt5xdujc3cuq",
         url = "https://registry.npmjs.org/meaning-of-life/-/meaning-of-life-1.0.0.tgz",
         package_visibility = ["//visibility:public"],
         dev = True,
         generate_bzl_library_targets = True,
         integrity = "sha512-fVA4xSydqtK9owabGcYw1r4EKEsMOVVeYQLeCXPu77Z+8Y2j2B2I16UqZlKIOHnYkJ4RSvpJ00ywy9IWjmuxYw==",
         transitive_closure = {
-            "meaning-of-life": ["1.0.0_-1287509853"],
+            "meaning-of-life": ["1.0.0_o3deharooos255qt5xdujc3cuq"],
         },
         patches = ["@//:examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch", "@//examples/npm_deps:patches/meaning-of-life@1.0.0-after_pnpm.patch"],
         patch_args = ["-p1"],

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -78,6 +78,9 @@ def _convert_pnpm_v6_version_peer_dep(version):
     # version(@scope/peer@version)(@scope/peer@version)
     # to a pnpm lock file v5 version_peer_version that is compatible with rules_js.
     if version[-1] == ")":
+        # Drop the patch_hash= not present in v5 so (patch_hash=123) -> (123) like v5
+        version = version.replace("(patch_hash=", "(")
+
         # There is a peer dep if the string ends with ")"
         peer_dep_index = version.find("(")
         peer_dep = version[peer_dep_index:]


### PR DESCRIPTION
Lockfile v5 had `1.2.3_hash` where v6+ has `1.2.3_(patch_hash=1.2.3)`. In 2.x we can add the extra test case that is broken in lockfile v5.3 (which we dropped in 2.x).

---

### Test plan

- Covered by existing test cases
