### PR TITLE
refactor(pnpm): remove .parse_pnpm_package_key util

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -634,14 +634,14 @@ def _npm_import_links_rule_impl(rctx):
     deps = {}
 
     for (dep_name, dep_version) in rctx.attr.deps.items():
-        store_package, store_version = utils.parse_pnpm_package_key(dep_name, dep_version)
+        package_store_name = utils.package_store_name(dep_name, dep_version)
         if dep_version.startswith("link:") or dep_version.startswith("file:"):
             dep_store_target = """"//{root_package}:{package_store_root}/{{}}/{package_store_name}".format(link_root_name)"""
         else:
             dep_store_target = """":{package_store_root}/{{}}/{package_store_name}/ref".format(link_root_name)"""
         dep_store_target = dep_store_target.format(
             root_package = rctx.attr.root_package,
-            package_store_name = utils.package_store_name(store_package, store_version),
+            package_store_name = package_store_name,
             package_store_root = utils.package_store_root,
         )
         ref_deps[dep_store_target] = ref_deps[dep_store_target] + [dep_name] if dep_store_target in ref_deps else [dep_name]
@@ -653,7 +653,6 @@ def _npm_import_links_rule_impl(rctx):
         # party npm deps; it is not used for 1st party deps
         for (dep_name, dep_versions) in rctx.attr.transitive_closure.items():
             for dep_version in dep_versions:
-                store_package, store_version = utils.parse_pnpm_package_key(dep_name, dep_version)
                 if dep_version.startswith("link:") or dep_version.startswith("file:"):
                     dep_store_target = """"//{root_package}:{package_store_root}/{{}}/{package_store_name}".format(link_root_name)"""
                     lc_dep_store_target = dep_store_target
@@ -666,14 +665,16 @@ def _npm_import_links_rule_impl(rctx):
                         # of the lifecycle action
                         lc_dep_store_target = """":{package_store_root}/{{}}/{package_store_name}/pkg_pre_lc_lite".format(link_root_name)"""
 
+                package_store_name = utils.package_store_name(dep_name, dep_version)
+
                 dep_store_target = dep_store_target.format(
                     root_package = rctx.attr.root_package,
-                    package_store_name = utils.package_store_name(store_package, store_version),
+                    package_store_name = package_store_name,
                     package_store_root = utils.package_store_root,
                 )
                 lc_dep_store_target = lc_dep_store_target.format(
                     root_package = rctx.attr.root_package,
-                    package_store_name = utils.package_store_name(store_package, store_version),
+                    package_store_name = package_store_name,
                     package_store_root = utils.package_store_root,
                 )
 
@@ -681,14 +682,13 @@ def _npm_import_links_rule_impl(rctx):
                 deps[dep_store_target] = deps[dep_store_target] + [dep_name] if dep_store_target in deps else [dep_name]
     else:
         for (dep_name, dep_version) in rctx.attr.deps.items():
-            store_package, store_version = utils.parse_pnpm_package_key(dep_name, dep_version)
             if dep_version.startswith("link:") or dep_version.startswith("file:"):
                 dep_store_target = """"//{root_package}:{package_store_root}/{{}}/{package_store_name}".format(link_root_name)"""
             else:
                 dep_store_target = """":{package_store_root}/{{}}/{package_store_name}".format(link_root_name)"""
             dep_store_target = dep_store_target.format(
                 root_package = rctx.attr.root_package,
-                package_store_name = utils.package_store_name(store_package, store_version),
+                package_store_name = utils.package_store_name(dep_name, dep_version),
                 package_store_root = utils.package_store_root,
             )
             lc_deps[dep_store_target] = lc_deps[dep_store_target] + [dep_name] if dep_store_target in lc_deps else [dep_name]

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -125,10 +125,10 @@ sh_binary(
             dep_key = "{}+{}".format(name, version)
             transitive_deps = {}
             for raw_package, raw_version in deps.items():
-                store_package, store_version = utils.parse_pnpm_package_key(raw_package, raw_version)
+                package_store_name = utils.package_store_name(raw_package, raw_version)
                 dep_store_target = """"//{root_package}:{package_store_root}/{{}}/{package_store_name}".format(name)""".format(
                     root_package = root_package,
-                    package_store_name = utils.package_store_name(store_package, store_version),
+                    package_store_name = package_store_name,
                     package_store_root = utils.package_store_root,
                 )
                 if dep_store_target not in transitive_deps:
@@ -176,10 +176,10 @@ sh_binary(
                     if dep_importer in importers.keys():
                         raw_deps = importers.get(dep_importer).get("deps")
                     for raw_package, raw_version in raw_deps.items():
-                        store_package, store_version = utils.parse_pnpm_package_key(raw_package, raw_version)
+                        package_store_name = utils.package_store_name(raw_package, raw_version)
                         dep_store_target = """"//{root_package}:{package_store_root}/{{}}/{package_store_name}".format(name)""".format(
                             root_package = root_package,
-                            package_store_name = utils.package_store_name(store_package, store_version),
+                            package_store_name = package_store_name,
                             package_store_root = utils.package_store_root,
                         )
                         if dep_store_target not in transitive_deps:

--- a/npm/private/test/utils_tests.bzl
+++ b/npm/private/test/utils_tests.bzl
@@ -35,16 +35,16 @@ def test_bazel_name(ctx):
 def test_pnpm_name(ctx):
     env = unittest.begin(ctx)
     asserts.equals(env, "@scope/y@1.1.1", utils.pnpm_name("@scope/y", "1.1.1"))
-    asserts.equals(env, ("@scope/y", "registry/@scope/y@1.1.1"), utils.parse_pnpm_package_key("@scope/y", "registry/@scope/y@1.1.1"))
-    asserts.equals(env, ("@scope/y", "1.1.1"), utils.parse_pnpm_package_key("@scope/y", "1.1.1"))
+    asserts.equals(env, "@scope+y@registry+@scope+y@1.1.1", utils.package_store_name("@scope/y", "registry/@scope/y@1.1.1"))
+    asserts.equals(env, "@scope+y@1.1.1", utils.package_store_name("@scope/y", "1.1.1"))
     return unittest.end(env)
 
 # buildifier: disable=function-docstring
 def test_link_version(ctx):
     env = unittest.begin(ctx)
-    asserts.equals(env, ("@scope/y", "0.0.0"), utils.parse_pnpm_package_key("@scope/y", "link:foo"))
-    asserts.equals(env, ("@scope/y", "0.0.0"), utils.parse_pnpm_package_key("@scope/y", "file:bar"))
-    asserts.equals(env, ("@scope/y", "0.0.0"), utils.parse_pnpm_package_key("@scope/y", "file:@foo/bar"))
+    asserts.equals(env, "@scope+y@0.0.0", utils.package_store_name("@scope/y", "link:foo"))
+    asserts.equals(env, "@scope+y@0.0.0", utils.package_store_name("@scope/y", "file:bar"))
+    asserts.equals(env, "@scope+y@0.0.0", utils.package_store_name("@scope/y", "file:@foo/bar"))
     return unittest.end(env)
 
 def test_friendly_name(ctx):

--- a/npm/private/transitive_closure.bzl
+++ b/npm/private/transitive_closure.bzl
@@ -38,7 +38,7 @@ def gather_transitive_closure(packages, package, no_optional, cache = {}):
             if version.startswith("npm:"):
                 # an aliased dependency
                 package_key = version[4:]
-                name, version = utils.parse_pnpm_package_key(name, version)
+                name, version = package_key.rsplit("@", 1)
             elif version not in packages:
                 package_key = utils.pnpm_name(name, version)
             else:

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -62,15 +62,6 @@ def _pnpm_name(name, version):
     "Make a name/version pnpm-style name for a package name and version"
     return "%s@%s" % (name, version)
 
-def _parse_pnpm_package_key(pnpm_name, pnpm_version):
-    if pnpm_version.startswith("link:") or pnpm_version.startswith("file:"):
-        return pnpm_name, "0.0.0"
-
-    if pnpm_version.startswith("npm:"):
-        return pnpm_version[4:].rsplit("@", 1)
-
-    return pnpm_name, pnpm_version
-
 # Metadata about a pnpm "project" (importer).
 #
 # Metadata may come from different locations depending on the lockfile, this struct should
@@ -614,8 +605,18 @@ def _friendly_name(name, version):
     "Make a name@version developer-friendly name for a package name and version"
     return "%s@%s" % (name, version)
 
-def _package_store_name(name, version):
+def _package_store_name(pnpm_name, pnpm_version):
     "Make a package store name for a given package and version"
+
+    if pnpm_version.startswith("link:") or pnpm_version.startswith("file:"):
+        name = pnpm_name
+        version = "0.0.0"
+    elif pnpm_version.startswith("npm:"):
+        name, version = pnpm_version[4:].rsplit("@", 1)
+    else:
+        name = pnpm_name
+        version = pnpm_version
+
     if version.startswith("@"):
         # Special case where the package name should _not_ be included in the package store name.
         # See https://github.com/aspect-build/rules_js/issues/423 for more context.
@@ -810,7 +811,6 @@ utils = struct(
     sorted_map = _sorted_map,
     pnpm_name = _pnpm_name,
     assert_lockfile_version = _assert_lockfile_version,
-    parse_pnpm_package_key = _parse_pnpm_package_key,
     parse_pnpm_lock_json = _parse_pnpm_lock_json,
     friendly_name = _friendly_name,
     package_store_name = _package_store_name,


### PR DESCRIPTION
This intermediate "pnpm package key" state isn't needed outside the parse logic.

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
