### PR TITLE
fix: fail lockfile translation for pnpm pnpm v9+ when no onlyBuildDependencies specified

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -114,6 +114,8 @@ See https://github.com/aspect-build/rules_js/issues/1445
 
     helpers.verify_patches(rctx, state)
 
+    helpers.verify_lifecycle_hooks_specified(rctx, state)
+
     rctx.report_progress("Translating {}".format(state.label_store.relative_path("pnpm_lock")))
 
     importers, packages = translate_to_transitive_closure(

--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -478,6 +478,7 @@ def _load_lockfile(priv, rctx, _, label_store):
     importers = {}
     packages = {}
     patched_dependencies = {}
+    lock_version = None
     lock_parse_err = None
 
     yq_args = [
@@ -489,8 +490,9 @@ def _load_lockfile(priv, rctx, _, label_store):
     if result.return_code:
         lock_parse_err = "failed to parse pnpm lock file with yq. '{}' exited with {}: \nSTDOUT:\n{}\nSTDERR:\n{}".format(" ".join(yq_args), result.return_code, result.stdout, result.stderr)
     else:
-        importers, packages, patched_dependencies, lock_parse_err = utils.parse_pnpm_lock_json(result.stdout if result.stdout != "null" else None)  # NB: yq will return the string "null" if the yaml file is empty
+        importers, packages, patched_dependencies, lock_version, lock_parse_err = utils.parse_pnpm_lock_json(result.stdout if result.stdout != "null" else None)  # NB: yq will return the string "null" if the yaml file is empty
 
+    priv["lock_version"] = lock_version
     priv["importers"] = importers
     priv["packages"] = packages
     priv["patched_dependencies"] = patched_dependencies
@@ -522,6 +524,9 @@ def _default_registry(priv):
 
 def _link_workspace(priv):
     return priv["link_workspace"]
+
+def _lockfile_version(priv):
+    return priv["lock_version"]
 
 def _importers(priv):
     return priv["importers"]
@@ -583,6 +588,7 @@ def _new(rctx_name, rctx, attr, bzlmod):
         should_update_pnpm_lock = lambda: _should_update_pnpm_lock(priv),
         default_registry = lambda: _default_registry(priv),
         link_workspace = lambda: _link_workspace(priv),
+        lockfile_version = lambda: _lockfile_version(priv),
         importers = lambda: _importers(priv),
         packages = lambda: _packages(priv),
         patched_dependencies = lambda: _patched_dependencies(priv),

--- a/npm/private/test/parse_pnpm_lock_tests.bzl
+++ b/npm/private/test/parse_pnpm_lock_tests.bzl
@@ -69,6 +69,7 @@ def _parse_lockfile_v5_test_impl(ctx):
             },
         },
         {},
+        5.4,
         None,
     )
 
@@ -130,6 +131,7 @@ def _parse_lockfile_v6_test_impl(ctx):
             },
         },
         {},
+        6.0,
         None,
     )
 

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -288,7 +288,7 @@ def _parse_pnpm_lock_common(parsed, err):
 
     patched_dependencies = parsed.get("patchedDependencies", {})
 
-    return importers, packages, patched_dependencies, None
+    return importers, packages, patched_dependencies, lockfile_version, None
 
 def _assert_lockfile_version(version, testonly = False):
     if type(version) != type(1.0):


### PR DESCRIPTION
To ensure users always set `onlyBuildDependencies` for pnpm 9+ where we can not automatically detect lifecycle events from only the lockfile.

---

### Test plan

- Manual testing; please provide instructions so we can reproduce:
