### PR TITLE
fix(pnpm): support npm: alias dependencies with pnpm lockfile v5

### DIFF
--- a/e2e/pnpm_lockfiles/README.md
+++ b/e2e/pnpm_lockfiles/README.md
@@ -1,16 +1,6 @@
 ### pnpm lockfile testing across versions
 
-TODO:
-
--   http references: `"hello": "https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello"`
-
-    Has inconsistencies across pnpm lockfile versions, issues with pnpm9
-
--   npm: references: `@aspect-test/a2": "npm:@aspect-test/a"`
-
-    No :node_modules/\* targets are generated for aliases to npm packages.
-
-    Note: _sometimes_ fails to install with pnpm9
+See notes in lockfile-test.bzl for test cases of each package.
 
 ## pnpm lockfile edge cases
 

--- a/e2e/pnpm_lockfiles/base/package.json
+++ b/e2e/pnpm_lockfiles/base/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "dependencies": {
         "@aspect-test/a": "^5.0.2",
+        "@aspect-test/a2": "npm:@aspect-test/a",
         "debug": "ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53",
         "hello": "https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello",
         "jsonify": "https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz",

--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -92,7 +92,7 @@ def lockfile_test(name = None):
             # ":node_modules/jsonify", TODO: v9
 
             # npm:
-            # ":node_modules/@aspect-test/c2",
+            ":node_modules/@aspect-test/a2",
 
             # Targets within the virtual store...
             # Direct dep targets

--- a/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
@@ -17,6 +17,7 @@ importers:
   .:
     specifiers:
       '@aspect-test/a': ^5.0.2
+      '@aspect-test/a2': npm:@aspect-test/a
       '@aspect-test/b': 5.0.2
       '@aspect-test/c': 2.0.0
       '@scoped/a': workspace:*
@@ -34,6 +35,7 @@ importers:
       uvu: 0.5.6
     dependencies:
       '@aspect-test/a': 5.0.2
+      '@aspect-test/a2': /@aspect-test/a/5.0.2
       '@scoped/a': link:../projects/a
       '@scoped/b': link:../projects/b
       '@scoped/c': file:../projects/c

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -77,6 +77,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_0(name = "{}/@aspect-test/a".format(name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
+            link_0(name = "{}/@aspect-test/a2".format(name))
+            link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
+            scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
             link_1(name = "{}/@aspect-test/b".format(name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
@@ -278,6 +281,7 @@ def npm_link_targets(name = "node_modules", package = None):
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
+            link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/c".format(bazel_package, name))
             link_targets.append("//{}:{}/is-odd".format(bazel_package, name))

--- a/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@aspect-test/a':
         specifier: ^5.0.2
         version: 5.0.2
+      '@aspect-test/a2':
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
       '@aspect-test/e':
         specifier: ~1.0.0
         version: 1.0.0

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -79,6 +79,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_0(name = "{}/@aspect-test/a".format(name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
+            link_0(name = "{}/@aspect-test/a2".format(name))
+            link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
+            scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
             link_1(name = "{}/@aspect-test/b".format(name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
@@ -283,6 +286,7 @@ def npm_link_targets(name = "node_modules", package = None):
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
+            link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/c".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/e".format(bazel_package, name))

--- a/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@aspect-test/a':
         specifier: ^5.0.2
         version: 5.0.2
+      '@aspect-test/a2':
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
       '@aspect-test/e':
         specifier: ~1.0.0
         version: 1.0.0

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -79,6 +79,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_0(name = "{}/@aspect-test/a".format(name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
+            link_0(name = "{}/@aspect-test/a2".format(name))
+            link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
+            scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
             link_1(name = "{}/@aspect-test/b".format(name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
@@ -283,6 +286,7 @@ def npm_link_targets(name = "node_modules", package = None):
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
+            link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/c".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/e".format(bazel_package, name))

--- a/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@aspect-test/a':
         specifier: ^5.0.2
         version: 5.0.2
+      '@aspect-test/a2':
+        specifier: npm:@aspect-test/a
+        version: '@aspect-test/a@5.0.2'
       '@aspect-test/e':
         specifier: ~1.0.0
         version: 1.0.0

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -79,6 +79,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_0(name = "{}/@aspect-test/a".format(name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
+            link_0(name = "{}/@aspect-test/a2".format(name))
+            link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
+            scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
             link_1(name = "{}/@aspect-test/b".format(name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
@@ -281,6 +284,7 @@ def npm_link_targets(name = "node_modules", package = None):
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
+            link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/c".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/e".format(bazel_package, name))


### PR DESCRIPTION
It's possible this bug has existed with lockfile v5 for quite some time, although I'm not certain.

--

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
