### PR TITLE
fix: include package store directory in default output of npm_link_package_store

### DIFF
--- a/examples/genrule/BUILD.bazel
+++ b/examples/genrule/BUILD.bazel
@@ -31,13 +31,12 @@ genrule(
     name = "call_acorn",
     srcs = [
         ":one.js",
-        # reference the location where the "acorn" npm package was linked in our root Bazel package.
-        "//:node_modules/acorn",
         "//:node_modules/acorn/dir",
     ],
     outs = ["out1"],
     cmd = " ".join([
         "$(NODE_PATH)",
+        # reference the location where the "acorn" npm package was linked in the rules_js npm package store.
         "./$(execpath //:node_modules/acorn/dir)/bin/acorn",
         "--compact",
         "$(execpath :one.js)",
@@ -69,7 +68,6 @@ genrule(
         ":require_acorn_js",
         # reference the location where the "acorn" npm package was linked in our root Bazel package.
         "//:node_modules/acorn",
-        "//:node_modules/acorn/dir",
     ],
     outs = ["out2"],
     cmd = """

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -92,7 +92,7 @@ def _npm_link_package_store_impl(ctx):
         )
         files.append(bin_file)
 
-    files_depset = depset(files)
+    files_depset = depset(files, transitive = [store_info.files])
 
     transitive_files_depset = depset(files, transitive = [store_info.transitive_files])
 

--- a/npm/private/test/npm_package/BUILD.bazel
+++ b/npm/private/test/npm_package/BUILD.bazel
@@ -26,6 +26,16 @@ npm_package(
     visibility = ["//visibility:public"],
 )
 
+npm_package(
+    name = "pkg_2",
+    srcs = [
+        ":lib_a",
+        ":node_modules/chalk",  # should be excluded
+        "//:node_modules/chalk",  # should be excluded
+    ],
+    visibility = ["//visibility:public"],
+)
+
 copy_to_directory(
     name = "expected_pkg",
     srcs = [
@@ -37,6 +47,12 @@ copy_to_directory(
 diff_test(
     name = "test_pkg",
     file1 = ":pkg",
+    file2 = ":expected_pkg",
+)
+
+diff_test(
+    name = "test_pkg_2",
+    file1 = ":pkg_2",
     file2 = ":expected_pkg",
 )
 
@@ -53,7 +69,6 @@ copy_to_directory(
     srcs = [
         "index.js",
         ":node_modules/chalk",
-        ":node_modules/chalk/dir",
         ":package.json",
     ],
 )


### PR DESCRIPTION
Having a dangling symlink as the default output of `:node_modules/foo` `npm_link_package_store` targets breaks genrules that worked in rules_js 1.0 since they needed to also depend on `:node_modules/foo`. This change fixes that use case.

It also resolves an `npm_package` bug where if a `:node_modules/foo` was included in sources, the underlying copy_to_directory action would fail to resolve the realpath of the dangling symlink and fail. This bug was reported in RELEASE 2.0 tracking issue: https://github.com/aspect-build/rules_js/issues/1671#issuecomment-2111386386. The issue was due to `:node_modules/foo` targets only having the symlink to package store in their default output and not the package store itself. This caused copy_to_directory to fail to follow the symlink since the package store directory was not in the output tree. NB: since the exclude srcs pattern includes `**/node_modules/**` the underlying `copy_to_directory` tool should not try to realpath that file since it is excluded from copying. That upstream fix is in progress here: https://github.com/aspect-build/bazel-lib/pull/857.


### Test plan

- Covered by existing test cases
- Added new test case

`//npm/private/test/npm_package:pkg_2` fails with 
```
ERROR: /Users/greg/aspect/rules/js/rules_js/npm/private/test/npm_package/BUILD.bazel:31:12: Copying files to directory npm/private/test/npm_package/pkg_2 failed: (Exit 1): copy_to_directory failed: error executing CopyToDirectory command (from target //npm/private/test/npm_package:pkg_2) external/aspect_bazel_lib~~toolchains~copy_to_directory_darwin_arm64/copy_to_directory bazel-out/darwin_arm64-fastbuild/bin/npm/private/test/npm_package/pkg_2_config.json ''
2024/05/28 02:58:46 lstat bazel-out/darwin_arm64-fastbuild/bin/npm/private/test/npm_package/node_modules/chalk failed: lstat bazel-out/darwin_arm64-fastbuild/bin/node_modules/.aspect_rules_js/chalk@5.0.1/node_modules/chalk: no such file or directory
```

without this patch
