### PR TITLE
refactor: detect and log duplicate package keys

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -12,7 +12,6 @@ load("//npm/private:npm_translate_lock_macro_helpers.bzl", macro_helpers = "help
 load("//npm/private:npm_translate_lock_state.bzl", "npm_translate_lock_state")
 load("//npm/private:npmrc.bzl", "parse_npmrc")
 load("//npm/private:transitive_closure.bzl", "translate_to_transitive_closure")
-load("//npm/private:utils.bzl", "utils")
 
 LATEST_PNPM_VERSION = _LATEST_PNPM_VERSION
 

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -161,7 +161,13 @@ def _convert_v6_packages(packages):
                     dependencies[dep_name] = _convert_pnpm_v6_package_name(dep_version)
                 package_info[key] = dependencies
 
-        result[_convert_pnpm_v6_package_name(package)] = package_info
+        package_key = _convert_pnpm_v6_package_name(package)
+
+        if package_key in result:
+            msg = "ERROR: duplicate package: {}\n\t{}\n\t{}".format(package_key, result[package_key], package_info)
+            fail(msg)
+
+        result[package_key] = package_info
 
     return result
 
@@ -228,7 +234,13 @@ def _convert_v9_packages(packages, snapshots):
         for info_name, info_value in package_info.items():
             snapshot_info[info_name] = info_value
 
-        result[_convert_pnpm_v9_package_name(package)] = snapshot_info
+        package_key = _convert_pnpm_v9_package_name(package)
+
+        if package_key in result:
+            msg = "ERROR: duplicate package: {}\n\t{}\n\t{}".format(package_key, result[package_key], snapshot_info)
+            fail(msg)
+
+        result[package_key] = snapshot_info
 
     return result
 


### PR DESCRIPTION
Some of these were useful when debugging pnpm 9, some name changes just for consistency, one WARNING for a case that I think is a bug today.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
