### PR TITLE
fix(pnpm): pnpm9 transitive npm: dependenies

### DIFF
--- a/e2e/pnpm_lockfiles/MODULE.bazel
+++ b/e2e/pnpm_lockfiles/MODULE.bazel
@@ -16,6 +16,7 @@ PNPM_LOCK_VERSIONS = [
 PNPM_LOCK_TEST_CASES = [
     "tarball-no-url-v54.yaml",
     "override-with-alias-url-v9.yaml",
+    "isaacs-cliui-v90.yaml",
 ]
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")

--- a/e2e/pnpm_lockfiles/README.md
+++ b/e2e/pnpm_lockfiles/README.md
@@ -2,8 +2,12 @@
 
 See notes in lockfile-test.bzl for test cases of each package.
 
-## pnpm lockfile edge cases
+## pnpm lockfile edge cases (./cases/\*)
 
 Unique test cases hard to cover with normal pnpm workspaces + package.json. Each
 test case is a pnpm-lock.yaml with a unique filename, see cases/BUILD for how the test
 cases run on each of those lockfiles.
+
+-   `isaacs-cliui-v*`: a transitive `npm:` dependency as an alias to use multiple versions of a single package, this is different then a direct `npm:` dependency
+-   `override-with-alias-url-v9` - a package overridden with a different package
+-   `tarball-no-url-v54` - a package with a tarball but not a full URL

--- a/e2e/pnpm_lockfiles/WORKSPACE
+++ b/e2e/pnpm_lockfiles/WORKSPACE
@@ -15,6 +15,7 @@ PNPM_LOCK_VERSIONS = [
 PNPM_LOCK_TEST_CASES = [
     "tarball-no-url-v54.yaml",
     "override-with-alias-url-v9.yaml",
+    "isaacs-cliui-v90.yaml",
 ]
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
@@ -62,9 +63,12 @@ npm_repositories_v90()
     for lockfile in PNPM_LOCK_TEST_CASES
 ]
 
+load("@isaacs-cliui-v90//:repositories.bzl", npm_repositories_isaacs_cliui_v90 = "npm_repositories")
 load("@override-with-alias-url-v9//:repositories.bzl", npm_repositories_override_with_alias_v90 = "npm_repositories")
 load("@tarball-no-url-v54//:repositories.bzl", npm_repositories_tarball_no_url_v54 = "npm_repositories")
 
 npm_repositories_tarball_no_url_v54()
 
 npm_repositories_override_with_alias_v90()
+
+npm_repositories_isaacs_cliui_v90()

--- a/e2e/pnpm_lockfiles/cases/BUILD.bazel
+++ b/e2e/pnpm_lockfiles/cases/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@isaacs-cliui-v90//:defs.bzl", isaacs_cliui_v90_link_all = "npm_link_all_packages")
 load("@override-with-alias-url-v9//:defs.bzl", override_with_alias_link_all = "npm_link_all_packages")
 load("@tarball-no-url-v54//:defs.bzl", tarball_no_url_link_all = "npm_link_all_packages")
 
@@ -21,5 +22,15 @@ build_test(
     targets = [
         ":override-with-alias-url-v9_modules",
         ":override-with-alias-url-v9_modules/lodash.pick",
+    ],
+)
+
+isaacs_cliui_v90_link_all(name = "isaacs_cliui_v90-modules")
+
+build_test(
+    name = "isaacs_cliui",
+    targets = [
+        ":isaacs_cliui_v90-modules",
+        ":isaacs_cliui_v90-modules/@isaacs/cliui",
     ],
 )

--- a/e2e/pnpm_lockfiles/cases/isaacs-cliui-v54.yaml
+++ b/e2e/pnpm_lockfiles/cases/isaacs-cliui-v54.yaml
@@ -1,0 +1,174 @@
+lockfileVersion: 5.4
+
+onlyBuiltDependencies: []
+
+importers:
+    .:
+        specifiers:
+            '@isaacs/cliui': 8.0.2
+        dependencies:
+            '@isaacs/cliui': 8.0.2
+
+packages:
+    /@isaacs/cliui/8.0.2:
+        resolution:
+            {
+                integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
+            }
+        engines: { node: '>=12' }
+        dependencies:
+            string-width: 5.1.2
+            string-width-cjs: /string-width/4.2.3
+            strip-ansi: 7.1.0
+            strip-ansi-cjs: /strip-ansi/6.0.1
+            wrap-ansi: 8.1.0
+            wrap-ansi-cjs: /wrap-ansi/7.0.0
+        dev: false
+
+    /ansi-regex/5.0.1:
+        resolution:
+            {
+                integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+            }
+        engines: { node: '>=8' }
+        dev: false
+
+    /ansi-regex/6.0.1:
+        resolution:
+            {
+                integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==,
+            }
+        engines: { node: '>=12' }
+        dev: false
+
+    /ansi-styles/4.3.0:
+        resolution:
+            {
+                integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+            }
+        engines: { node: '>=8' }
+        dependencies:
+            color-convert: 2.0.1
+        dev: false
+
+    /ansi-styles/6.2.1:
+        resolution:
+            {
+                integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
+            }
+        engines: { node: '>=12' }
+        dev: false
+
+    /color-convert/2.0.1:
+        resolution:
+            {
+                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+            }
+        engines: { node: '>=7.0.0' }
+        dependencies:
+            color-name: 1.1.4
+        dev: false
+
+    /color-name/1.1.4:
+        resolution:
+            {
+                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+            }
+        dev: false
+
+    /eastasianwidth/0.2.0:
+        resolution:
+            {
+                integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
+            }
+        dev: false
+
+    /emoji-regex/8.0.0:
+        resolution:
+            {
+                integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+            }
+        dev: false
+
+    /emoji-regex/9.2.2:
+        resolution:
+            {
+                integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
+            }
+        dev: false
+
+    /is-fullwidth-code-point/3.0.0:
+        resolution:
+            {
+                integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+            }
+        engines: { node: '>=8' }
+        dev: false
+
+    /string-width/4.2.3:
+        resolution:
+            {
+                integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+            }
+        engines: { node: '>=8' }
+        dependencies:
+            emoji-regex: 8.0.0
+            is-fullwidth-code-point: 3.0.0
+            strip-ansi: 6.0.1
+        dev: false
+
+    /string-width/5.1.2:
+        resolution:
+            {
+                integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
+            }
+        engines: { node: '>=12' }
+        dependencies:
+            eastasianwidth: 0.2.0
+            emoji-regex: 9.2.2
+            strip-ansi: 7.1.0
+        dev: false
+
+    /strip-ansi/6.0.1:
+        resolution:
+            {
+                integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+            }
+        engines: { node: '>=8' }
+        dependencies:
+            ansi-regex: 5.0.1
+        dev: false
+
+    /strip-ansi/7.1.0:
+        resolution:
+            {
+                integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==,
+            }
+        engines: { node: '>=12' }
+        dependencies:
+            ansi-regex: 6.0.1
+        dev: false
+
+    /wrap-ansi/7.0.0:
+        resolution:
+            {
+                integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+            }
+        engines: { node: '>=10' }
+        dependencies:
+            ansi-styles: 4.3.0
+            string-width: 4.2.3
+            strip-ansi: 6.0.1
+        dev: false
+
+    /wrap-ansi/8.1.0:
+        resolution:
+            {
+                integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
+            }
+        engines: { node: '>=12' }
+        dependencies:
+            ansi-styles: 6.2.1
+            string-width: 5.1.2
+            strip-ansi: 7.1.0
+        dev: false

--- a/e2e/pnpm_lockfiles/cases/isaacs-cliui-v61.yaml
+++ b/e2e/pnpm_lockfiles/cases/isaacs-cliui-v61.yaml
@@ -1,0 +1,178 @@
+lockfileVersion: '6.0'
+
+settings:
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
+
+onlyBuiltDependencies: []
+
+importers:
+    .:
+        dependencies:
+            '@isaacs/cliui':
+                specifier: 8.0.2
+                version: 8.0.2
+
+packages:
+    /@isaacs/cliui@8.0.2:
+        resolution:
+            {
+                integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
+            }
+        engines: { node: '>=12' }
+        dependencies:
+            string-width: 5.1.2
+            string-width-cjs: /string-width@4.2.3
+            strip-ansi: 7.1.0
+            strip-ansi-cjs: /strip-ansi@6.0.1
+            wrap-ansi: 8.1.0
+            wrap-ansi-cjs: /wrap-ansi@7.0.0
+        dev: false
+
+    /ansi-regex@5.0.1:
+        resolution:
+            {
+                integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+            }
+        engines: { node: '>=8' }
+        dev: false
+
+    /ansi-regex@6.0.1:
+        resolution:
+            {
+                integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==,
+            }
+        engines: { node: '>=12' }
+        dev: false
+
+    /ansi-styles@4.3.0:
+        resolution:
+            {
+                integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+            }
+        engines: { node: '>=8' }
+        dependencies:
+            color-convert: 2.0.1
+        dev: false
+
+    /ansi-styles@6.2.1:
+        resolution:
+            {
+                integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
+            }
+        engines: { node: '>=12' }
+        dev: false
+
+    /color-convert@2.0.1:
+        resolution:
+            {
+                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+            }
+        engines: { node: '>=7.0.0' }
+        dependencies:
+            color-name: 1.1.4
+        dev: false
+
+    /color-name@1.1.4:
+        resolution:
+            {
+                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+            }
+        dev: false
+
+    /eastasianwidth@0.2.0:
+        resolution:
+            {
+                integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
+            }
+        dev: false
+
+    /emoji-regex@8.0.0:
+        resolution:
+            {
+                integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+            }
+        dev: false
+
+    /emoji-regex@9.2.2:
+        resolution:
+            {
+                integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
+            }
+        dev: false
+
+    /is-fullwidth-code-point@3.0.0:
+        resolution:
+            {
+                integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+            }
+        engines: { node: '>=8' }
+        dev: false
+
+    /string-width@4.2.3:
+        resolution:
+            {
+                integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+            }
+        engines: { node: '>=8' }
+        dependencies:
+            emoji-regex: 8.0.0
+            is-fullwidth-code-point: 3.0.0
+            strip-ansi: 6.0.1
+        dev: false
+
+    /string-width@5.1.2:
+        resolution:
+            {
+                integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
+            }
+        engines: { node: '>=12' }
+        dependencies:
+            eastasianwidth: 0.2.0
+            emoji-regex: 9.2.2
+            strip-ansi: 7.1.0
+        dev: false
+
+    /strip-ansi@6.0.1:
+        resolution:
+            {
+                integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+            }
+        engines: { node: '>=8' }
+        dependencies:
+            ansi-regex: 5.0.1
+        dev: false
+
+    /strip-ansi@7.1.0:
+        resolution:
+            {
+                integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==,
+            }
+        engines: { node: '>=12' }
+        dependencies:
+            ansi-regex: 6.0.1
+        dev: false
+
+    /wrap-ansi@7.0.0:
+        resolution:
+            {
+                integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+            }
+        engines: { node: '>=10' }
+        dependencies:
+            ansi-styles: 4.3.0
+            string-width: 4.2.3
+            strip-ansi: 6.0.1
+        dev: false
+
+    /wrap-ansi@8.1.0:
+        resolution:
+            {
+                integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
+            }
+        engines: { node: '>=12' }
+        dependencies:
+            ansi-styles: 6.2.1
+            string-width: 5.1.2
+            strip-ansi: 7.1.0
+        dev: false

--- a/e2e/pnpm_lockfiles/cases/isaacs-cliui-v90.yaml
+++ b/e2e/pnpm_lockfiles/cases/isaacs-cliui-v90.yaml
@@ -1,0 +1,194 @@
+lockfileVersion: '9.0'
+
+settings:
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
+
+importers:
+    .:
+        dependencies:
+            '@isaacs/cliui':
+                specifier: 8.0.2
+                version: 8.0.2
+
+packages:
+    '@isaacs/cliui@8.0.2':
+        resolution:
+            {
+                integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
+            }
+        engines: { node: '>=12' }
+
+    ansi-regex@5.0.1:
+        resolution:
+            {
+                integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+            }
+        engines: { node: '>=8' }
+
+    ansi-regex@6.0.1:
+        resolution:
+            {
+                integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==,
+            }
+        engines: { node: '>=12' }
+
+    ansi-styles@4.3.0:
+        resolution:
+            {
+                integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+            }
+        engines: { node: '>=8' }
+
+    ansi-styles@6.2.1:
+        resolution:
+            {
+                integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
+            }
+        engines: { node: '>=12' }
+
+    color-convert@2.0.1:
+        resolution:
+            {
+                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+            }
+        engines: { node: '>=7.0.0' }
+
+    color-name@1.1.4:
+        resolution:
+            {
+                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+            }
+
+    eastasianwidth@0.2.0:
+        resolution:
+            {
+                integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
+            }
+
+    emoji-regex@8.0.0:
+        resolution:
+            {
+                integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+            }
+
+    emoji-regex@9.2.2:
+        resolution:
+            {
+                integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
+            }
+
+    is-fullwidth-code-point@3.0.0:
+        resolution:
+            {
+                integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+            }
+        engines: { node: '>=8' }
+
+    string-width@4.2.3:
+        resolution:
+            {
+                integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+            }
+        engines: { node: '>=8' }
+
+    string-width@5.1.2:
+        resolution:
+            {
+                integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
+            }
+        engines: { node: '>=12' }
+
+    strip-ansi@6.0.1:
+        resolution:
+            {
+                integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+            }
+        engines: { node: '>=8' }
+
+    strip-ansi@7.1.0:
+        resolution:
+            {
+                integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==,
+            }
+        engines: { node: '>=12' }
+
+    wrap-ansi@7.0.0:
+        resolution:
+            {
+                integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+            }
+        engines: { node: '>=10' }
+
+    wrap-ansi@8.1.0:
+        resolution:
+            {
+                integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
+            }
+        engines: { node: '>=12' }
+
+snapshots:
+    '@isaacs/cliui@8.0.2':
+        dependencies:
+            string-width: 5.1.2
+            string-width-cjs: string-width@4.2.3
+            strip-ansi: 7.1.0
+            strip-ansi-cjs: strip-ansi@6.0.1
+            wrap-ansi: 8.1.0
+            wrap-ansi-cjs: wrap-ansi@7.0.0
+
+    ansi-regex@5.0.1: {}
+
+    ansi-regex@6.0.1: {}
+
+    ansi-styles@4.3.0:
+        dependencies:
+            color-convert: 2.0.1
+
+    ansi-styles@6.2.1: {}
+
+    color-convert@2.0.1:
+        dependencies:
+            color-name: 1.1.4
+
+    color-name@1.1.4: {}
+
+    eastasianwidth@0.2.0: {}
+
+    emoji-regex@8.0.0: {}
+
+    emoji-regex@9.2.2: {}
+
+    is-fullwidth-code-point@3.0.0: {}
+
+    string-width@4.2.3:
+        dependencies:
+            emoji-regex: 8.0.0
+            is-fullwidth-code-point: 3.0.0
+            strip-ansi: 6.0.1
+
+    string-width@5.1.2:
+        dependencies:
+            eastasianwidth: 0.2.0
+            emoji-regex: 9.2.2
+            strip-ansi: 7.1.0
+
+    strip-ansi@6.0.1:
+        dependencies:
+            ansi-regex: 5.0.1
+
+    strip-ansi@7.1.0:
+        dependencies:
+            ansi-regex: 6.0.1
+
+    wrap-ansi@7.0.0:
+        dependencies:
+            ansi-styles: 4.3.0
+            string-width: 4.2.3
+            strip-ansi: 6.0.1
+
+    wrap-ansi@8.1.0:
+        dependencies:
+            ansi-styles: 6.2.1
+            string-width: 5.1.2
+            strip-ansi: 7.1.0


### PR DESCRIPTION
This is for transitive `npm:` dependencies, previously we only handled direct `npm:` deps with v9.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
