### PR TITLE
feat: add include_npm_sources to npm_package

### DIFF
--- a/docs/npm_package.md
+++ b/docs/npm_package.md
@@ -17,7 +17,7 @@ npm_package(<a href="#npm_package-name">name</a>, <a href="#npm_package-srcs">sr
             <a href="#npm_package-include_external_repositories">include_external_repositories</a>, <a href="#npm_package-include_srcs_packages">include_srcs_packages</a>, <a href="#npm_package-exclude_srcs_packages">exclude_srcs_packages</a>,
             <a href="#npm_package-include_srcs_patterns">include_srcs_patterns</a>, <a href="#npm_package-exclude_srcs_patterns">exclude_srcs_patterns</a>, <a href="#npm_package-replace_prefixes">replace_prefixes</a>, <a href="#npm_package-allow_overwrites">allow_overwrites</a>,
             <a href="#npm_package-include_sources">include_sources</a>, <a href="#npm_package-include_types">include_types</a>, <a href="#npm_package-include_transitive_sources">include_transitive_sources</a>, <a href="#npm_package-include_transitive_types">include_transitive_types</a>,
-            <a href="#npm_package-include_runfiles">include_runfiles</a>, <a href="#npm_package-hardlink">hardlink</a>, <a href="#npm_package-publishable">publishable</a>, <a href="#npm_package-verbose">verbose</a>, <a href="#npm_package-kwargs">kwargs</a>)
+            <a href="#npm_package-include_npm_sources">include_npm_sources</a>, <a href="#npm_package-include_runfiles">include_runfiles</a>, <a href="#npm_package-hardlink">hardlink</a>, <a href="#npm_package-publishable">publishable</a>, <a href="#npm_package-verbose">verbose</a>, <a href="#npm_package-kwargs">kwargs</a>)
 </pre>
 
 A macro that packages sources into a directory (a tree artifact) and provides an `NpmPackageInfo`.
@@ -58,18 +58,23 @@ for more information on supported globbing patterns.
 `npm_package` makes use of `copy_to_directory`
 (https://docs.aspect.build/rules/aspect_bazel_lib/docs/copy_to_directory) under the hood,
 adopting its API and its copy action using composition. However, unlike `copy_to_directory`,
-`npm_package` includes `transitive_sources` and `transitive_types` files from `JsInfo` providers in srcs
+`npm_package` includes direct and transitive sources and types files from `JsInfo` providers in srcs
 by default. The behavior of including sources and types from `JsInfo` can be configured
-using the `include_sources`, `include_transitive_sources`, `include_types`, `include_transitive_types`
-attributes.
+using the `include_sources`, `include_transitive_sources`, `include_types`, `include_transitive_types`.
 
 The two `include*_types` options may cause type-check actions to run, which slows down your
 development round-trip.
 You can pass the Bazel option `--@aspect_rules_js//npm:exclude_types_from_npm_packages`
 to override these two attributes for an individual `bazel` invocation, avoiding the type-check.
 
-`npm_package` also includes default runfiles from `srcs` by default which `copy_to_directory` does not. This behavior
-can be configured with the `include_runfiles` attribute.
+As of rules_js 2.0, the recommended solution for avoiding eager type-checking when linking
+1p deps is to link `js_library` or any `JsInfo` producing targets directly without the
+indirection of going through an `npm_package` target (see https://github.com/aspect-build/rules_js/pull/1646
+for more details).
+
+`npm_package` can also include npm packages sources and default runfiles from `srcs` which `copy_to_directory` does not.
+These behaviors can be configured with the `include_npm_sourfes` and `include_runfiles` attributes
+respectively.
 
 The default `include_srcs_packages`, `[".", "./**"]`, prevents files from outside of the target's
 package and subpackages from being included.
@@ -101,10 +106,11 @@ To stamp the current git tag as the "version" in the package.json file, see
 | <a id="npm_package-exclude_srcs_patterns"></a>exclude_srcs_patterns |  List of paths (with glob support) to exclude from output directory.<br><br>Files in srcs are not copied to the output directory if their output directory path, after applying `root_paths`, matches one of the patterns specified.<br><br>Forward slashes (`/`) should be used as path separators.<br><br>Files that do not have matching output directory paths are subject to subsequent filters and transformations to determine if they are copied and what their path in the output directory will be.<br><br>Globs are supported (see rule docstring above).   |  `["**/node_modules/**"]` |
 | <a id="npm_package-replace_prefixes"></a>replace_prefixes |  Map of paths prefixes (with glob support) to replace in the output directory path when copying files.<br><br>If the output directory path for a file starts with or fully matches a a key in the dict then the matching portion of the output directory path is replaced with the dict value for that key. The final path segment matched can be a partial match of that segment and only the matching portion will be replaced. If there are multiple keys that match, the longest match wins.<br><br>Forward slashes (`/`) should be used as path separators.<br><br>Replace prefix transformation are the final step in the list of filters and transformations. The final output path of a file being copied into the output directory is determined at this step.<br><br>Globs are supported (see rule docstring above).   |  `{}` |
 | <a id="npm_package-allow_overwrites"></a>allow_overwrites |  If True, allow files to be overwritten if the same output file is copied to twice.<br><br>The order of srcs matters as the last copy of a particular file will win when overwriting. Performance of `npm_package` will be slightly degraded when allow_overwrites is True since copies cannot be parallelized out as they are calculated. Instead all copy paths must be calculated before any copies can be started.   |  `False` |
-| <a id="npm_package-include_sources"></a>include_sources |  When True, `sources` from `JsInfo` providers in `data` targets are included in the list of available files to copy.   |  `True` |
-| <a id="npm_package-include_types"></a>include_types |  When True, `types` from `JsInfo` providers in `data` targets are included in the list of available files to copy.   |  `True` |
-| <a id="npm_package-include_transitive_sources"></a>include_transitive_sources |  When True, `transitive_sources` from `JsInfo` providers in `data` targets are included in the list of available files to copy.   |  `True` |
-| <a id="npm_package-include_transitive_types"></a>include_transitive_types |  When True, `transitive_types` from `JsInfo` providers in `data` targets are included in the list of available files to copy.   |  `True` |
+| <a id="npm_package-include_sources"></a>include_sources |  When True, `sources` from `JsInfo` providers in `srcs` targets are included in the list of available files to copy.   |  `True` |
+| <a id="npm_package-include_types"></a>include_types |  When True, `types` from `JsInfo` providers in `srcs` targets are included in the list of available files to copy.   |  `True` |
+| <a id="npm_package-include_transitive_sources"></a>include_transitive_sources |  When True, `transitive_sources` from `JsInfo` providers in `srcs` targets are included in the list of available files to copy.   |  `True` |
+| <a id="npm_package-include_transitive_types"></a>include_transitive_types |  When True, `transitive_types` from `JsInfo` providers in `srcs` targets are included in the list of available files to copy.   |  `True` |
+| <a id="npm_package-include_npm_sources"></a>include_npm_sources |  When True, `npm_sources` from `JsInfo` providers in `srcs` targets are included in the list of available files to copy.   |  `False` |
 | <a id="npm_package-include_runfiles"></a>include_runfiles |  When True, default runfiles from `srcs` targets are included in the list of available files to copy.<br><br>This may be needed in a few cases:<br><br>- to work-around issues with rules that don't provide everything needed in sources, transitive_sources, types & transitive_types - to depend on the runfiles targets that don't use JsInfo<br><br>NB: The default value will be flipped to False in the next major release as runfiles are not needed in the general case and adding them to the list of files available to copy can add noticeable overhead to the analysis phase in a large repository with many npm_package targets.   |  `False` |
 | <a id="npm_package-hardlink"></a>hardlink |  Controls when to use hardlinks to files instead of making copies.<br><br>Creating hardlinks is much faster than making copies of files with the caveat that hardlinks share file permissions with their source.<br><br>Since Bazel removes write permissions on files in the output tree after an action completes, hardlinks to source files are not recommended since write permissions will be inadvertently removed from sources files.<br><br>- `auto`: hardlinks are used for generated files already in the output tree - `off`: all files are copied - `on`: hardlinks are used for all files (not recommended)   |  `"auto"` |
 | <a id="npm_package-publishable"></a>publishable |  When True, enable generation of `{name}.publish` target   |  `False` |

--- a/npm/private/test/npm_package/BUILD.bazel
+++ b/npm/private/test/npm_package/BUILD.bazel
@@ -35,7 +35,31 @@ copy_to_directory(
 )
 
 diff_test(
-    name = "test",
+    name = "test_pkg",
+    file1 = ":pkg",
+    file2 = ":expected_pkg",
+)
+
+npm_package(
+    name = "pkg_with_node_modules",
+    srcs = [":lib_a"],
+    exclude_srcs_patterns = [],
+    include_npm_sources = True,
+    visibility = ["//visibility:public"],
+)
+
+copy_to_directory(
+    name = "expected_pkg_with_node_modules",
+    srcs = [
+        "index.js",
+        ":node_modules/chalk",
+        ":node_modules/chalk/dir",
+        ":package.json",
+    ],
+)
+
+diff_test(
+    name = "test_pkg_with_node_modules",
     file1 = ":pkg",
     file2 = ":expected_pkg",
 )


### PR DESCRIPTION
Since npm packages are no longer included in type in rules_js 2.0, adding the option `include_npm_sources` covers the use case where users want to include `node_modules` folders in their `npm_package`

### Test plan

- Covered by existing test cases
- Added new test case