### PR TITLE
refactor: normalize pnpm lockfile data in parser

### DIFF
--- a/e2e/pnpm_lockfiles/README.md
+++ b/e2e/pnpm_lockfiles/README.md
@@ -13,3 +13,5 @@ TODO:
 -   npm: references: `@aspect-test/a2": "npm:@aspect-test/a"`
 
     No :node_modules/\* targets are generated for aliases to npm packages.
+
+    Note: _sometimes_ fails to install with pnpm9

--- a/e2e/pnpm_lockfiles/base/package.json
+++ b/e2e/pnpm_lockfiles/base/package.json
@@ -8,6 +8,7 @@
         "uvu": "0.5.6",
         "@scoped/a": "workspace:*",
         "@scoped/b": "link:../projects/b",
+        "@scoped/c": "file:../projects/c",
         "@scoped/d": "../projects/d"
     },
     "devDependencies": {

--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -101,9 +101,8 @@ def lockfile_test(name = None):
             # Direct deps from custom registry
             # ":.aspect_rules_js/node_modules/@types+node@registry.npmjs.org+@types+node@16.18.11",
 
-            # TODO: differs across lockfile versions
-            # Direct deps with peers differ across lockfile versions
-            # ":.aspect_rules_js/node_modules/@aspect-test+d@2.0.0_@aspect-test+c@2.0.2",
+            # Direct deps with peers
+            ":.aspect_rules_js/node_modules/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.2",
         ],
     )
 

--- a/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
@@ -14,6 +14,7 @@ importers:
       '@aspect-test/c': 2.0.0
       '@scoped/a': workspace:*
       '@scoped/b': link:../projects/b
+      '@scoped/c': file:../projects/c
       '@scoped/d': ../projects/d
       '@types/archiver': 5.3.1
       '@types/node': 16.18.11
@@ -24,6 +25,7 @@ importers:
       '@aspect-test/a': 5.0.2
       '@scoped/a': link:../projects/a
       '@scoped/b': link:../projects/b
+      '@scoped/c': file:../projects/c
       '@scoped/d': link:../projects/d
       meaning-of-life: 1.0.0_o3deharooos255qt5xdujc3cuq
       rollup: 3.2.5
@@ -151,6 +153,13 @@ packages:
       diff: 5.2.0
       kleur: 4.1.5
       sade: 1.8.1
+    dev: false
+
+  file:../projects/c:
+    resolution: {directory: ../projects/c, type: directory}
+    name: '@scoped/c'
+    dependencies:
+      '@scoped/a': link:../a
     dev: false
 
   registry.npmjs.org/@types/archiver/5.3.1:

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -88,6 +88,41 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
 
     if is_root:
         _npm_package_store(
+            name = ".aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+            src = "//projects/c:pkg",
+            package = "@scoped/c",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == native.package_name():
+            # terminal target for direct dependencies
+            _npm_link_package_store(
+                name = "{}/@scoped/c".format(name),
+                src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+
+            # filegroup target that provides a single file which is
+            # package directory for use in $(execpath) and $(rootpath)
+            native.filegroup(
+                name = "{}/@scoped/c/dir".format(name),
+                srcs = [":{}/@scoped/c".format(name)],
+                output_group = "package_directory",
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+            link_targets.append(":{}/@scoped/c".format(name))
+            scope_targets["@scoped"] = scope_targets["@scoped"] + [link_targets[-1]] if "@scoped" in scope_targets else [link_targets[-1]]
+
+    if is_root:
+        _npm_package_store(
             name = ".aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
             src = "//projects/a:pkg",
             package = "@scoped/a",
@@ -221,6 +256,10 @@ def npm_link_targets(name = "node_modules", package = None):
             link_targets.append("//{}:{}/uvu".format(bazel_package, name))
             link_targets.append("//{}:{}/@types/archiver".format(bazel_package, name))
             link_targets.append("//{}:{}/@types/node".format(bazel_package, name))
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == bazel_package:
+            link_targets.append("//{}:{}/@scoped/c".format(bazel_package, name))
 
     for link_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
         if link_package == bazel_package:

--- a/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@scoped/b':
         specifier: link:../projects/b
         version: link:../projects/b
+      '@scoped/c':
+        specifier: file:../projects/c
+        version: file:../projects/c
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
@@ -168,6 +171,13 @@ packages:
       diff: 5.2.0
       kleur: 4.1.5
       sade: 1.8.1
+    dev: false
+
+  file:../projects/c:
+    resolution: {directory: ../projects/c, type: directory}
+    name: '@scoped/c'
+    dependencies:
+      '@scoped/a': link:../a
     dev: false
 
   registry.npmjs.org/@types/archiver@5.3.1:

--- a/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@scoped/b':
         specifier: link:../projects/b
         version: link:../projects/b
+      '@scoped/c':
+        specifier: file:../projects/c
+        version: file:../projects/c
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
@@ -172,6 +175,13 @@ packages:
       diff: 5.2.0
       kleur: 4.1.5
       sade: 1.8.1
+    dev: false
+
+  file:../projects/c:
+    resolution: {directory: ../projects/c, type: directory}
+    name: '@scoped/c'
+    dependencies:
+      '@scoped/a': link:../a
     dev: false
 
   registry.npmjs.org/@types/archiver@5.3.1:

--- a/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@scoped/b':
         specifier: link:../projects/b
         version: link:../projects/b
+      '@scoped/c':
+        specifier: file:../projects/c
+        version: file:../projects/c
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
@@ -100,6 +103,9 @@ packages:
     resolution: {integrity: sha512-GyAxHYKN650db+xnimHnL2LPz65ilmQsVhCasWA7drDNQn/rfmPiEVMzjRiS7m46scXIERaBmiJMzYDf0bIUbA==}
     hasBin: true
 
+  '@scoped/c@file:../projects/c':
+    resolution: {directory: ../projects/c, type: directory}
+
   '@types/archiver@5.3.1':
     resolution: {integrity: sha512-wKYZaSXaDvTZuInAWjCeGG7BEAgTWG2zZW0/f7IYFcoHB2X2d9lkVFnrOlXl3W6NrvO6Ml3FLLu8Uksyymcpnw==, tarball: https://registry.npmjs.org/@types/archiver/-/archiver-5.3.1.tgz}
 
@@ -174,6 +180,10 @@ snapshots:
       '@aspect-test/c': 2.0.2
 
   '@aspect-test/e@1.0.0': {}
+
+  '@scoped/c@file:../projects/c':
+    dependencies:
+      '@scoped/a': link:../a
 
   '@types/archiver@5.3.1':
     dependencies:

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -93,6 +93,41 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
 
     if is_root:
         _npm_package_store(
+            name = ".aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+            src = "//projects/c:pkg",
+            package = "@scoped/c",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == native.package_name():
+            # terminal target for direct dependencies
+            _npm_link_package_store(
+                name = "{}/@scoped/c".format(name),
+                src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+
+            # filegroup target that provides a single file which is
+            # package directory for use in $(execpath) and $(rootpath)
+            native.filegroup(
+                name = "{}/@scoped/c/dir".format(name),
+                srcs = [":{}/@scoped/c".format(name)],
+                output_group = "package_directory",
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+            link_targets.append(":{}/@scoped/c".format(name))
+            scope_targets["@scoped"] = scope_targets["@scoped"] + [link_targets[-1]] if "@scoped" in scope_targets else [link_targets[-1]]
+
+    if is_root:
+        _npm_package_store(
             name = ".aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
             src = "//projects/a:pkg",
             package = "@scoped/a",
@@ -227,6 +262,10 @@ def npm_link_targets(name = "node_modules", package = None):
             link_targets.append("//{}:{}/meaning-of-life".format(bazel_package, name))
             link_targets.append("//{}:{}/rollup".format(bazel_package, name))
             link_targets.append("//{}:{}/uvu".format(bazel_package, name))
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == bazel_package:
+            link_targets.append("//{}:{}/@scoped/c".format(bazel_package, name))
 
     for link_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
         if link_package == bazel_package:

--- a/npm/private/test/parse_pnpm_lock_tests.bzl
+++ b/npm/private/test/parse_pnpm_lock_tests.bzl
@@ -15,6 +15,38 @@ def _parse_empty_lock_test_impl(ctx):
 
     return unittest.end(env)
 
+expected_importers = {
+    ".": {
+        "dependencies": {
+            "@aspect-test/a": "5.0.0",
+        },
+        "dev_dependencies": {},
+        "optional_dependencies": {},
+    },
+}
+expected_packages = {
+    "@aspect-test/a@5.0.0": {
+        "id": None,
+        "name": "@aspect-test/a",
+        "dependencies": {
+            "@aspect-test/b": "5.0.0",
+            "@aspect-test/c": "1.0.0",
+            "@aspect-test/d": "2.0.0_at_aspect-test_c_1.0.0",
+        },
+        "optional_dependencies": {},
+        "peer_dependencies": {},
+        "dev": False,
+        "has_bin": True,
+        "optional": False,
+        "requires_build": False,
+        "version": "5.0.0",
+        "friendly_version": "5.0.0",
+        "resolution": {
+            "integrity": "sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==",
+        },
+    },
+}
+
 def _parse_lockfile_v5_test_impl(ctx):
     env = unittest.begin(ctx)
 
@@ -45,29 +77,8 @@ def _parse_lockfile_v5_test_impl(ctx):
 """)
 
     expected = (
-        {
-            ".": {
-                "dependencies": {
-                    "@aspect-test/a": "5.0.0",
-                },
-                "optionalDependencies": {},
-                "devDependencies": {},
-            },
-        },
-        {
-            "/@aspect-test/a/5.0.0": {
-                "resolution": {
-                    "integrity": "sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==",
-                },
-                "hasBin": True,
-                "dependencies": {
-                    "@aspect-test/b": "5.0.0",
-                    "@aspect-test/c": "1.0.0",
-                    "@aspect-test/d": "2.0.0_@aspect-test+c@1.0.0",
-                },
-                "dev": False,
-            },
-        },
+        expected_importers,
+        expected_packages,
         {},
         5.4,
         None,
@@ -107,31 +118,68 @@ def _parse_lockfile_v6_test_impl(ctx):
 """)
 
     expected = (
-        {
-            ".": {
-                "dependencies": {
-                    "@aspect-test/a": "5.0.0",
-                },
-                "optionalDependencies": {},
-                "devDependencies": {},
-            },
-        },
-        {
-            "/@aspect-test/a/5.0.0": {
-                "resolution": {
-                    "integrity": "sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==",
-                },
-                "hasBin": True,
-                "dependencies": {
-                    "@aspect-test/b": "5.0.0",
-                    "@aspect-test/c": "1.0.0",
-                    "@aspect-test/d": "2.0.0_at_aspect-test_c_1.0.0",
-                },
-                "dev": False,
-            },
-        },
+        expected_importers,
+        expected_packages,
         {},
         6.0,
+        None,
+    )
+
+    asserts.equals(env, expected, parsed_json)
+
+    return unittest.end(env)
+
+def _parse_lockfile_v9_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    parsed_json = utils.parse_pnpm_lock_json("""\
+{
+  "lockfileVersion": "9.0",
+  "settings": {
+    "autoInstallPeers": true,
+    "excludeLinksFromLockfile": false
+  },
+  "importers": {
+    ".": {
+      "dependencies": {
+        "@aspect-test/a": {
+          "specifier": "5.0.0",
+          "version": "5.0.0"
+        }
+      }
+    }
+  },
+  "packages": {
+    "@aspect-test/a@5.0.0": {
+      "resolution": {
+        "integrity": "sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw=="
+      },
+      "hasBin": true
+    }
+  },
+  "snapshots": {
+    "@aspect-test/a@5.0.0": {
+      "dependencies": {
+        "@aspect-test/b": "5.0.0",
+        "@aspect-test/c": "1.0.0",
+        "@aspect-test/d": "2.0.0(@aspect-test/c@1.0.0)"
+      }
+    }
+  }
+}
+""")
+
+    # NOTE: unknown properties in >=v9
+    v9_expected_packages = dict(expected_packages)
+    v9_expected_packages["@aspect-test/a@5.0.0"] = dict(v9_expected_packages["@aspect-test/a@5.0.0"])
+    v9_expected_packages["@aspect-test/a@5.0.0"]["dev"] = None
+    v9_expected_packages["@aspect-test/a@5.0.0"]["requires_build"] = None
+
+    expected = (
+        expected_importers,
+        v9_expected_packages,
+        {},
+        9.0,
         None,
     )
 
@@ -142,11 +190,13 @@ def _parse_lockfile_v6_test_impl(ctx):
 a_test = unittest.make(_parse_empty_lock_test_impl, attrs = {})
 b_test = unittest.make(_parse_lockfile_v5_test_impl, attrs = {})
 c_test = unittest.make(_parse_lockfile_v6_test_impl, attrs = {})
+d_test = unittest.make(_parse_lockfile_v9_test_impl, attrs = {})
 
 TESTS = [
     a_test,
     b_test,
     c_test,
+    d_test,
 ]
 
 def parse_pnpm_lock_tests(name):

--- a/npm/private/test/snapshots/wksp/repositories.bzl
+++ b/npm/private/test/snapshots/wksp/repositories.bzl
@@ -1723,11 +1723,11 @@ def npm_repositories():
         integrity = "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
         deps = {
             "string-width": "5.1.2",
-            "string-width-cjs": "/string-width/4.2.3",
+            "string-width-cjs": "/string-width@4.2.3",
             "strip-ansi": "7.1.0",
-            "strip-ansi-cjs": "/strip-ansi/6.0.1",
+            "strip-ansi-cjs": "/strip-ansi@6.0.1",
             "wrap-ansi": "8.1.0",
-            "wrap-ansi-cjs": "/wrap-ansi/7.0.0",
+            "wrap-ansi-cjs": "/wrap-ansi@7.0.0",
         },
         transitive_closure = {
             "@isaacs/cliui": ["8.0.2"],
@@ -17855,7 +17855,7 @@ def npm_repositories():
             "point-in-polygon": "1.1.0",
             "polybooljs": "1.2.0",
             "probe-image-size": "7.2.3",
-            "regl": "/@plotly/regl/2.1.2",
+            "regl": "/@plotly/regl@2.1.2",
             "regl-error2d": "2.0.12",
             "regl-line2d": "3.1.2",
             "regl-scatter2d": "3.3.1",

--- a/npm/private/test/transitive_closure_tests.bzl
+++ b/npm/private/test/transitive_closure_tests.bzl
@@ -6,7 +6,7 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//npm/private:transitive_closure.bzl", "gather_transitive_closure")
 
 TEST_PACKAGES = {
-    "@aspect-test/a/5.0.0": {
+    "@aspect-test/a@5.0.0": {
         "name": "@aspect-test/a",
         "version": "5.0.0",
         "integrity": "sha512-t/lwpVXG/jmxTotGEsmjwuihC2Lvz/Iqt63o78SI3O5XallxtFp5j2WM2M6HwkFiii9I42KdlAF8B3plZMz0Fw==",
@@ -17,21 +17,21 @@ TEST_PACKAGES = {
         },
         "optional_dependencies": {},
     },
-    "@aspect-test/b/5.0.0": {
+    "@aspect-test/b@5.0.0": {
         "dependencies": {},
         "optional_dependencies": {
             "@aspect-test/c": "2.0.0",
         },
     },
-    "@aspect-test/c/1.0.0": {
+    "@aspect-test/c@1.0.0": {
         "dependencies": {},
         "optional_dependencies": {},
     },
-    "@aspect-test/c/2.0.0": {
+    "@aspect-test/c@2.0.0": {
         "dependencies": {},
         "optional_dependencies": {},
     },
-    "@aspect-test/d/2.0.0_@aspect-test+c@1.0.0": {
+    "@aspect-test/d@2.0.0_@aspect-test+c@1.0.0": {
         "dependencies": {},
         "optional_dependencies": {},
     },
@@ -44,12 +44,12 @@ def test_walk_deps(ctx):
     not_no_optional = False
 
     # Walk the example tree above
-    closure = gather_transitive_closure(TEST_PACKAGES, "@aspect-test/a/5.0.0", not_no_optional)
+    closure = gather_transitive_closure(TEST_PACKAGES, "@aspect-test/a@5.0.0", not_no_optional)
     expected = {"@aspect-test/a": ["5.0.0"], "@aspect-test/b": ["5.0.0"], "@aspect-test/c": ["1.0.0", "2.0.0"], "@aspect-test/d": ["2.0.0_@aspect-test+c@1.0.0"]}
     asserts.equals(env, expected, closure)
 
     # Run again with no_optional set, this means we shouldn't walk the dep from @aspect-test/b/5.0.0 -> @aspect-test/c/2.0.0
-    closure = gather_transitive_closure(TEST_PACKAGES, "@aspect-test/a/5.0.0", no_optional)
+    closure = gather_transitive_closure(TEST_PACKAGES, "@aspect-test/a@5.0.0", no_optional)
     expected = {"@aspect-test/a": ["5.0.0"], "@aspect-test/b": ["5.0.0"], "@aspect-test/c": ["1.0.0"], "@aspect-test/d": ["2.0.0_@aspect-test+c@1.0.0"]}
     asserts.equals(env, expected, closure)
 

--- a/npm/private/test/utils_tests.bzl
+++ b/npm/private/test/utils_tests.bzl
@@ -11,10 +11,10 @@ def test_strip_peer_dep_or_patched_version(ctx):
     asserts.equals(
         env,
         "21.1.0",
-        utils.strip_peer_dep_or_patched_version("21.1.0_rollup@2.70.2_x@1.1.1"),
+        utils.strip_v5_peer_dep_or_patched_version("21.1.0_rollup@2.70.2_x@1.1.1"),
     )
-    asserts.equals(env, "1.0.0", utils.strip_peer_dep_or_patched_version("1.0.0_o3deharooos255qt5xdujc3cuq"))
-    asserts.equals(env, "21.1.0", utils.strip_peer_dep_or_patched_version("21.1.0"))
+    asserts.equals(env, "1.0.0", utils.strip_v5_peer_dep_or_patched_version("1.0.0_o3deharooos255qt5xdujc3cuq"))
+    asserts.equals(env, "21.1.0", utils.strip_v5_peer_dep_or_patched_version("21.1.0"))
     return unittest.end(env)
 
 def test_bazel_name(ctx):
@@ -34,9 +34,8 @@ def test_bazel_name(ctx):
 # buildifier: disable=function-docstring
 def test_pnpm_name(ctx):
     env = unittest.begin(ctx)
-    asserts.equals(env, "@scope/y/1.1.1", utils.pnpm_name("@scope/y", "1.1.1"))
-    asserts.equals(env, ("@scope/y", "1.1.1"), utils.parse_pnpm_package_key("@scope/y", "/@scope/y/1.1.1"))
-    asserts.equals(env, ("@scope/y", "registry/@scope/y/1.1.1"), utils.parse_pnpm_package_key("@scope/y", "registry/@scope/y/1.1.1"))
+    asserts.equals(env, "@scope/y@1.1.1", utils.pnpm_name("@scope/y", "1.1.1"))
+    asserts.equals(env, ("@scope/y", "registry/@scope/y@1.1.1"), utils.parse_pnpm_package_key("@scope/y", "registry/@scope/y@1.1.1"))
     asserts.equals(env, ("@scope/y", "1.1.1"), utils.parse_pnpm_package_key("@scope/y", "1.1.1"))
     return unittest.end(env)
 

--- a/npm/private/transitive_closure.bzl
+++ b/npm/private/transitive_closure.bzl
@@ -75,71 +75,12 @@ def gather_transitive_closure(packages, package, no_optional, cache = {}):
 def _get_package_info_deps(package_info, no_optional):
     return package_info["dependencies"] if no_optional else dicts.add(package_info["dependencies"], package_info["optional_dependencies"])
 
-def _gather_package_info(package_path, package_snapshot):
-    if package_path.startswith("/"):
-        # an aliased dependency
-        package = package_path[1:]
-        name, version = utils.parse_pnpm_package_key("", package_path)
-        friendly_version = utils.strip_peer_dep_or_patched_version(version)
-        package_key = package
-    elif package_path.startswith("file:") and utils.is_vendored_tarfile(package_snapshot):
-        if "name" not in package_snapshot:
-            fail("expected package %s to have a name field" % package_path)
-        name = package_snapshot["name"]
-        package = package_snapshot["name"]
-        version = package_path
-        if "version" in package_snapshot:
-            version = package_snapshot["version"]
-        package_key = "{}/{}".format(package, version)
-        friendly_version = version
-    elif package_path.startswith("file:"):
-        package = package_path
-        if "name" not in package_snapshot:
-            msg = "expected package {} to have a name field".format(package_path)
-            fail(msg)
-        name = package_snapshot["name"]
-        version = package_path
-        friendly_version = package_snapshot["version"] if "version" in package_snapshot else version
-        package_key = package
-    else:
-        package = package_path
-        if "name" not in package_snapshot:
-            msg = "expected package {} to have a name field".format(package_path)
-            fail(msg)
-        if "version" not in package_snapshot:
-            msg = "expected package {} to have a version field".format(package_path)
-            fail(msg)
-        name = package_snapshot["name"]
-        version = package_path
-        friendly_version = package_snapshot["version"]
-        package_key = package
-
-    if "resolution" not in package_snapshot:
-        msg = "package {} has no resolution field".format(package_path)
-        fail(msg)
-    id = package_snapshot["id"] if "id" in package_snapshot else None
-    resolution = package_snapshot["resolution"]
-
-    return package_key, {
-        "name": name,
-        "id": id,
-        "version": version,
-        "friendly_version": friendly_version,
-        "resolution": resolution,
-        "dependencies": package_snapshot.get("dependencies", {}),
-        "optional_dependencies": package_snapshot.get("optionalDependencies", {}),
-        "dev": package_snapshot.get("dev", False),
-        "optional": package_snapshot.get("optional", False),
-        "has_bin": package_snapshot.get("hasBin", False),
-        "requires_build": package_snapshot.get("requiresBuild", False),
-    }
-
-def translate_to_transitive_closure(lock_importers, lock_packages, prod = False, dev = False, no_optional = False):
+def translate_to_transitive_closure(importers, packages, prod = False, dev = False, no_optional = False):
     """Implementation detail of translate_package_lock, converts pnpm-lock to a different dictionary with more data.
 
     Args:
-        lock_importers: lockfile importers dict
-        lock_packages: lockfile packages dict
+        importers: workspace projects (pnpm "importers")
+        packages: all package info by name
         prod: If true, only install dependencies
         dev: If true, only install devDependencies
         no_optional: If true, optionalDependencies are not installed
@@ -148,34 +89,21 @@ def translate_to_transitive_closure(lock_importers, lock_packages, prod = False,
         Nested dictionary suitable for further processing in our repository rule
     """
 
-    # All package info mapped by package name
-    packages = {}
-
     # Packages resolved to a different version
     package_version_map = {}
 
-    for package_path, package_snapshot in lock_packages.items():
-        package_key, package_info = _gather_package_info(package_path, package_snapshot)
-
-        if package_key in packages:
-            msg = "ERROR: duplicate package info: {}\n\t{}\n\t{}".format(package_key, packages[package_key], package_info)
-
-            # buildifier: disable=print
-            print(msg)
-
-        packages[package_key] = package_info
-
-        # tarbal versions
+    # tarbal versions
+    for package_key, package_info in packages.items():
         if package_info["resolution"].get("tarball", None) and package_info["resolution"]["tarball"].startswith("file:"):
             package_version_map[package_key] = package_info
 
     # Collect deps of each importer (workspace projects)
-    importers = {}
-    for importPath in lock_importers.keys():
-        lock_importer = lock_importers[importPath]
-        prod_deps = {} if dev else lock_importer.get("dependencies", {})
-        dev_deps = {} if prod else lock_importer.get("devDependencies", {})
-        opt_deps = {} if no_optional else lock_importer.get("optionalDependencies", {})
+    importers_deps = {}
+    for importPath in importers.keys():
+        lock_importer = importers[importPath]
+        prod_deps = {} if dev else lock_importer.get("dependencies")
+        dev_deps = {} if prod else lock_importer.get("dev_dependencies")
+        opt_deps = {} if no_optional else lock_importer.get("optional_dependencies")
 
         deps = dicts.add(prod_deps, opt_deps)
         all_deps = dicts.add(prod_deps, dev_deps, opt_deps)
@@ -187,7 +115,7 @@ def translate_to_transitive_closure(lock_importers, lock_packages, prod = False,
             if info["name"] in all_deps:
                 all_deps[info["name"]] = info["version"]
 
-        importers[importPath] = {
+        importers_deps[importPath] = {
             # deps this importer should pass on if it is linked as a first-party package; this does
             # not include devDependencies
             "deps": deps,
@@ -199,15 +127,14 @@ def translate_to_transitive_closure(lock_importers, lock_packages, prod = False,
     # Collect transitive dependencies for each package
     cache = {}
     for package in packages.keys():
-        package_info = packages[package]
-
-        package_info["transitive_closure"] = gather_transitive_closure(
+        transitive_closure = gather_transitive_closure(
             packages,
             package,
             no_optional,
             cache,
         )
 
-        cache[package] = package_info["transitive_closure"]
+        packages[package]["transitive_closure"] = transitive_closure
+        cache[package] = transitive_closure
 
-    return (importers, packages)
+    return (importers_deps, packages)


### PR DESCRIPTION
This way the data is standardized to a format for rules_js at parse time instead of elsewhere throughout the code.

Today the lockfile parsing normalizes to a version similar to pnpm lock v5, then `_gather_package_info` normalizes that a bit to a more rules_js specific format. The idea of this PR is to directly convert to that rules_js format as part of parsing, instead of `pnpm vX => pnpm v5 => rules_js` (where X = 5,6,9) we will have `pnpm vX => rules_js` and ideally have less code...

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
