### PR TITLE
fix(pnpm): pnpm9 npm: dependencies with peers

### DIFF
--- a/e2e/pnpm_lockfiles/MODULE.bazel
+++ b/e2e/pnpm_lockfiles/MODULE.bazel
@@ -17,6 +17,8 @@ PNPM_LOCK_TEST_CASES = [
     "tarball-no-url-v54.yaml",
     "override-with-alias-url-v9.yaml",
     "isaacs-cliui-v90.yaml",
+    "docusaurus-direct-peer-v6.yaml",
+    "docusaurus-direct-peer-v9.yaml",
 ]
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")

--- a/e2e/pnpm_lockfiles/README.md
+++ b/e2e/pnpm_lockfiles/README.md
@@ -11,3 +11,4 @@ cases run on each of those lockfiles.
 -   `isaacs-cliui-v*`: a transitive `npm:` dependency as an alias to use multiple versions of a single package, this is different then a direct `npm:` dependency
 -   `override-with-alias-url-v9` - a package overridden with a different package
 -   `tarball-no-url-v54` - a package with a tarball but not a full URL
+-   `docusaurus-direct-peer-v*` - a direct dependency with a (peer=123) in the `importers` including within `npm:` dependencies

--- a/e2e/pnpm_lockfiles/WORKSPACE
+++ b/e2e/pnpm_lockfiles/WORKSPACE
@@ -16,6 +16,8 @@ PNPM_LOCK_TEST_CASES = [
     "tarball-no-url-v54.yaml",
     "override-with-alias-url-v9.yaml",
     "isaacs-cliui-v90.yaml",
+    "docusaurus-direct-peer-v6.yaml",
+    "docusaurus-direct-peer-v9.yaml",
 ]
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
@@ -63,6 +65,8 @@ npm_repositories_v90()
     for lockfile in PNPM_LOCK_TEST_CASES
 ]
 
+load("@docusaurus-direct-peer-v6//:repositories.bzl", npm_repositories_direct_with_peers_v6 = "npm_repositories")
+load("@docusaurus-direct-peer-v9//:repositories.bzl", npm_repositories_direct_with_peers_v9 = "npm_repositories")
 load("@isaacs-cliui-v90//:repositories.bzl", npm_repositories_isaacs_cliui_v90 = "npm_repositories")
 load("@override-with-alias-url-v9//:repositories.bzl", npm_repositories_override_with_alias_v90 = "npm_repositories")
 load("@tarball-no-url-v54//:repositories.bzl", npm_repositories_tarball_no_url_v54 = "npm_repositories")
@@ -72,3 +76,7 @@ npm_repositories_tarball_no_url_v54()
 npm_repositories_override_with_alias_v90()
 
 npm_repositories_isaacs_cliui_v90()
+
+npm_repositories_direct_with_peers_v6()
+
+npm_repositories_direct_with_peers_v9()

--- a/e2e/pnpm_lockfiles/cases/BUILD.bazel
+++ b/e2e/pnpm_lockfiles/cases/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@docusaurus-direct-peer-v6//:defs.bzl", docusaurus_direct_with_peers_v6_link_all = "npm_link_all_packages")
+load("@docusaurus-direct-peer-v9//:defs.bzl", docusaurus_direct_with_peers_v9_link_all = "npm_link_all_packages")
 load("@isaacs-cliui-v90//:defs.bzl", isaacs_cliui_v90_link_all = "npm_link_all_packages")
 load("@override-with-alias-url-v9//:defs.bzl", override_with_alias_link_all = "npm_link_all_packages")
 load("@tarball-no-url-v54//:defs.bzl", tarball_no_url_link_all = "npm_link_all_packages")
@@ -32,5 +34,21 @@ build_test(
     targets = [
         ":isaacs_cliui_v90-modules",
         ":isaacs_cliui_v90-modules/@isaacs/cliui",
+    ],
+)
+
+docusaurus_direct_with_peers_v9_link_all(name = "docusaurus_direct_with_peers_v9-modules")
+
+docusaurus_direct_with_peers_v6_link_all(name = "docusaurus_direct_with_peers_v6-modules")
+
+build_test(
+    name = "docusaurus_direct_with_peers",
+    targets = [
+        ":docusaurus_direct_with_peers_v9-modules",
+        ":docusaurus_direct_with_peers_v9-modules/@docusaurus/module-type-aliases",
+
+        # TODO: causes 'conflicting actions' error
+        # ":docusaurus_direct_with_peers_v6-modules",
+        # ":docusaurus_direct_with_peers_v6-modules/@docusaurus/module-type-aliases",
     ],
 )

--- a/e2e/pnpm_lockfiles/cases/docusaurus-direct-peer-v6.yaml
+++ b/e2e/pnpm_lockfiles/cases/docusaurus-direct-peer-v6.yaml
@@ -1,0 +1,2361 @@
+lockfileVersion: '6.0'
+
+settings:
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
+
+onlyBuiltDependencies: []
+
+importers:
+    .:
+        dependencies:
+            '@docusaurus/module-type-aliases':
+                specifier: ^3.1.0
+                version: 3.1.0(react-dom@18.3.1)(react@18.3.1)
+
+packages:
+    /@babel/runtime@7.24.6:
+        resolution:
+            {
+                integrity: sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==,
+            }
+        engines: { node: '>=6.9.0' }
+        dependencies:
+            regenerator-runtime: 0.14.1
+        dev: false
+
+    /@docusaurus/module-type-aliases@3.1.0(react-dom@18.3.1)(react@18.3.1):
+        resolution:
+            {
+                integrity: sha512-XUl7Z4PWlKg4l6KF05JQ3iDHQxnPxbQUqTNKvviHyuHdlalOFv6qeDAm7IbzyQPJD5VA6y4dpRbTWSqP9ClwPg==,
+            }
+        peerDependencies:
+            react: '*'
+            react-dom: '*'
+        dependencies:
+            '@docusaurus/react-loadable': 5.5.2(react@18.3.1)
+            '@docusaurus/types': 3.1.0(react-dom@18.3.1)(react@18.3.1)
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+            '@types/react-router-config': 5.0.11
+            '@types/react-router-dom': 5.3.3
+            react: 18.3.1
+            react-dom: 18.3.1(react@18.3.1)
+            react-helmet-async: 2.0.5(react@18.3.1)
+            react-loadable: /@docusaurus/react-loadable@5.5.2(react@18.3.1)
+        transitivePeerDependencies:
+            - '@swc/core'
+            - esbuild
+            - supports-color
+            - uglify-js
+            - webpack-cli
+        dev: false
+
+    /@docusaurus/react-loadable@5.5.2(react@18.3.1):
+        resolution:
+            {
+                integrity: sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==,
+            }
+        peerDependencies:
+            react: '*'
+        dependencies:
+            '@types/react': 18.3.3
+            prop-types: 15.8.1
+            react: 18.3.1
+        dev: false
+
+    /@docusaurus/types@3.1.0(react-dom@18.3.1)(react@18.3.1):
+        resolution:
+            {
+                integrity: sha512-VaczOZf7+re8aFBIWnex1XENomwHdsSTkrdX43zyor7G/FY4OIsP6X28Xc3o0jiY0YdNuvIDyA5TNwOtpgkCVw==,
+            }
+        peerDependencies:
+            react: ^18.0.0
+            react-dom: ^18.0.0
+        dependencies:
+            '@mdx-js/mdx': 3.0.1
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+            commander: 5.1.0
+            joi: 17.13.1
+            react: 18.3.1
+            react-dom: 18.3.1(react@18.3.1)
+            react-helmet-async: 1.3.0(react-dom@18.3.1)(react@18.3.1)
+            utility-types: 3.11.0
+            webpack: 5.91.0
+            webpack-merge: 5.10.0
+        transitivePeerDependencies:
+            - '@swc/core'
+            - esbuild
+            - supports-color
+            - uglify-js
+            - webpack-cli
+        dev: false
+
+    /@hapi/hoek@9.3.0:
+        resolution:
+            {
+                integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==,
+            }
+        dev: false
+
+    /@hapi/topo@5.1.0:
+        resolution:
+            {
+                integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==,
+            }
+        dependencies:
+            '@hapi/hoek': 9.3.0
+        dev: false
+
+    /@jridgewell/gen-mapping@0.3.5:
+        resolution:
+            {
+                integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==,
+            }
+        engines: { node: '>=6.0.0' }
+        dependencies:
+            '@jridgewell/set-array': 1.2.1
+            '@jridgewell/sourcemap-codec': 1.4.15
+            '@jridgewell/trace-mapping': 0.3.25
+        dev: false
+
+    /@jridgewell/resolve-uri@3.1.2:
+        resolution:
+            {
+                integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+            }
+        engines: { node: '>=6.0.0' }
+        dev: false
+
+    /@jridgewell/set-array@1.2.1:
+        resolution:
+            {
+                integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==,
+            }
+        engines: { node: '>=6.0.0' }
+        dev: false
+
+    /@jridgewell/source-map@0.3.6:
+        resolution:
+            {
+                integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==,
+            }
+        dependencies:
+            '@jridgewell/gen-mapping': 0.3.5
+            '@jridgewell/trace-mapping': 0.3.25
+        dev: false
+
+    /@jridgewell/sourcemap-codec@1.4.15:
+        resolution:
+            {
+                integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==,
+            }
+        dev: false
+
+    /@jridgewell/trace-mapping@0.3.25:
+        resolution:
+            {
+                integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==,
+            }
+        dependencies:
+            '@jridgewell/resolve-uri': 3.1.2
+            '@jridgewell/sourcemap-codec': 1.4.15
+        dev: false
+
+    /@mdx-js/mdx@3.0.1:
+        resolution:
+            {
+                integrity: sha512-eIQ4QTrOWyL3LWEe/bu6Taqzq2HQvHcyTMaOrI95P2/LmJE7AsfPfgJGuFLPVqBUE1BC1rik3VIhU+s9u72arA==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/mdx': 2.0.13
+            collapse-white-space: 2.1.0
+            devlop: 1.1.0
+            estree-util-build-jsx: 3.0.1
+            estree-util-is-identifier-name: 3.0.0
+            estree-util-to-js: 2.0.0
+            estree-walker: 3.0.3
+            hast-util-to-estree: 3.1.0
+            hast-util-to-jsx-runtime: 2.3.0
+            markdown-extensions: 2.0.0
+            periscopic: 3.1.0
+            remark-mdx: 3.0.1
+            remark-parse: 11.0.0
+            remark-rehype: 11.1.0
+            source-map: 0.7.4
+            unified: 11.0.4
+            unist-util-position-from-estree: 2.0.0
+            unist-util-stringify-position: 4.0.0
+            unist-util-visit: 5.0.0
+            vfile: 6.0.1
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /@sideway/address@4.1.5:
+        resolution:
+            {
+                integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==,
+            }
+        dependencies:
+            '@hapi/hoek': 9.3.0
+        dev: false
+
+    /@sideway/formula@3.0.1:
+        resolution:
+            {
+                integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==,
+            }
+        dev: false
+
+    /@sideway/pinpoint@2.0.0:
+        resolution:
+            {
+                integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==,
+            }
+        dev: false
+
+    /@types/acorn@4.0.6:
+        resolution:
+            {
+                integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+        dev: false
+
+    /@types/debug@4.1.12:
+        resolution:
+            {
+                integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==,
+            }
+        dependencies:
+            '@types/ms': 0.7.34
+        dev: false
+
+    /@types/eslint-scope@3.7.7:
+        resolution:
+            {
+                integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==,
+            }
+        dependencies:
+            '@types/eslint': 8.56.10
+            '@types/estree': 1.0.5
+        dev: false
+
+    /@types/eslint@8.56.10:
+        resolution:
+            {
+                integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+            '@types/json-schema': 7.0.15
+        dev: false
+
+    /@types/estree-jsx@1.0.5:
+        resolution:
+            {
+                integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+        dev: false
+
+    /@types/estree@1.0.5:
+        resolution:
+            {
+                integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==,
+            }
+        dev: false
+
+    /@types/hast@3.0.4:
+        resolution:
+            {
+                integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+        dev: false
+
+    /@types/history@4.7.11:
+        resolution:
+            {
+                integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==,
+            }
+        dev: false
+
+    /@types/json-schema@7.0.15:
+        resolution:
+            {
+                integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+            }
+        dev: false
+
+    /@types/mdast@4.0.4:
+        resolution:
+            {
+                integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+        dev: false
+
+    /@types/mdx@2.0.13:
+        resolution:
+            {
+                integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
+            }
+        dev: false
+
+    /@types/ms@0.7.34:
+        resolution:
+            {
+                integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==,
+            }
+        dev: false
+
+    /@types/node@20.14.1:
+        resolution:
+            {
+                integrity: sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==,
+            }
+        dependencies:
+            undici-types: 5.26.5
+        dev: false
+
+    /@types/prop-types@15.7.12:
+        resolution:
+            {
+                integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==,
+            }
+        dev: false
+
+    /@types/react-router-config@5.0.11:
+        resolution:
+            {
+                integrity: sha512-WmSAg7WgqW7m4x8Mt4N6ZyKz0BubSj/2tVUMsAHp+Yd2AMwcSbeFq9WympT19p5heCFmF97R9eD5uUR/t4HEqw==,
+            }
+        dependencies:
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+            '@types/react-router': 5.1.20
+        dev: false
+
+    /@types/react-router-dom@5.3.3:
+        resolution:
+            {
+                integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==,
+            }
+        dependencies:
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+            '@types/react-router': 5.1.20
+        dev: false
+
+    /@types/react-router@5.1.20:
+        resolution:
+            {
+                integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==,
+            }
+        dependencies:
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+        dev: false
+
+    /@types/react@18.3.3:
+        resolution:
+            {
+                integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==,
+            }
+        dependencies:
+            '@types/prop-types': 15.7.12
+            csstype: 3.1.3
+        dev: false
+
+    /@types/unist@2.0.10:
+        resolution:
+            {
+                integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==,
+            }
+        dev: false
+
+    /@types/unist@3.0.2:
+        resolution:
+            {
+                integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==,
+            }
+        dev: false
+
+    /@ungap/structured-clone@1.2.0:
+        resolution:
+            {
+                integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==,
+            }
+        dev: false
+
+    /@webassemblyjs/ast@1.12.1:
+        resolution:
+            {
+                integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==,
+            }
+        dependencies:
+            '@webassemblyjs/helper-numbers': 1.11.6
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+        dev: false
+
+    /@webassemblyjs/floating-point-hex-parser@1.11.6:
+        resolution:
+            {
+                integrity: sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==,
+            }
+        dev: false
+
+    /@webassemblyjs/helper-api-error@1.11.6:
+        resolution:
+            {
+                integrity: sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==,
+            }
+        dev: false
+
+    /@webassemblyjs/helper-buffer@1.12.1:
+        resolution:
+            {
+                integrity: sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==,
+            }
+        dev: false
+
+    /@webassemblyjs/helper-numbers@1.11.6:
+        resolution:
+            {
+                integrity: sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==,
+            }
+        dependencies:
+            '@webassemblyjs/floating-point-hex-parser': 1.11.6
+            '@webassemblyjs/helper-api-error': 1.11.6
+            '@xtuc/long': 4.2.2
+        dev: false
+
+    /@webassemblyjs/helper-wasm-bytecode@1.11.6:
+        resolution:
+            {
+                integrity: sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==,
+            }
+        dev: false
+
+    /@webassemblyjs/helper-wasm-section@1.12.1:
+        resolution:
+            {
+                integrity: sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==,
+            }
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-buffer': 1.12.1
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+            '@webassemblyjs/wasm-gen': 1.12.1
+        dev: false
+
+    /@webassemblyjs/ieee754@1.11.6:
+        resolution:
+            {
+                integrity: sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==,
+            }
+        dependencies:
+            '@xtuc/ieee754': 1.2.0
+        dev: false
+
+    /@webassemblyjs/leb128@1.11.6:
+        resolution:
+            {
+                integrity: sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==,
+            }
+        dependencies:
+            '@xtuc/long': 4.2.2
+        dev: false
+
+    /@webassemblyjs/utf8@1.11.6:
+        resolution:
+            {
+                integrity: sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==,
+            }
+        dev: false
+
+    /@webassemblyjs/wasm-edit@1.12.1:
+        resolution:
+            {
+                integrity: sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==,
+            }
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-buffer': 1.12.1
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+            '@webassemblyjs/helper-wasm-section': 1.12.1
+            '@webassemblyjs/wasm-gen': 1.12.1
+            '@webassemblyjs/wasm-opt': 1.12.1
+            '@webassemblyjs/wasm-parser': 1.12.1
+            '@webassemblyjs/wast-printer': 1.12.1
+        dev: false
+
+    /@webassemblyjs/wasm-gen@1.12.1:
+        resolution:
+            {
+                integrity: sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==,
+            }
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+            '@webassemblyjs/ieee754': 1.11.6
+            '@webassemblyjs/leb128': 1.11.6
+            '@webassemblyjs/utf8': 1.11.6
+        dev: false
+
+    /@webassemblyjs/wasm-opt@1.12.1:
+        resolution:
+            {
+                integrity: sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==,
+            }
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-buffer': 1.12.1
+            '@webassemblyjs/wasm-gen': 1.12.1
+            '@webassemblyjs/wasm-parser': 1.12.1
+        dev: false
+
+    /@webassemblyjs/wasm-parser@1.12.1:
+        resolution:
+            {
+                integrity: sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==,
+            }
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-api-error': 1.11.6
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+            '@webassemblyjs/ieee754': 1.11.6
+            '@webassemblyjs/leb128': 1.11.6
+            '@webassemblyjs/utf8': 1.11.6
+        dev: false
+
+    /@webassemblyjs/wast-printer@1.12.1:
+        resolution:
+            {
+                integrity: sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==,
+            }
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@xtuc/long': 4.2.2
+        dev: false
+
+    /@xtuc/ieee754@1.2.0:
+        resolution:
+            {
+                integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==,
+            }
+        dev: false
+
+    /@xtuc/long@4.2.2:
+        resolution:
+            {
+                integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==,
+            }
+        dev: false
+
+    /acorn-import-assertions@1.9.0(acorn@8.11.3):
+        resolution:
+            {
+                integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==,
+            }
+        peerDependencies:
+            acorn: ^8
+        dependencies:
+            acorn: 8.11.3
+        dev: false
+
+    /acorn-jsx@5.3.2(acorn@8.11.3):
+        resolution:
+            {
+                integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+            }
+        peerDependencies:
+            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+        dependencies:
+            acorn: 8.11.3
+        dev: false
+
+    /acorn@8.11.3:
+        resolution:
+            {
+                integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==,
+            }
+        engines: { node: '>=0.4.0' }
+        hasBin: true
+        dev: false
+
+    /ajv-keywords@3.5.2(ajv@6.12.6):
+        resolution:
+            {
+                integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==,
+            }
+        peerDependencies:
+            ajv: ^6.9.1
+        dependencies:
+            ajv: 6.12.6
+        dev: false
+
+    /ajv@6.12.6:
+        resolution:
+            {
+                integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+            }
+        dependencies:
+            fast-deep-equal: 3.1.3
+            fast-json-stable-stringify: 2.1.0
+            json-schema-traverse: 0.4.1
+            uri-js: 4.4.1
+        dev: false
+
+    /astring@1.8.6:
+        resolution:
+            {
+                integrity: sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==,
+            }
+        hasBin: true
+        dev: false
+
+    /bail@2.0.2:
+        resolution:
+            {
+                integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
+            }
+        dev: false
+
+    /browserslist@4.23.0:
+        resolution:
+            {
+                integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==,
+            }
+        engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+        hasBin: true
+        dependencies:
+            caniuse-lite: 1.0.30001627
+            electron-to-chromium: 1.4.789
+            node-releases: 2.0.14
+            update-browserslist-db: 1.0.16(browserslist@4.23.0)
+        dev: false
+
+    /buffer-from@1.1.2:
+        resolution:
+            {
+                integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
+            }
+        dev: false
+
+    /caniuse-lite@1.0.30001627:
+        resolution:
+            {
+                integrity: sha512-4zgNiB8nTyV/tHhwZrFs88ryjls/lHiqFhrxCW4qSTeuRByBVnPYpDInchOIySWknznucaf31Z4KYqjfbrecVw==,
+            }
+        dev: false
+
+    /ccount@2.0.1:
+        resolution:
+            {
+                integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
+            }
+        dev: false
+
+    /character-entities-html4@2.1.0:
+        resolution:
+            {
+                integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==,
+            }
+        dev: false
+
+    /character-entities-legacy@3.0.0:
+        resolution:
+            {
+                integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==,
+            }
+        dev: false
+
+    /character-entities@2.0.2:
+        resolution:
+            {
+                integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==,
+            }
+        dev: false
+
+    /character-reference-invalid@2.0.1:
+        resolution:
+            {
+                integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
+            }
+        dev: false
+
+    /chrome-trace-event@1.0.4:
+        resolution:
+            {
+                integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==,
+            }
+        engines: { node: '>=6.0' }
+        dev: false
+
+    /clone-deep@4.0.1:
+        resolution:
+            {
+                integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==,
+            }
+        engines: { node: '>=6' }
+        dependencies:
+            is-plain-object: 2.0.4
+            kind-of: 6.0.3
+            shallow-clone: 3.0.1
+        dev: false
+
+    /collapse-white-space@2.1.0:
+        resolution:
+            {
+                integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
+            }
+        dev: false
+
+    /comma-separated-tokens@2.0.3:
+        resolution:
+            {
+                integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
+            }
+        dev: false
+
+    /commander@2.20.3:
+        resolution:
+            {
+                integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
+            }
+        dev: false
+
+    /commander@5.1.0:
+        resolution:
+            {
+                integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==,
+            }
+        engines: { node: '>= 6' }
+        dev: false
+
+    /csstype@3.1.3:
+        resolution:
+            {
+                integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==,
+            }
+        dev: false
+
+    /debug@4.3.5:
+        resolution:
+            {
+                integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==,
+            }
+        engines: { node: '>=6.0' }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+        dependencies:
+            ms: 2.1.2
+        dev: false
+
+    /decode-named-character-reference@1.0.2:
+        resolution:
+            {
+                integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==,
+            }
+        dependencies:
+            character-entities: 2.0.2
+        dev: false
+
+    /dequal@2.0.3:
+        resolution:
+            {
+                integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
+            }
+        engines: { node: '>=6' }
+        dev: false
+
+    /devlop@1.1.0:
+        resolution:
+            {
+                integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
+            }
+        dependencies:
+            dequal: 2.0.3
+        dev: false
+
+    /electron-to-chromium@1.4.789:
+        resolution:
+            {
+                integrity: sha512-0VbyiaXoT++Fi2vHGo2ThOeS6X3vgRCWrjPeO2FeIAWL6ItiSJ9BqlH8LfCXe3X1IdcG+S0iLoNaxQWhfZoGzQ==,
+            }
+        dev: false
+
+    /enhanced-resolve@5.17.0:
+        resolution:
+            {
+                integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==,
+            }
+        engines: { node: '>=10.13.0' }
+        dependencies:
+            graceful-fs: 4.2.11
+            tapable: 2.2.1
+        dev: false
+
+    /es-module-lexer@1.5.3:
+        resolution:
+            {
+                integrity: sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==,
+            }
+        dev: false
+
+    /escalade@3.1.2:
+        resolution:
+            {
+                integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==,
+            }
+        engines: { node: '>=6' }
+        dev: false
+
+    /eslint-scope@5.1.1:
+        resolution:
+            {
+                integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==,
+            }
+        engines: { node: '>=8.0.0' }
+        dependencies:
+            esrecurse: 4.3.0
+            estraverse: 4.3.0
+        dev: false
+
+    /esrecurse@4.3.0:
+        resolution:
+            {
+                integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+            }
+        engines: { node: '>=4.0' }
+        dependencies:
+            estraverse: 5.3.0
+        dev: false
+
+    /estraverse@4.3.0:
+        resolution:
+            {
+                integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==,
+            }
+        engines: { node: '>=4.0' }
+        dev: false
+
+    /estraverse@5.3.0:
+        resolution:
+            {
+                integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+            }
+        engines: { node: '>=4.0' }
+        dev: false
+
+    /estree-util-attach-comments@3.0.0:
+        resolution:
+            {
+                integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+        dev: false
+
+    /estree-util-build-jsx@3.0.1:
+        resolution:
+            {
+                integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==,
+            }
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            devlop: 1.1.0
+            estree-util-is-identifier-name: 3.0.0
+            estree-walker: 3.0.3
+        dev: false
+
+    /estree-util-is-identifier-name@3.0.0:
+        resolution:
+            {
+                integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==,
+            }
+        dev: false
+
+    /estree-util-to-js@2.0.0:
+        resolution:
+            {
+                integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==,
+            }
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            astring: 1.8.6
+            source-map: 0.7.4
+        dev: false
+
+    /estree-util-visit@2.0.0:
+        resolution:
+            {
+                integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==,
+            }
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            '@types/unist': 3.0.2
+        dev: false
+
+    /estree-walker@3.0.3:
+        resolution:
+            {
+                integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+        dev: false
+
+    /events@3.3.0:
+        resolution:
+            {
+                integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==,
+            }
+        engines: { node: '>=0.8.x' }
+        dev: false
+
+    /extend@3.0.2:
+        resolution:
+            {
+                integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
+            }
+        dev: false
+
+    /fast-deep-equal@3.1.3:
+        resolution:
+            {
+                integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+            }
+        dev: false
+
+    /fast-json-stable-stringify@2.1.0:
+        resolution:
+            {
+                integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+            }
+        dev: false
+
+    /flat@5.0.2:
+        resolution:
+            {
+                integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==,
+            }
+        hasBin: true
+        dev: false
+
+    /glob-to-regexp@0.4.1:
+        resolution:
+            {
+                integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==,
+            }
+        dev: false
+
+    /graceful-fs@4.2.11:
+        resolution:
+            {
+                integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+            }
+        dev: false
+
+    /has-flag@4.0.0:
+        resolution:
+            {
+                integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+            }
+        engines: { node: '>=8' }
+        dev: false
+
+    /hast-util-to-estree@3.1.0:
+        resolution:
+            {
+                integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            comma-separated-tokens: 2.0.3
+            devlop: 1.1.0
+            estree-util-attach-comments: 3.0.0
+            estree-util-is-identifier-name: 3.0.0
+            hast-util-whitespace: 3.0.0
+            mdast-util-mdx-expression: 2.0.0
+            mdast-util-mdx-jsx: 3.1.2
+            mdast-util-mdxjs-esm: 2.0.1
+            property-information: 6.5.0
+            space-separated-tokens: 2.0.2
+            style-to-object: 0.4.4
+            unist-util-position: 5.0.0
+            zwitch: 2.0.4
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /hast-util-to-jsx-runtime@2.3.0:
+        resolution:
+            {
+                integrity: sha512-H/y0+IWPdsLLS738P8tDnrQ8Z+dj12zQQ6WC11TIM21C8WFVoIxcqWXf2H3hiTVZjF1AWqoimGwrTWecWrnmRQ==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/unist': 3.0.2
+            comma-separated-tokens: 2.0.3
+            devlop: 1.1.0
+            estree-util-is-identifier-name: 3.0.0
+            hast-util-whitespace: 3.0.0
+            mdast-util-mdx-expression: 2.0.0
+            mdast-util-mdx-jsx: 3.1.2
+            mdast-util-mdxjs-esm: 2.0.1
+            property-information: 6.5.0
+            space-separated-tokens: 2.0.2
+            style-to-object: 1.0.6
+            unist-util-position: 5.0.0
+            vfile-message: 4.0.2
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /hast-util-whitespace@3.0.0:
+        resolution:
+            {
+                integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
+            }
+        dependencies:
+            '@types/hast': 3.0.4
+        dev: false
+
+    /inline-style-parser@0.1.1:
+        resolution:
+            {
+                integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==,
+            }
+        dev: false
+
+    /inline-style-parser@0.2.3:
+        resolution:
+            {
+                integrity: sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g==,
+            }
+        dev: false
+
+    /invariant@2.2.4:
+        resolution:
+            {
+                integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==,
+            }
+        dependencies:
+            loose-envify: 1.4.0
+        dev: false
+
+    /is-alphabetical@2.0.1:
+        resolution:
+            {
+                integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==,
+            }
+        dev: false
+
+    /is-alphanumerical@2.0.1:
+        resolution:
+            {
+                integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
+            }
+        dependencies:
+            is-alphabetical: 2.0.1
+            is-decimal: 2.0.1
+        dev: false
+
+    /is-decimal@2.0.1:
+        resolution:
+            {
+                integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==,
+            }
+        dev: false
+
+    /is-hexadecimal@2.0.1:
+        resolution:
+            {
+                integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
+            }
+        dev: false
+
+    /is-plain-obj@4.1.0:
+        resolution:
+            {
+                integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
+            }
+        engines: { node: '>=12' }
+        dev: false
+
+    /is-plain-object@2.0.4:
+        resolution:
+            {
+                integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==,
+            }
+        engines: { node: '>=0.10.0' }
+        dependencies:
+            isobject: 3.0.1
+        dev: false
+
+    /is-reference@3.0.2:
+        resolution:
+            {
+                integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+        dev: false
+
+    /isobject@3.0.1:
+        resolution:
+            {
+                integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==,
+            }
+        engines: { node: '>=0.10.0' }
+        dev: false
+
+    /jest-worker@27.5.1:
+        resolution:
+            {
+                integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==,
+            }
+        engines: { node: '>= 10.13.0' }
+        dependencies:
+            '@types/node': 20.14.1
+            merge-stream: 2.0.0
+            supports-color: 8.1.1
+        dev: false
+
+    /joi@17.13.1:
+        resolution:
+            {
+                integrity: sha512-vaBlIKCyo4FCUtCm7Eu4QZd/q02bWcxfUO6YSXAZOWF6gzcLBeba8kwotUdYJjDLW8Cz8RywsSOqiNJZW0mNvg==,
+            }
+        dependencies:
+            '@hapi/hoek': 9.3.0
+            '@hapi/topo': 5.1.0
+            '@sideway/address': 4.1.5
+            '@sideway/formula': 3.0.1
+            '@sideway/pinpoint': 2.0.0
+        dev: false
+
+    /js-tokens@4.0.0:
+        resolution:
+            {
+                integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+            }
+        dev: false
+
+    /json-parse-even-better-errors@2.3.1:
+        resolution:
+            {
+                integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
+            }
+        dev: false
+
+    /json-schema-traverse@0.4.1:
+        resolution:
+            {
+                integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+            }
+        dev: false
+
+    /kind-of@6.0.3:
+        resolution:
+            {
+                integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
+            }
+        engines: { node: '>=0.10.0' }
+        dev: false
+
+    /loader-runner@4.3.0:
+        resolution:
+            {
+                integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==,
+            }
+        engines: { node: '>=6.11.5' }
+        dev: false
+
+    /longest-streak@3.1.0:
+        resolution:
+            {
+                integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
+            }
+        dev: false
+
+    /loose-envify@1.4.0:
+        resolution:
+            {
+                integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
+            }
+        hasBin: true
+        dependencies:
+            js-tokens: 4.0.0
+        dev: false
+
+    /markdown-extensions@2.0.0:
+        resolution:
+            {
+                integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==,
+            }
+        engines: { node: '>=16' }
+        dev: false
+
+    /mdast-util-from-markdown@2.0.1:
+        resolution:
+            {
+                integrity: sha512-aJEUyzZ6TzlsX2s5B4Of7lN7EQtAxvtradMMglCQDyaTFgse6CmtmdJ15ElnVRlCg1vpNyVtbem0PWzlNieZsA==,
+            }
+        dependencies:
+            '@types/mdast': 4.0.4
+            '@types/unist': 3.0.2
+            decode-named-character-reference: 1.0.2
+            devlop: 1.1.0
+            mdast-util-to-string: 4.0.0
+            micromark: 4.0.0
+            micromark-util-decode-numeric-character-reference: 2.0.1
+            micromark-util-decode-string: 2.0.0
+            micromark-util-normalize-identifier: 2.0.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            unist-util-stringify-position: 4.0.0
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /mdast-util-mdx-expression@2.0.0:
+        resolution:
+            {
+                integrity: sha512-fGCu8eWdKUKNu5mohVGkhBXCXGnOTLuFqOvGMvdikr+J1w7lDJgxThOKpwRWzzbyXAU2hhSwsmssOY4yTokluw==,
+            }
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            devlop: 1.1.0
+            mdast-util-from-markdown: 2.0.1
+            mdast-util-to-markdown: 2.1.0
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /mdast-util-mdx-jsx@3.1.2:
+        resolution:
+            {
+                integrity: sha512-eKMQDeywY2wlHc97k5eD8VC+9ASMjN8ItEZQNGwJ6E0XWKiW/Z0V5/H8pvoXUf+y+Mj0VIgeRRbujBmFn4FTyA==,
+            }
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            '@types/unist': 3.0.2
+            ccount: 2.0.1
+            devlop: 1.1.0
+            mdast-util-from-markdown: 2.0.1
+            mdast-util-to-markdown: 2.1.0
+            parse-entities: 4.0.1
+            stringify-entities: 4.0.4
+            unist-util-remove-position: 5.0.0
+            unist-util-stringify-position: 4.0.0
+            vfile-message: 4.0.2
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /mdast-util-mdx@3.0.0:
+        resolution:
+            {
+                integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==,
+            }
+        dependencies:
+            mdast-util-from-markdown: 2.0.1
+            mdast-util-mdx-expression: 2.0.0
+            mdast-util-mdx-jsx: 3.1.2
+            mdast-util-mdxjs-esm: 2.0.1
+            mdast-util-to-markdown: 2.1.0
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /mdast-util-mdxjs-esm@2.0.1:
+        resolution:
+            {
+                integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
+            }
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            devlop: 1.1.0
+            mdast-util-from-markdown: 2.0.1
+            mdast-util-to-markdown: 2.1.0
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /mdast-util-phrasing@4.1.0:
+        resolution:
+            {
+                integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==,
+            }
+        dependencies:
+            '@types/mdast': 4.0.4
+            unist-util-is: 6.0.0
+        dev: false
+
+    /mdast-util-to-hast@13.1.0:
+        resolution:
+            {
+                integrity: sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==,
+            }
+        dependencies:
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            '@ungap/structured-clone': 1.2.0
+            devlop: 1.1.0
+            micromark-util-sanitize-uri: 2.0.0
+            trim-lines: 3.0.1
+            unist-util-position: 5.0.0
+            unist-util-visit: 5.0.0
+            vfile: 6.0.1
+        dev: false
+
+    /mdast-util-to-markdown@2.1.0:
+        resolution:
+            {
+                integrity: sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==,
+            }
+        dependencies:
+            '@types/mdast': 4.0.4
+            '@types/unist': 3.0.2
+            longest-streak: 3.1.0
+            mdast-util-phrasing: 4.1.0
+            mdast-util-to-string: 4.0.0
+            micromark-util-decode-string: 2.0.0
+            unist-util-visit: 5.0.0
+            zwitch: 2.0.4
+        dev: false
+
+    /mdast-util-to-string@4.0.0:
+        resolution:
+            {
+                integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
+            }
+        dependencies:
+            '@types/mdast': 4.0.4
+        dev: false
+
+    /merge-stream@2.0.0:
+        resolution:
+            {
+                integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
+            }
+        dev: false
+
+    /micromark-core-commonmark@2.0.1:
+        resolution:
+            {
+                integrity: sha512-CUQyKr1e///ZODyD1U3xit6zXwy1a8q2a1S1HKtIlmgvurrEpaw/Y9y6KSIbF8P59cn/NjzHyO+Q2fAyYLQrAA==,
+            }
+        dependencies:
+            decode-named-character-reference: 1.0.2
+            devlop: 1.1.0
+            micromark-factory-destination: 2.0.0
+            micromark-factory-label: 2.0.0
+            micromark-factory-space: 2.0.0
+            micromark-factory-title: 2.0.0
+            micromark-factory-whitespace: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-chunked: 2.0.0
+            micromark-util-classify-character: 2.0.0
+            micromark-util-html-tag-name: 2.0.0
+            micromark-util-normalize-identifier: 2.0.0
+            micromark-util-resolve-all: 2.0.0
+            micromark-util-subtokenize: 2.0.1
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-extension-mdx-expression@3.0.0:
+        resolution:
+            {
+                integrity: sha512-sI0nwhUDz97xyzqJAbHQhp5TfaxEvZZZ2JDqUo+7NvyIYG6BZ5CPPqj2ogUoPJlmXHBnyZUzISg9+oUmU6tUjQ==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+            devlop: 1.1.0
+            micromark-factory-mdx-expression: 2.0.1
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-events-to-acorn: 2.0.2
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-extension-mdx-jsx@3.0.0:
+        resolution:
+            {
+                integrity: sha512-uvhhss8OGuzR4/N17L1JwvmJIpPhAd8oByMawEKx6NVdBCbesjH4t+vjEp3ZXft9DwvlKSD07fCeI44/N0Vf2w==,
+            }
+        dependencies:
+            '@types/acorn': 4.0.6
+            '@types/estree': 1.0.5
+            devlop: 1.1.0
+            estree-util-is-identifier-name: 3.0.0
+            micromark-factory-mdx-expression: 2.0.1
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            vfile-message: 4.0.2
+        dev: false
+
+    /micromark-extension-mdx-md@2.0.0:
+        resolution:
+            {
+                integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==,
+            }
+        dependencies:
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-extension-mdxjs-esm@3.0.0:
+        resolution:
+            {
+                integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+            devlop: 1.1.0
+            micromark-core-commonmark: 2.0.1
+            micromark-util-character: 2.1.0
+            micromark-util-events-to-acorn: 2.0.2
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            unist-util-position-from-estree: 2.0.0
+            vfile-message: 4.0.2
+        dev: false
+
+    /micromark-extension-mdxjs@3.0.0:
+        resolution:
+            {
+                integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==,
+            }
+        dependencies:
+            acorn: 8.11.3
+            acorn-jsx: 5.3.2(acorn@8.11.3)
+            micromark-extension-mdx-expression: 3.0.0
+            micromark-extension-mdx-jsx: 3.0.0
+            micromark-extension-mdx-md: 2.0.0
+            micromark-extension-mdxjs-esm: 3.0.0
+            micromark-util-combine-extensions: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-factory-destination@2.0.0:
+        resolution:
+            {
+                integrity: sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==,
+            }
+        dependencies:
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-factory-label@2.0.0:
+        resolution:
+            {
+                integrity: sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==,
+            }
+        dependencies:
+            devlop: 1.1.0
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-factory-mdx-expression@2.0.1:
+        resolution:
+            {
+                integrity: sha512-F0ccWIUHRLRrYp5TC9ZYXmZo+p2AM13ggbsW4T0b5CRKP8KHVRB8t4pwtBgTxtjRmwrK0Irwm7vs2JOZabHZfg==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+            devlop: 1.1.0
+            micromark-util-character: 2.1.0
+            micromark-util-events-to-acorn: 2.0.2
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            unist-util-position-from-estree: 2.0.0
+            vfile-message: 4.0.2
+        dev: false
+
+    /micromark-factory-space@2.0.0:
+        resolution:
+            {
+                integrity: sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==,
+            }
+        dependencies:
+            micromark-util-character: 2.1.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-factory-title@2.0.0:
+        resolution:
+            {
+                integrity: sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==,
+            }
+        dependencies:
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-factory-whitespace@2.0.0:
+        resolution:
+            {
+                integrity: sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==,
+            }
+        dependencies:
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-util-character@2.1.0:
+        resolution:
+            {
+                integrity: sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==,
+            }
+        dependencies:
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-util-chunked@2.0.0:
+        resolution:
+            {
+                integrity: sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==,
+            }
+        dependencies:
+            micromark-util-symbol: 2.0.0
+        dev: false
+
+    /micromark-util-classify-character@2.0.0:
+        resolution:
+            {
+                integrity: sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==,
+            }
+        dependencies:
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-util-combine-extensions@2.0.0:
+        resolution:
+            {
+                integrity: sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==,
+            }
+        dependencies:
+            micromark-util-chunked: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-util-decode-numeric-character-reference@2.0.1:
+        resolution:
+            {
+                integrity: sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==,
+            }
+        dependencies:
+            micromark-util-symbol: 2.0.0
+        dev: false
+
+    /micromark-util-decode-string@2.0.0:
+        resolution:
+            {
+                integrity: sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==,
+            }
+        dependencies:
+            decode-named-character-reference: 1.0.2
+            micromark-util-character: 2.1.0
+            micromark-util-decode-numeric-character-reference: 2.0.1
+            micromark-util-symbol: 2.0.0
+        dev: false
+
+    /micromark-util-encode@2.0.0:
+        resolution:
+            {
+                integrity: sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==,
+            }
+        dev: false
+
+    /micromark-util-events-to-acorn@2.0.2:
+        resolution:
+            {
+                integrity: sha512-Fk+xmBrOv9QZnEDguL9OI9/NQQp6Hz4FuQ4YmCb/5V7+9eAh1s6AYSvL20kHkD67YIg7EpE54TiSlcsf3vyZgA==,
+            }
+        dependencies:
+            '@types/acorn': 4.0.6
+            '@types/estree': 1.0.5
+            '@types/unist': 3.0.2
+            devlop: 1.1.0
+            estree-util-visit: 2.0.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            vfile-message: 4.0.2
+        dev: false
+
+    /micromark-util-html-tag-name@2.0.0:
+        resolution:
+            {
+                integrity: sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==,
+            }
+        dev: false
+
+    /micromark-util-normalize-identifier@2.0.0:
+        resolution:
+            {
+                integrity: sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==,
+            }
+        dependencies:
+            micromark-util-symbol: 2.0.0
+        dev: false
+
+    /micromark-util-resolve-all@2.0.0:
+        resolution:
+            {
+                integrity: sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==,
+            }
+        dependencies:
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-util-sanitize-uri@2.0.0:
+        resolution:
+            {
+                integrity: sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==,
+            }
+        dependencies:
+            micromark-util-character: 2.1.0
+            micromark-util-encode: 2.0.0
+            micromark-util-symbol: 2.0.0
+        dev: false
+
+    /micromark-util-subtokenize@2.0.1:
+        resolution:
+            {
+                integrity: sha512-jZNtiFl/1aY73yS3UGQkutD0UbhTt68qnRpw2Pifmz5wV9h8gOVsN70v+Lq/f1rKaU/W8pxRe8y8Q9FX1AOe1Q==,
+            }
+        dependencies:
+            devlop: 1.1.0
+            micromark-util-chunked: 2.0.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        dev: false
+
+    /micromark-util-symbol@2.0.0:
+        resolution:
+            {
+                integrity: sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==,
+            }
+        dev: false
+
+    /micromark-util-types@2.0.0:
+        resolution:
+            {
+                integrity: sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==,
+            }
+        dev: false
+
+    /micromark@4.0.0:
+        resolution:
+            {
+                integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==,
+            }
+        dependencies:
+            '@types/debug': 4.1.12
+            debug: 4.3.5
+            decode-named-character-reference: 1.0.2
+            devlop: 1.1.0
+            micromark-core-commonmark: 2.0.1
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-chunked: 2.0.0
+            micromark-util-combine-extensions: 2.0.0
+            micromark-util-decode-numeric-character-reference: 2.0.1
+            micromark-util-encode: 2.0.0
+            micromark-util-normalize-identifier: 2.0.0
+            micromark-util-resolve-all: 2.0.0
+            micromark-util-sanitize-uri: 2.0.0
+            micromark-util-subtokenize: 2.0.1
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /mime-db@1.52.0:
+        resolution:
+            {
+                integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+            }
+        engines: { node: '>= 0.6' }
+        dev: false
+
+    /mime-types@2.1.35:
+        resolution:
+            {
+                integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+            }
+        engines: { node: '>= 0.6' }
+        dependencies:
+            mime-db: 1.52.0
+        dev: false
+
+    /ms@2.1.2:
+        resolution:
+            {
+                integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==,
+            }
+        dev: false
+
+    /neo-async@2.6.2:
+        resolution:
+            {
+                integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==,
+            }
+        dev: false
+
+    /node-releases@2.0.14:
+        resolution:
+            {
+                integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==,
+            }
+        dev: false
+
+    /object-assign@4.1.1:
+        resolution:
+            {
+                integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+            }
+        engines: { node: '>=0.10.0' }
+        dev: false
+
+    /parse-entities@4.0.1:
+        resolution:
+            {
+                integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==,
+            }
+        dependencies:
+            '@types/unist': 2.0.10
+            character-entities: 2.0.2
+            character-entities-legacy: 3.0.0
+            character-reference-invalid: 2.0.1
+            decode-named-character-reference: 1.0.2
+            is-alphanumerical: 2.0.1
+            is-decimal: 2.0.1
+            is-hexadecimal: 2.0.1
+        dev: false
+
+    /periscopic@3.1.0:
+        resolution:
+            {
+                integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==,
+            }
+        dependencies:
+            '@types/estree': 1.0.5
+            estree-walker: 3.0.3
+            is-reference: 3.0.2
+        dev: false
+
+    /picocolors@1.0.1:
+        resolution:
+            {
+                integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==,
+            }
+        dev: false
+
+    /prop-types@15.8.1:
+        resolution:
+            {
+                integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
+            }
+        dependencies:
+            loose-envify: 1.4.0
+            object-assign: 4.1.1
+            react-is: 16.13.1
+        dev: false
+
+    /property-information@6.5.0:
+        resolution:
+            {
+                integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==,
+            }
+        dev: false
+
+    /punycode@2.3.1:
+        resolution:
+            {
+                integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+            }
+        engines: { node: '>=6' }
+        dev: false
+
+    /randombytes@2.1.0:
+        resolution:
+            {
+                integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==,
+            }
+        dependencies:
+            safe-buffer: 5.2.1
+        dev: false
+
+    /react-dom@18.3.1(react@18.3.1):
+        resolution:
+            {
+                integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==,
+            }
+        peerDependencies:
+            react: ^18.3.1
+        dependencies:
+            loose-envify: 1.4.0
+            react: 18.3.1
+            scheduler: 0.23.2
+        dev: false
+
+    /react-fast-compare@3.2.2:
+        resolution:
+            {
+                integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==,
+            }
+        dev: false
+
+    /react-helmet-async@1.3.0(react-dom@18.3.1)(react@18.3.1):
+        resolution:
+            {
+                integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==,
+            }
+        peerDependencies:
+            react: ^16.6.0 || ^17.0.0 || ^18.0.0
+            react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
+        dependencies:
+            '@babel/runtime': 7.24.6
+            invariant: 2.2.4
+            prop-types: 15.8.1
+            react: 18.3.1
+            react-dom: 18.3.1(react@18.3.1)
+            react-fast-compare: 3.2.2
+            shallowequal: 1.1.0
+        dev: false
+
+    /react-helmet-async@2.0.5(react@18.3.1):
+        resolution:
+            {
+                integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==,
+            }
+        peerDependencies:
+            react: ^16.6.0 || ^17.0.0 || ^18.0.0
+        dependencies:
+            invariant: 2.2.4
+            react: 18.3.1
+            react-fast-compare: 3.2.2
+            shallowequal: 1.1.0
+        dev: false
+
+    /react-is@16.13.1:
+        resolution:
+            {
+                integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
+            }
+        dev: false
+
+    /react@18.3.1:
+        resolution:
+            {
+                integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==,
+            }
+        engines: { node: '>=0.10.0' }
+        dependencies:
+            loose-envify: 1.4.0
+        dev: false
+
+    /regenerator-runtime@0.14.1:
+        resolution:
+            {
+                integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==,
+            }
+        dev: false
+
+    /remark-mdx@3.0.1:
+        resolution:
+            {
+                integrity: sha512-3Pz3yPQ5Rht2pM5R+0J2MrGoBSrzf+tJG94N+t/ilfdh8YLyyKYtidAYwTveB20BoHAcwIopOUqhcmh2F7hGYA==,
+            }
+        dependencies:
+            mdast-util-mdx: 3.0.0
+            micromark-extension-mdxjs: 3.0.0
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /remark-parse@11.0.0:
+        resolution:
+            {
+                integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==,
+            }
+        dependencies:
+            '@types/mdast': 4.0.4
+            mdast-util-from-markdown: 2.0.1
+            micromark-util-types: 2.0.0
+            unified: 11.0.4
+        transitivePeerDependencies:
+            - supports-color
+        dev: false
+
+    /remark-rehype@11.1.0:
+        resolution:
+            {
+                integrity: sha512-z3tJrAs2kIs1AqIIy6pzHmAHlF1hWQ+OdY4/hv+Wxe35EhyLKcajL33iUEn3ScxtFox9nUvRufR/Zre8Q08H/g==,
+            }
+        dependencies:
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            mdast-util-to-hast: 13.1.0
+            unified: 11.0.4
+            vfile: 6.0.1
+        dev: false
+
+    /safe-buffer@5.2.1:
+        resolution:
+            {
+                integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+            }
+        dev: false
+
+    /scheduler@0.23.2:
+        resolution:
+            {
+                integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
+            }
+        dependencies:
+            loose-envify: 1.4.0
+        dev: false
+
+    /schema-utils@3.3.0:
+        resolution:
+            {
+                integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==,
+            }
+        engines: { node: '>= 10.13.0' }
+        dependencies:
+            '@types/json-schema': 7.0.15
+            ajv: 6.12.6
+            ajv-keywords: 3.5.2(ajv@6.12.6)
+        dev: false
+
+    /serialize-javascript@6.0.2:
+        resolution:
+            {
+                integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==,
+            }
+        dependencies:
+            randombytes: 2.1.0
+        dev: false
+
+    /shallow-clone@3.0.1:
+        resolution:
+            {
+                integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==,
+            }
+        engines: { node: '>=8' }
+        dependencies:
+            kind-of: 6.0.3
+        dev: false
+
+    /shallowequal@1.1.0:
+        resolution:
+            {
+                integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==,
+            }
+        dev: false
+
+    /source-map-support@0.5.21:
+        resolution:
+            {
+                integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
+            }
+        dependencies:
+            buffer-from: 1.1.2
+            source-map: 0.6.1
+        dev: false
+
+    /source-map@0.6.1:
+        resolution:
+            {
+                integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
+            }
+        engines: { node: '>=0.10.0' }
+        dev: false
+
+    /source-map@0.7.4:
+        resolution:
+            {
+                integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==,
+            }
+        engines: { node: '>= 8' }
+        dev: false
+
+    /space-separated-tokens@2.0.2:
+        resolution:
+            {
+                integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
+            }
+        dev: false
+
+    /stringify-entities@4.0.4:
+        resolution:
+            {
+                integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
+            }
+        dependencies:
+            character-entities-html4: 2.1.0
+            character-entities-legacy: 3.0.0
+        dev: false
+
+    /style-to-object@0.4.4:
+        resolution:
+            {
+                integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==,
+            }
+        dependencies:
+            inline-style-parser: 0.1.1
+        dev: false
+
+    /style-to-object@1.0.6:
+        resolution:
+            {
+                integrity: sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==,
+            }
+        dependencies:
+            inline-style-parser: 0.2.3
+        dev: false
+
+    /supports-color@8.1.1:
+        resolution:
+            {
+                integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==,
+            }
+        engines: { node: '>=10' }
+        dependencies:
+            has-flag: 4.0.0
+        dev: false
+
+    /tapable@2.2.1:
+        resolution:
+            {
+                integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==,
+            }
+        engines: { node: '>=6' }
+        dev: false
+
+    /terser-webpack-plugin@5.3.10(webpack@5.91.0):
+        resolution:
+            {
+                integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==,
+            }
+        engines: { node: '>= 10.13.0' }
+        peerDependencies:
+            '@swc/core': '*'
+            esbuild: '*'
+            uglify-js: '*'
+            webpack: ^5.1.0
+        peerDependenciesMeta:
+            '@swc/core':
+                optional: true
+            esbuild:
+                optional: true
+            uglify-js:
+                optional: true
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.25
+            jest-worker: 27.5.1
+            schema-utils: 3.3.0
+            serialize-javascript: 6.0.2
+            terser: 5.31.0
+            webpack: 5.91.0
+        dev: false
+
+    /terser@5.31.0:
+        resolution:
+            {
+                integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==,
+            }
+        engines: { node: '>=10' }
+        hasBin: true
+        dependencies:
+            '@jridgewell/source-map': 0.3.6
+            acorn: 8.11.3
+            commander: 2.20.3
+            source-map-support: 0.5.21
+        dev: false
+
+    /trim-lines@3.0.1:
+        resolution:
+            {
+                integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==,
+            }
+        dev: false
+
+    /trough@2.2.0:
+        resolution:
+            {
+                integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
+            }
+        dev: false
+
+    /undici-types@5.26.5:
+        resolution:
+            {
+                integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==,
+            }
+        dev: false
+
+    /unified@11.0.4:
+        resolution:
+            {
+                integrity: sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+            bail: 2.0.2
+            devlop: 1.1.0
+            extend: 3.0.2
+            is-plain-obj: 4.1.0
+            trough: 2.2.0
+            vfile: 6.0.1
+        dev: false
+
+    /unist-util-is@6.0.0:
+        resolution:
+            {
+                integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+        dev: false
+
+    /unist-util-position-from-estree@2.0.0:
+        resolution:
+            {
+                integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+        dev: false
+
+    /unist-util-position@5.0.0:
+        resolution:
+            {
+                integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+        dev: false
+
+    /unist-util-remove-position@5.0.0:
+        resolution:
+            {
+                integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-visit: 5.0.0
+        dev: false
+
+    /unist-util-stringify-position@4.0.0:
+        resolution:
+            {
+                integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+        dev: false
+
+    /unist-util-visit-parents@6.0.1:
+        resolution:
+            {
+                integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-is: 6.0.0
+        dev: false
+
+    /unist-util-visit@5.0.0:
+        resolution:
+            {
+                integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-is: 6.0.0
+            unist-util-visit-parents: 6.0.1
+        dev: false
+
+    /update-browserslist-db@1.0.16(browserslist@4.23.0):
+        resolution:
+            {
+                integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==,
+            }
+        hasBin: true
+        peerDependencies:
+            browserslist: '>= 4.21.0'
+        dependencies:
+            browserslist: 4.23.0
+            escalade: 3.1.2
+            picocolors: 1.0.1
+        dev: false
+
+    /uri-js@4.4.1:
+        resolution:
+            {
+                integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+            }
+        dependencies:
+            punycode: 2.3.1
+        dev: false
+
+    /utility-types@3.11.0:
+        resolution:
+            {
+                integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==,
+            }
+        engines: { node: '>= 4' }
+        dev: false
+
+    /vfile-message@4.0.2:
+        resolution:
+            {
+                integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-stringify-position: 4.0.0
+        dev: false
+
+    /vfile@6.0.1:
+        resolution:
+            {
+                integrity: sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==,
+            }
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-stringify-position: 4.0.0
+            vfile-message: 4.0.2
+        dev: false
+
+    /watchpack@2.4.1:
+        resolution:
+            {
+                integrity: sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==,
+            }
+        engines: { node: '>=10.13.0' }
+        dependencies:
+            glob-to-regexp: 0.4.1
+            graceful-fs: 4.2.11
+        dev: false
+
+    /webpack-merge@5.10.0:
+        resolution:
+            {
+                integrity: sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==,
+            }
+        engines: { node: '>=10.0.0' }
+        dependencies:
+            clone-deep: 4.0.1
+            flat: 5.0.2
+            wildcard: 2.0.1
+        dev: false
+
+    /webpack-sources@3.2.3:
+        resolution:
+            {
+                integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==,
+            }
+        engines: { node: '>=10.13.0' }
+        dev: false
+
+    /webpack@5.91.0:
+        resolution:
+            {
+                integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==,
+            }
+        engines: { node: '>=10.13.0' }
+        hasBin: true
+        peerDependencies:
+            webpack-cli: '*'
+        peerDependenciesMeta:
+            webpack-cli:
+                optional: true
+        dependencies:
+            '@types/eslint-scope': 3.7.7
+            '@types/estree': 1.0.5
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/wasm-edit': 1.12.1
+            '@webassemblyjs/wasm-parser': 1.12.1
+            acorn: 8.11.3
+            acorn-import-assertions: 1.9.0(acorn@8.11.3)
+            browserslist: 4.23.0
+            chrome-trace-event: 1.0.4
+            enhanced-resolve: 5.17.0
+            es-module-lexer: 1.5.3
+            eslint-scope: 5.1.1
+            events: 3.3.0
+            glob-to-regexp: 0.4.1
+            graceful-fs: 4.2.11
+            json-parse-even-better-errors: 2.3.1
+            loader-runner: 4.3.0
+            mime-types: 2.1.35
+            neo-async: 2.6.2
+            schema-utils: 3.3.0
+            tapable: 2.2.1
+            terser-webpack-plugin: 5.3.10(webpack@5.91.0)
+            watchpack: 2.4.1
+            webpack-sources: 3.2.3
+        transitivePeerDependencies:
+            - '@swc/core'
+            - esbuild
+            - uglify-js
+        dev: false
+
+    /wildcard@2.0.1:
+        resolution:
+            {
+                integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==,
+            }
+        dev: false
+
+    /zwitch@2.0.4:
+        resolution:
+            {
+                integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
+            }
+        dev: false

--- a/e2e/pnpm_lockfiles/cases/docusaurus-direct-peer-v9.yaml
+++ b/e2e/pnpm_lockfiles/cases/docusaurus-direct-peer-v9.yaml
@@ -1,0 +1,2584 @@
+lockfileVersion: '9.0'
+
+settings:
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
+
+importers:
+    .:
+        dependencies:
+            '@docusaurus/module-type-aliases':
+                specifier: ^3.1.0
+                version: 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+packages:
+    '@babel/runtime@7.24.6':
+        resolution:
+            {
+                integrity: sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@docusaurus/module-type-aliases@3.4.0':
+        resolution:
+            {
+                integrity: sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==,
+            }
+        peerDependencies:
+            react: '*'
+            react-dom: '*'
+
+    '@docusaurus/react-loadable@6.0.0':
+        resolution:
+            {
+                integrity: sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==,
+            }
+        peerDependencies:
+            react: '*'
+
+    '@docusaurus/types@3.4.0':
+        resolution:
+            {
+                integrity: sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==,
+            }
+        peerDependencies:
+            react: ^18.0.0
+            react-dom: ^18.0.0
+
+    '@hapi/hoek@9.3.0':
+        resolution:
+            {
+                integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==,
+            }
+
+    '@hapi/topo@5.1.0':
+        resolution:
+            {
+                integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==,
+            }
+
+    '@jridgewell/gen-mapping@0.3.5':
+        resolution:
+            {
+                integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==,
+            }
+        engines: { node: '>=6.0.0' }
+
+    '@jridgewell/resolve-uri@3.1.2':
+        resolution:
+            {
+                integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+            }
+        engines: { node: '>=6.0.0' }
+
+    '@jridgewell/set-array@1.2.1':
+        resolution:
+            {
+                integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==,
+            }
+        engines: { node: '>=6.0.0' }
+
+    '@jridgewell/source-map@0.3.6':
+        resolution:
+            {
+                integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==,
+            }
+
+    '@jridgewell/sourcemap-codec@1.4.15':
+        resolution:
+            {
+                integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==,
+            }
+
+    '@jridgewell/trace-mapping@0.3.25':
+        resolution:
+            {
+                integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==,
+            }
+
+    '@mdx-js/mdx@3.0.1':
+        resolution:
+            {
+                integrity: sha512-eIQ4QTrOWyL3LWEe/bu6Taqzq2HQvHcyTMaOrI95P2/LmJE7AsfPfgJGuFLPVqBUE1BC1rik3VIhU+s9u72arA==,
+            }
+
+    '@sideway/address@4.1.5':
+        resolution:
+            {
+                integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==,
+            }
+
+    '@sideway/formula@3.0.1':
+        resolution:
+            {
+                integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==,
+            }
+
+    '@sideway/pinpoint@2.0.0':
+        resolution:
+            {
+                integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==,
+            }
+
+    '@types/acorn@4.0.6':
+        resolution:
+            {
+                integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==,
+            }
+
+    '@types/debug@4.1.12':
+        resolution:
+            {
+                integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==,
+            }
+
+    '@types/eslint-scope@3.7.7':
+        resolution:
+            {
+                integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==,
+            }
+
+    '@types/eslint@8.56.10':
+        resolution:
+            {
+                integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==,
+            }
+
+    '@types/estree-jsx@1.0.5':
+        resolution:
+            {
+                integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
+            }
+
+    '@types/estree@1.0.5':
+        resolution:
+            {
+                integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==,
+            }
+
+    '@types/hast@3.0.4':
+        resolution:
+            {
+                integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
+            }
+
+    '@types/history@4.7.11':
+        resolution:
+            {
+                integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==,
+            }
+
+    '@types/json-schema@7.0.15':
+        resolution:
+            {
+                integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+            }
+
+    '@types/mdast@4.0.4':
+        resolution:
+            {
+                integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
+            }
+
+    '@types/mdx@2.0.13':
+        resolution:
+            {
+                integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
+            }
+
+    '@types/ms@0.7.34':
+        resolution:
+            {
+                integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==,
+            }
+
+    '@types/node@20.14.1':
+        resolution:
+            {
+                integrity: sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==,
+            }
+
+    '@types/prop-types@15.7.12':
+        resolution:
+            {
+                integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==,
+            }
+
+    '@types/react-router-config@5.0.11':
+        resolution:
+            {
+                integrity: sha512-WmSAg7WgqW7m4x8Mt4N6ZyKz0BubSj/2tVUMsAHp+Yd2AMwcSbeFq9WympT19p5heCFmF97R9eD5uUR/t4HEqw==,
+            }
+
+    '@types/react-router-dom@5.3.3':
+        resolution:
+            {
+                integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==,
+            }
+
+    '@types/react-router@5.1.20':
+        resolution:
+            {
+                integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==,
+            }
+
+    '@types/react@18.3.3':
+        resolution:
+            {
+                integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==,
+            }
+
+    '@types/unist@2.0.10':
+        resolution:
+            {
+                integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==,
+            }
+
+    '@types/unist@3.0.2':
+        resolution:
+            {
+                integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==,
+            }
+
+    '@ungap/structured-clone@1.2.0':
+        resolution:
+            {
+                integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==,
+            }
+
+    '@webassemblyjs/ast@1.12.1':
+        resolution:
+            {
+                integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==,
+            }
+
+    '@webassemblyjs/floating-point-hex-parser@1.11.6':
+        resolution:
+            {
+                integrity: sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==,
+            }
+
+    '@webassemblyjs/helper-api-error@1.11.6':
+        resolution:
+            {
+                integrity: sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==,
+            }
+
+    '@webassemblyjs/helper-buffer@1.12.1':
+        resolution:
+            {
+                integrity: sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==,
+            }
+
+    '@webassemblyjs/helper-numbers@1.11.6':
+        resolution:
+            {
+                integrity: sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==,
+            }
+
+    '@webassemblyjs/helper-wasm-bytecode@1.11.6':
+        resolution:
+            {
+                integrity: sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==,
+            }
+
+    '@webassemblyjs/helper-wasm-section@1.12.1':
+        resolution:
+            {
+                integrity: sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==,
+            }
+
+    '@webassemblyjs/ieee754@1.11.6':
+        resolution:
+            {
+                integrity: sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==,
+            }
+
+    '@webassemblyjs/leb128@1.11.6':
+        resolution:
+            {
+                integrity: sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==,
+            }
+
+    '@webassemblyjs/utf8@1.11.6':
+        resolution:
+            {
+                integrity: sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==,
+            }
+
+    '@webassemblyjs/wasm-edit@1.12.1':
+        resolution:
+            {
+                integrity: sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==,
+            }
+
+    '@webassemblyjs/wasm-gen@1.12.1':
+        resolution:
+            {
+                integrity: sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==,
+            }
+
+    '@webassemblyjs/wasm-opt@1.12.1':
+        resolution:
+            {
+                integrity: sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==,
+            }
+
+    '@webassemblyjs/wasm-parser@1.12.1':
+        resolution:
+            {
+                integrity: sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==,
+            }
+
+    '@webassemblyjs/wast-printer@1.12.1':
+        resolution:
+            {
+                integrity: sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==,
+            }
+
+    '@xtuc/ieee754@1.2.0':
+        resolution:
+            {
+                integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==,
+            }
+
+    '@xtuc/long@4.2.2':
+        resolution:
+            {
+                integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==,
+            }
+
+    acorn-import-assertions@1.9.0:
+        resolution:
+            {
+                integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==,
+            }
+        peerDependencies:
+            acorn: ^8
+
+    acorn-jsx@5.3.2:
+        resolution:
+            {
+                integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+            }
+        peerDependencies:
+            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+    acorn@8.11.3:
+        resolution:
+            {
+                integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==,
+            }
+        engines: { node: '>=0.4.0' }
+        hasBin: true
+
+    ajv-keywords@3.5.2:
+        resolution:
+            {
+                integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==,
+            }
+        peerDependencies:
+            ajv: ^6.9.1
+
+    ajv@6.12.6:
+        resolution:
+            {
+                integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+            }
+
+    astring@1.8.6:
+        resolution:
+            {
+                integrity: sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==,
+            }
+        hasBin: true
+
+    bail@2.0.2:
+        resolution:
+            {
+                integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
+            }
+
+    browserslist@4.23.0:
+        resolution:
+            {
+                integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==,
+            }
+        engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+        hasBin: true
+
+    buffer-from@1.1.2:
+        resolution:
+            {
+                integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
+            }
+
+    caniuse-lite@1.0.30001627:
+        resolution:
+            {
+                integrity: sha512-4zgNiB8nTyV/tHhwZrFs88ryjls/lHiqFhrxCW4qSTeuRByBVnPYpDInchOIySWknznucaf31Z4KYqjfbrecVw==,
+            }
+
+    ccount@2.0.1:
+        resolution:
+            {
+                integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
+            }
+
+    character-entities-html4@2.1.0:
+        resolution:
+            {
+                integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==,
+            }
+
+    character-entities-legacy@3.0.0:
+        resolution:
+            {
+                integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==,
+            }
+
+    character-entities@2.0.2:
+        resolution:
+            {
+                integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==,
+            }
+
+    character-reference-invalid@2.0.1:
+        resolution:
+            {
+                integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
+            }
+
+    chrome-trace-event@1.0.4:
+        resolution:
+            {
+                integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==,
+            }
+        engines: { node: '>=6.0' }
+
+    clone-deep@4.0.1:
+        resolution:
+            {
+                integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==,
+            }
+        engines: { node: '>=6' }
+
+    collapse-white-space@2.1.0:
+        resolution:
+            {
+                integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
+            }
+
+    comma-separated-tokens@2.0.3:
+        resolution:
+            {
+                integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
+            }
+
+    commander@2.20.3:
+        resolution:
+            {
+                integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
+            }
+
+    commander@5.1.0:
+        resolution:
+            {
+                integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==,
+            }
+        engines: { node: '>= 6' }
+
+    csstype@3.1.3:
+        resolution:
+            {
+                integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==,
+            }
+
+    debug@4.3.5:
+        resolution:
+            {
+                integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==,
+            }
+        engines: { node: '>=6.0' }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+
+    decode-named-character-reference@1.0.2:
+        resolution:
+            {
+                integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==,
+            }
+
+    dequal@2.0.3:
+        resolution:
+            {
+                integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
+            }
+        engines: { node: '>=6' }
+
+    devlop@1.1.0:
+        resolution:
+            {
+                integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
+            }
+
+    electron-to-chromium@1.4.789:
+        resolution:
+            {
+                integrity: sha512-0VbyiaXoT++Fi2vHGo2ThOeS6X3vgRCWrjPeO2FeIAWL6ItiSJ9BqlH8LfCXe3X1IdcG+S0iLoNaxQWhfZoGzQ==,
+            }
+
+    enhanced-resolve@5.17.0:
+        resolution:
+            {
+                integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==,
+            }
+        engines: { node: '>=10.13.0' }
+
+    es-module-lexer@1.5.3:
+        resolution:
+            {
+                integrity: sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==,
+            }
+
+    escalade@3.1.2:
+        resolution:
+            {
+                integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==,
+            }
+        engines: { node: '>=6' }
+
+    eslint-scope@5.1.1:
+        resolution:
+            {
+                integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==,
+            }
+        engines: { node: '>=8.0.0' }
+
+    esrecurse@4.3.0:
+        resolution:
+            {
+                integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+            }
+        engines: { node: '>=4.0' }
+
+    estraverse@4.3.0:
+        resolution:
+            {
+                integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==,
+            }
+        engines: { node: '>=4.0' }
+
+    estraverse@5.3.0:
+        resolution:
+            {
+                integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+            }
+        engines: { node: '>=4.0' }
+
+    estree-util-attach-comments@3.0.0:
+        resolution:
+            {
+                integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==,
+            }
+
+    estree-util-build-jsx@3.0.1:
+        resolution:
+            {
+                integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==,
+            }
+
+    estree-util-is-identifier-name@3.0.0:
+        resolution:
+            {
+                integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==,
+            }
+
+    estree-util-to-js@2.0.0:
+        resolution:
+            {
+                integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==,
+            }
+
+    estree-util-visit@2.0.0:
+        resolution:
+            {
+                integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==,
+            }
+
+    estree-walker@3.0.3:
+        resolution:
+            {
+                integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+            }
+
+    events@3.3.0:
+        resolution:
+            {
+                integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==,
+            }
+        engines: { node: '>=0.8.x' }
+
+    extend@3.0.2:
+        resolution:
+            {
+                integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
+            }
+
+    fast-deep-equal@3.1.3:
+        resolution:
+            {
+                integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+            }
+
+    fast-json-stable-stringify@2.1.0:
+        resolution:
+            {
+                integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+            }
+
+    flat@5.0.2:
+        resolution:
+            {
+                integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==,
+            }
+        hasBin: true
+
+    glob-to-regexp@0.4.1:
+        resolution:
+            {
+                integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==,
+            }
+
+    graceful-fs@4.2.11:
+        resolution:
+            {
+                integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+            }
+
+    has-flag@4.0.0:
+        resolution:
+            {
+                integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+            }
+        engines: { node: '>=8' }
+
+    hast-util-to-estree@3.1.0:
+        resolution:
+            {
+                integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==,
+            }
+
+    hast-util-to-jsx-runtime@2.3.0:
+        resolution:
+            {
+                integrity: sha512-H/y0+IWPdsLLS738P8tDnrQ8Z+dj12zQQ6WC11TIM21C8WFVoIxcqWXf2H3hiTVZjF1AWqoimGwrTWecWrnmRQ==,
+            }
+
+    hast-util-whitespace@3.0.0:
+        resolution:
+            {
+                integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
+            }
+
+    inline-style-parser@0.1.1:
+        resolution:
+            {
+                integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==,
+            }
+
+    inline-style-parser@0.2.3:
+        resolution:
+            {
+                integrity: sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g==,
+            }
+
+    invariant@2.2.4:
+        resolution:
+            {
+                integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==,
+            }
+
+    is-alphabetical@2.0.1:
+        resolution:
+            {
+                integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==,
+            }
+
+    is-alphanumerical@2.0.1:
+        resolution:
+            {
+                integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
+            }
+
+    is-decimal@2.0.1:
+        resolution:
+            {
+                integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==,
+            }
+
+    is-hexadecimal@2.0.1:
+        resolution:
+            {
+                integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
+            }
+
+    is-plain-obj@4.1.0:
+        resolution:
+            {
+                integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
+            }
+        engines: { node: '>=12' }
+
+    is-plain-object@2.0.4:
+        resolution:
+            {
+                integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-reference@3.0.2:
+        resolution:
+            {
+                integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==,
+            }
+
+    isobject@3.0.1:
+        resolution:
+            {
+                integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    jest-worker@27.5.1:
+        resolution:
+            {
+                integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==,
+            }
+        engines: { node: '>= 10.13.0' }
+
+    joi@17.13.1:
+        resolution:
+            {
+                integrity: sha512-vaBlIKCyo4FCUtCm7Eu4QZd/q02bWcxfUO6YSXAZOWF6gzcLBeba8kwotUdYJjDLW8Cz8RywsSOqiNJZW0mNvg==,
+            }
+
+    js-tokens@4.0.0:
+        resolution:
+            {
+                integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+            }
+
+    json-parse-even-better-errors@2.3.1:
+        resolution:
+            {
+                integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
+            }
+
+    json-schema-traverse@0.4.1:
+        resolution:
+            {
+                integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+            }
+
+    kind-of@6.0.3:
+        resolution:
+            {
+                integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    loader-runner@4.3.0:
+        resolution:
+            {
+                integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==,
+            }
+        engines: { node: '>=6.11.5' }
+
+    longest-streak@3.1.0:
+        resolution:
+            {
+                integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
+            }
+
+    loose-envify@1.4.0:
+        resolution:
+            {
+                integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
+            }
+        hasBin: true
+
+    markdown-extensions@2.0.0:
+        resolution:
+            {
+                integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==,
+            }
+        engines: { node: '>=16' }
+
+    mdast-util-from-markdown@2.0.1:
+        resolution:
+            {
+                integrity: sha512-aJEUyzZ6TzlsX2s5B4Of7lN7EQtAxvtradMMglCQDyaTFgse6CmtmdJ15ElnVRlCg1vpNyVtbem0PWzlNieZsA==,
+            }
+
+    mdast-util-mdx-expression@2.0.0:
+        resolution:
+            {
+                integrity: sha512-fGCu8eWdKUKNu5mohVGkhBXCXGnOTLuFqOvGMvdikr+J1w7lDJgxThOKpwRWzzbyXAU2hhSwsmssOY4yTokluw==,
+            }
+
+    mdast-util-mdx-jsx@3.1.2:
+        resolution:
+            {
+                integrity: sha512-eKMQDeywY2wlHc97k5eD8VC+9ASMjN8ItEZQNGwJ6E0XWKiW/Z0V5/H8pvoXUf+y+Mj0VIgeRRbujBmFn4FTyA==,
+            }
+
+    mdast-util-mdx@3.0.0:
+        resolution:
+            {
+                integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==,
+            }
+
+    mdast-util-mdxjs-esm@2.0.1:
+        resolution:
+            {
+                integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
+            }
+
+    mdast-util-phrasing@4.1.0:
+        resolution:
+            {
+                integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==,
+            }
+
+    mdast-util-to-hast@13.1.0:
+        resolution:
+            {
+                integrity: sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==,
+            }
+
+    mdast-util-to-markdown@2.1.0:
+        resolution:
+            {
+                integrity: sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==,
+            }
+
+    mdast-util-to-string@4.0.0:
+        resolution:
+            {
+                integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
+            }
+
+    merge-stream@2.0.0:
+        resolution:
+            {
+                integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
+            }
+
+    micromark-core-commonmark@2.0.1:
+        resolution:
+            {
+                integrity: sha512-CUQyKr1e///ZODyD1U3xit6zXwy1a8q2a1S1HKtIlmgvurrEpaw/Y9y6KSIbF8P59cn/NjzHyO+Q2fAyYLQrAA==,
+            }
+
+    micromark-extension-mdx-expression@3.0.0:
+        resolution:
+            {
+                integrity: sha512-sI0nwhUDz97xyzqJAbHQhp5TfaxEvZZZ2JDqUo+7NvyIYG6BZ5CPPqj2ogUoPJlmXHBnyZUzISg9+oUmU6tUjQ==,
+            }
+
+    micromark-extension-mdx-jsx@3.0.0:
+        resolution:
+            {
+                integrity: sha512-uvhhss8OGuzR4/N17L1JwvmJIpPhAd8oByMawEKx6NVdBCbesjH4t+vjEp3ZXft9DwvlKSD07fCeI44/N0Vf2w==,
+            }
+
+    micromark-extension-mdx-md@2.0.0:
+        resolution:
+            {
+                integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==,
+            }
+
+    micromark-extension-mdxjs-esm@3.0.0:
+        resolution:
+            {
+                integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==,
+            }
+
+    micromark-extension-mdxjs@3.0.0:
+        resolution:
+            {
+                integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==,
+            }
+
+    micromark-factory-destination@2.0.0:
+        resolution:
+            {
+                integrity: sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==,
+            }
+
+    micromark-factory-label@2.0.0:
+        resolution:
+            {
+                integrity: sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==,
+            }
+
+    micromark-factory-mdx-expression@2.0.1:
+        resolution:
+            {
+                integrity: sha512-F0ccWIUHRLRrYp5TC9ZYXmZo+p2AM13ggbsW4T0b5CRKP8KHVRB8t4pwtBgTxtjRmwrK0Irwm7vs2JOZabHZfg==,
+            }
+
+    micromark-factory-space@2.0.0:
+        resolution:
+            {
+                integrity: sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==,
+            }
+
+    micromark-factory-title@2.0.0:
+        resolution:
+            {
+                integrity: sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==,
+            }
+
+    micromark-factory-whitespace@2.0.0:
+        resolution:
+            {
+                integrity: sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==,
+            }
+
+    micromark-util-character@2.1.0:
+        resolution:
+            {
+                integrity: sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==,
+            }
+
+    micromark-util-chunked@2.0.0:
+        resolution:
+            {
+                integrity: sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==,
+            }
+
+    micromark-util-classify-character@2.0.0:
+        resolution:
+            {
+                integrity: sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==,
+            }
+
+    micromark-util-combine-extensions@2.0.0:
+        resolution:
+            {
+                integrity: sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==,
+            }
+
+    micromark-util-decode-numeric-character-reference@2.0.1:
+        resolution:
+            {
+                integrity: sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==,
+            }
+
+    micromark-util-decode-string@2.0.0:
+        resolution:
+            {
+                integrity: sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==,
+            }
+
+    micromark-util-encode@2.0.0:
+        resolution:
+            {
+                integrity: sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==,
+            }
+
+    micromark-util-events-to-acorn@2.0.2:
+        resolution:
+            {
+                integrity: sha512-Fk+xmBrOv9QZnEDguL9OI9/NQQp6Hz4FuQ4YmCb/5V7+9eAh1s6AYSvL20kHkD67YIg7EpE54TiSlcsf3vyZgA==,
+            }
+
+    micromark-util-html-tag-name@2.0.0:
+        resolution:
+            {
+                integrity: sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==,
+            }
+
+    micromark-util-normalize-identifier@2.0.0:
+        resolution:
+            {
+                integrity: sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==,
+            }
+
+    micromark-util-resolve-all@2.0.0:
+        resolution:
+            {
+                integrity: sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==,
+            }
+
+    micromark-util-sanitize-uri@2.0.0:
+        resolution:
+            {
+                integrity: sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==,
+            }
+
+    micromark-util-subtokenize@2.0.1:
+        resolution:
+            {
+                integrity: sha512-jZNtiFl/1aY73yS3UGQkutD0UbhTt68qnRpw2Pifmz5wV9h8gOVsN70v+Lq/f1rKaU/W8pxRe8y8Q9FX1AOe1Q==,
+            }
+
+    micromark-util-symbol@2.0.0:
+        resolution:
+            {
+                integrity: sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==,
+            }
+
+    micromark-util-types@2.0.0:
+        resolution:
+            {
+                integrity: sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==,
+            }
+
+    micromark@4.0.0:
+        resolution:
+            {
+                integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==,
+            }
+
+    mime-db@1.52.0:
+        resolution:
+            {
+                integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+            }
+        engines: { node: '>= 0.6' }
+
+    mime-types@2.1.35:
+        resolution:
+            {
+                integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+            }
+        engines: { node: '>= 0.6' }
+
+    ms@2.1.2:
+        resolution:
+            {
+                integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==,
+            }
+
+    neo-async@2.6.2:
+        resolution:
+            {
+                integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==,
+            }
+
+    node-releases@2.0.14:
+        resolution:
+            {
+                integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==,
+            }
+
+    object-assign@4.1.1:
+        resolution:
+            {
+                integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    parse-entities@4.0.1:
+        resolution:
+            {
+                integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==,
+            }
+
+    periscopic@3.1.0:
+        resolution:
+            {
+                integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==,
+            }
+
+    picocolors@1.0.1:
+        resolution:
+            {
+                integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==,
+            }
+
+    prop-types@15.8.1:
+        resolution:
+            {
+                integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
+            }
+
+    property-information@6.5.0:
+        resolution:
+            {
+                integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==,
+            }
+
+    punycode@2.3.1:
+        resolution:
+            {
+                integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+            }
+        engines: { node: '>=6' }
+
+    randombytes@2.1.0:
+        resolution:
+            {
+                integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==,
+            }
+
+    react-dom@18.3.1:
+        resolution:
+            {
+                integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==,
+            }
+        peerDependencies:
+            react: ^18.3.1
+
+    react-fast-compare@3.2.2:
+        resolution:
+            {
+                integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==,
+            }
+
+    react-helmet-async@1.3.0:
+        resolution:
+            {
+                integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==,
+            }
+        peerDependencies:
+            react: ^16.6.0 || ^17.0.0 || ^18.0.0
+            react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
+
+    react-helmet-async@2.0.5:
+        resolution:
+            {
+                integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==,
+            }
+        peerDependencies:
+            react: ^16.6.0 || ^17.0.0 || ^18.0.0
+
+    react-is@16.13.1:
+        resolution:
+            {
+                integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
+            }
+
+    react@18.3.1:
+        resolution:
+            {
+                integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    regenerator-runtime@0.14.1:
+        resolution:
+            {
+                integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==,
+            }
+
+    remark-mdx@3.0.1:
+        resolution:
+            {
+                integrity: sha512-3Pz3yPQ5Rht2pM5R+0J2MrGoBSrzf+tJG94N+t/ilfdh8YLyyKYtidAYwTveB20BoHAcwIopOUqhcmh2F7hGYA==,
+            }
+
+    remark-parse@11.0.0:
+        resolution:
+            {
+                integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==,
+            }
+
+    remark-rehype@11.1.0:
+        resolution:
+            {
+                integrity: sha512-z3tJrAs2kIs1AqIIy6pzHmAHlF1hWQ+OdY4/hv+Wxe35EhyLKcajL33iUEn3ScxtFox9nUvRufR/Zre8Q08H/g==,
+            }
+
+    safe-buffer@5.2.1:
+        resolution:
+            {
+                integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+            }
+
+    scheduler@0.23.2:
+        resolution:
+            {
+                integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
+            }
+
+    schema-utils@3.3.0:
+        resolution:
+            {
+                integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==,
+            }
+        engines: { node: '>= 10.13.0' }
+
+    serialize-javascript@6.0.2:
+        resolution:
+            {
+                integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==,
+            }
+
+    shallow-clone@3.0.1:
+        resolution:
+            {
+                integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==,
+            }
+        engines: { node: '>=8' }
+
+    shallowequal@1.1.0:
+        resolution:
+            {
+                integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==,
+            }
+
+    source-map-support@0.5.21:
+        resolution:
+            {
+                integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
+            }
+
+    source-map@0.6.1:
+        resolution:
+            {
+                integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    source-map@0.7.4:
+        resolution:
+            {
+                integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==,
+            }
+        engines: { node: '>= 8' }
+
+    space-separated-tokens@2.0.2:
+        resolution:
+            {
+                integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
+            }
+
+    stringify-entities@4.0.4:
+        resolution:
+            {
+                integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
+            }
+
+    style-to-object@0.4.4:
+        resolution:
+            {
+                integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==,
+            }
+
+    style-to-object@1.0.6:
+        resolution:
+            {
+                integrity: sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==,
+            }
+
+    supports-color@8.1.1:
+        resolution:
+            {
+                integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==,
+            }
+        engines: { node: '>=10' }
+
+    tapable@2.2.1:
+        resolution:
+            {
+                integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==,
+            }
+        engines: { node: '>=6' }
+
+    terser-webpack-plugin@5.3.10:
+        resolution:
+            {
+                integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==,
+            }
+        engines: { node: '>= 10.13.0' }
+        peerDependencies:
+            '@swc/core': '*'
+            esbuild: '*'
+            uglify-js: '*'
+            webpack: ^5.1.0
+        peerDependenciesMeta:
+            '@swc/core':
+                optional: true
+            esbuild:
+                optional: true
+            uglify-js:
+                optional: true
+
+    terser@5.31.0:
+        resolution:
+            {
+                integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==,
+            }
+        engines: { node: '>=10' }
+        hasBin: true
+
+    trim-lines@3.0.1:
+        resolution:
+            {
+                integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==,
+            }
+
+    trough@2.2.0:
+        resolution:
+            {
+                integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
+            }
+
+    undici-types@5.26.5:
+        resolution:
+            {
+                integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==,
+            }
+
+    unified@11.0.4:
+        resolution:
+            {
+                integrity: sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==,
+            }
+
+    unist-util-is@6.0.0:
+        resolution:
+            {
+                integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==,
+            }
+
+    unist-util-position-from-estree@2.0.0:
+        resolution:
+            {
+                integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==,
+            }
+
+    unist-util-position@5.0.0:
+        resolution:
+            {
+                integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==,
+            }
+
+    unist-util-remove-position@5.0.0:
+        resolution:
+            {
+                integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==,
+            }
+
+    unist-util-stringify-position@4.0.0:
+        resolution:
+            {
+                integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
+            }
+
+    unist-util-visit-parents@6.0.1:
+        resolution:
+            {
+                integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==,
+            }
+
+    unist-util-visit@5.0.0:
+        resolution:
+            {
+                integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==,
+            }
+
+    update-browserslist-db@1.0.16:
+        resolution:
+            {
+                integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==,
+            }
+        hasBin: true
+        peerDependencies:
+            browserslist: '>= 4.21.0'
+
+    uri-js@4.4.1:
+        resolution:
+            {
+                integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+            }
+
+    utility-types@3.11.0:
+        resolution:
+            {
+                integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==,
+            }
+        engines: { node: '>= 4' }
+
+    vfile-message@4.0.2:
+        resolution:
+            {
+                integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==,
+            }
+
+    vfile@6.0.1:
+        resolution:
+            {
+                integrity: sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==,
+            }
+
+    watchpack@2.4.1:
+        resolution:
+            {
+                integrity: sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==,
+            }
+        engines: { node: '>=10.13.0' }
+
+    webpack-merge@5.10.0:
+        resolution:
+            {
+                integrity: sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==,
+            }
+        engines: { node: '>=10.0.0' }
+
+    webpack-sources@3.2.3:
+        resolution:
+            {
+                integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==,
+            }
+        engines: { node: '>=10.13.0' }
+
+    webpack@5.91.0:
+        resolution:
+            {
+                integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==,
+            }
+        engines: { node: '>=10.13.0' }
+        hasBin: true
+        peerDependencies:
+            webpack-cli: '*'
+        peerDependenciesMeta:
+            webpack-cli:
+                optional: true
+
+    wildcard@2.0.1:
+        resolution:
+            {
+                integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==,
+            }
+
+    zwitch@2.0.4:
+        resolution:
+            {
+                integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
+            }
+
+snapshots:
+    '@babel/runtime@7.24.6':
+        dependencies:
+            regenerator-runtime: 0.14.1
+
+    '@docusaurus/module-type-aliases@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+        dependencies:
+            '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+            '@types/react-router-config': 5.0.11
+            '@types/react-router-dom': 5.3.3
+            react: 18.3.1
+            react-dom: 18.3.1(react@18.3.1)
+            react-helmet-async: 2.0.5(react@18.3.1)
+            react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
+        transitivePeerDependencies:
+            - '@swc/core'
+            - esbuild
+            - supports-color
+            - uglify-js
+            - webpack-cli
+
+    '@docusaurus/react-loadable@6.0.0(react@18.3.1)':
+        dependencies:
+            '@types/react': 18.3.3
+            react: 18.3.1
+
+    '@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+        dependencies:
+            '@mdx-js/mdx': 3.0.1
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+            commander: 5.1.0
+            joi: 17.13.1
+            react: 18.3.1
+            react-dom: 18.3.1(react@18.3.1)
+            react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            utility-types: 3.11.0
+            webpack: 5.91.0
+            webpack-merge: 5.10.0
+        transitivePeerDependencies:
+            - '@swc/core'
+            - esbuild
+            - supports-color
+            - uglify-js
+            - webpack-cli
+
+    '@hapi/hoek@9.3.0': {}
+
+    '@hapi/topo@5.1.0':
+        dependencies:
+            '@hapi/hoek': 9.3.0
+
+    '@jridgewell/gen-mapping@0.3.5':
+        dependencies:
+            '@jridgewell/set-array': 1.2.1
+            '@jridgewell/sourcemap-codec': 1.4.15
+            '@jridgewell/trace-mapping': 0.3.25
+
+    '@jridgewell/resolve-uri@3.1.2': {}
+
+    '@jridgewell/set-array@1.2.1': {}
+
+    '@jridgewell/source-map@0.3.6':
+        dependencies:
+            '@jridgewell/gen-mapping': 0.3.5
+            '@jridgewell/trace-mapping': 0.3.25
+
+    '@jridgewell/sourcemap-codec@1.4.15': {}
+
+    '@jridgewell/trace-mapping@0.3.25':
+        dependencies:
+            '@jridgewell/resolve-uri': 3.1.2
+            '@jridgewell/sourcemap-codec': 1.4.15
+
+    '@mdx-js/mdx@3.0.1':
+        dependencies:
+            '@types/estree': 1.0.5
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/mdx': 2.0.13
+            collapse-white-space: 2.1.0
+            devlop: 1.1.0
+            estree-util-build-jsx: 3.0.1
+            estree-util-is-identifier-name: 3.0.0
+            estree-util-to-js: 2.0.0
+            estree-walker: 3.0.3
+            hast-util-to-estree: 3.1.0
+            hast-util-to-jsx-runtime: 2.3.0
+            markdown-extensions: 2.0.0
+            periscopic: 3.1.0
+            remark-mdx: 3.0.1
+            remark-parse: 11.0.0
+            remark-rehype: 11.1.0
+            source-map: 0.7.4
+            unified: 11.0.4
+            unist-util-position-from-estree: 2.0.0
+            unist-util-stringify-position: 4.0.0
+            unist-util-visit: 5.0.0
+            vfile: 6.0.1
+        transitivePeerDependencies:
+            - supports-color
+
+    '@sideway/address@4.1.5':
+        dependencies:
+            '@hapi/hoek': 9.3.0
+
+    '@sideway/formula@3.0.1': {}
+
+    '@sideway/pinpoint@2.0.0': {}
+
+    '@types/acorn@4.0.6':
+        dependencies:
+            '@types/estree': 1.0.5
+
+    '@types/debug@4.1.12':
+        dependencies:
+            '@types/ms': 0.7.34
+
+    '@types/eslint-scope@3.7.7':
+        dependencies:
+            '@types/eslint': 8.56.10
+            '@types/estree': 1.0.5
+
+    '@types/eslint@8.56.10':
+        dependencies:
+            '@types/estree': 1.0.5
+            '@types/json-schema': 7.0.15
+
+    '@types/estree-jsx@1.0.5':
+        dependencies:
+            '@types/estree': 1.0.5
+
+    '@types/estree@1.0.5': {}
+
+    '@types/hast@3.0.4':
+        dependencies:
+            '@types/unist': 3.0.2
+
+    '@types/history@4.7.11': {}
+
+    '@types/json-schema@7.0.15': {}
+
+    '@types/mdast@4.0.4':
+        dependencies:
+            '@types/unist': 3.0.2
+
+    '@types/mdx@2.0.13': {}
+
+    '@types/ms@0.7.34': {}
+
+    '@types/node@20.14.1':
+        dependencies:
+            undici-types: 5.26.5
+
+    '@types/prop-types@15.7.12': {}
+
+    '@types/react-router-config@5.0.11':
+        dependencies:
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+            '@types/react-router': 5.1.20
+
+    '@types/react-router-dom@5.3.3':
+        dependencies:
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+            '@types/react-router': 5.1.20
+
+    '@types/react-router@5.1.20':
+        dependencies:
+            '@types/history': 4.7.11
+            '@types/react': 18.3.3
+
+    '@types/react@18.3.3':
+        dependencies:
+            '@types/prop-types': 15.7.12
+            csstype: 3.1.3
+
+    '@types/unist@2.0.10': {}
+
+    '@types/unist@3.0.2': {}
+
+    '@ungap/structured-clone@1.2.0': {}
+
+    '@webassemblyjs/ast@1.12.1':
+        dependencies:
+            '@webassemblyjs/helper-numbers': 1.11.6
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+
+    '@webassemblyjs/floating-point-hex-parser@1.11.6': {}
+
+    '@webassemblyjs/helper-api-error@1.11.6': {}
+
+    '@webassemblyjs/helper-buffer@1.12.1': {}
+
+    '@webassemblyjs/helper-numbers@1.11.6':
+        dependencies:
+            '@webassemblyjs/floating-point-hex-parser': 1.11.6
+            '@webassemblyjs/helper-api-error': 1.11.6
+            '@xtuc/long': 4.2.2
+
+    '@webassemblyjs/helper-wasm-bytecode@1.11.6': {}
+
+    '@webassemblyjs/helper-wasm-section@1.12.1':
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-buffer': 1.12.1
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+            '@webassemblyjs/wasm-gen': 1.12.1
+
+    '@webassemblyjs/ieee754@1.11.6':
+        dependencies:
+            '@xtuc/ieee754': 1.2.0
+
+    '@webassemblyjs/leb128@1.11.6':
+        dependencies:
+            '@xtuc/long': 4.2.2
+
+    '@webassemblyjs/utf8@1.11.6': {}
+
+    '@webassemblyjs/wasm-edit@1.12.1':
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-buffer': 1.12.1
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+            '@webassemblyjs/helper-wasm-section': 1.12.1
+            '@webassemblyjs/wasm-gen': 1.12.1
+            '@webassemblyjs/wasm-opt': 1.12.1
+            '@webassemblyjs/wasm-parser': 1.12.1
+            '@webassemblyjs/wast-printer': 1.12.1
+
+    '@webassemblyjs/wasm-gen@1.12.1':
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+            '@webassemblyjs/ieee754': 1.11.6
+            '@webassemblyjs/leb128': 1.11.6
+            '@webassemblyjs/utf8': 1.11.6
+
+    '@webassemblyjs/wasm-opt@1.12.1':
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-buffer': 1.12.1
+            '@webassemblyjs/wasm-gen': 1.12.1
+            '@webassemblyjs/wasm-parser': 1.12.1
+
+    '@webassemblyjs/wasm-parser@1.12.1':
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/helper-api-error': 1.11.6
+            '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+            '@webassemblyjs/ieee754': 1.11.6
+            '@webassemblyjs/leb128': 1.11.6
+            '@webassemblyjs/utf8': 1.11.6
+
+    '@webassemblyjs/wast-printer@1.12.1':
+        dependencies:
+            '@webassemblyjs/ast': 1.12.1
+            '@xtuc/long': 4.2.2
+
+    '@xtuc/ieee754@1.2.0': {}
+
+    '@xtuc/long@4.2.2': {}
+
+    acorn-import-assertions@1.9.0(acorn@8.11.3):
+        dependencies:
+            acorn: 8.11.3
+
+    acorn-jsx@5.3.2(acorn@8.11.3):
+        dependencies:
+            acorn: 8.11.3
+
+    acorn@8.11.3: {}
+
+    ajv-keywords@3.5.2(ajv@6.12.6):
+        dependencies:
+            ajv: 6.12.6
+
+    ajv@6.12.6:
+        dependencies:
+            fast-deep-equal: 3.1.3
+            fast-json-stable-stringify: 2.1.0
+            json-schema-traverse: 0.4.1
+            uri-js: 4.4.1
+
+    astring@1.8.6: {}
+
+    bail@2.0.2: {}
+
+    browserslist@4.23.0:
+        dependencies:
+            caniuse-lite: 1.0.30001627
+            electron-to-chromium: 1.4.789
+            node-releases: 2.0.14
+            update-browserslist-db: 1.0.16(browserslist@4.23.0)
+
+    buffer-from@1.1.2: {}
+
+    caniuse-lite@1.0.30001627: {}
+
+    ccount@2.0.1: {}
+
+    character-entities-html4@2.1.0: {}
+
+    character-entities-legacy@3.0.0: {}
+
+    character-entities@2.0.2: {}
+
+    character-reference-invalid@2.0.1: {}
+
+    chrome-trace-event@1.0.4: {}
+
+    clone-deep@4.0.1:
+        dependencies:
+            is-plain-object: 2.0.4
+            kind-of: 6.0.3
+            shallow-clone: 3.0.1
+
+    collapse-white-space@2.1.0: {}
+
+    comma-separated-tokens@2.0.3: {}
+
+    commander@2.20.3: {}
+
+    commander@5.1.0: {}
+
+    csstype@3.1.3: {}
+
+    debug@4.3.5:
+        dependencies:
+            ms: 2.1.2
+
+    decode-named-character-reference@1.0.2:
+        dependencies:
+            character-entities: 2.0.2
+
+    dequal@2.0.3: {}
+
+    devlop@1.1.0:
+        dependencies:
+            dequal: 2.0.3
+
+    electron-to-chromium@1.4.789: {}
+
+    enhanced-resolve@5.17.0:
+        dependencies:
+            graceful-fs: 4.2.11
+            tapable: 2.2.1
+
+    es-module-lexer@1.5.3: {}
+
+    escalade@3.1.2: {}
+
+    eslint-scope@5.1.1:
+        dependencies:
+            esrecurse: 4.3.0
+            estraverse: 4.3.0
+
+    esrecurse@4.3.0:
+        dependencies:
+            estraverse: 5.3.0
+
+    estraverse@4.3.0: {}
+
+    estraverse@5.3.0: {}
+
+    estree-util-attach-comments@3.0.0:
+        dependencies:
+            '@types/estree': 1.0.5
+
+    estree-util-build-jsx@3.0.1:
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            devlop: 1.1.0
+            estree-util-is-identifier-name: 3.0.0
+            estree-walker: 3.0.3
+
+    estree-util-is-identifier-name@3.0.0: {}
+
+    estree-util-to-js@2.0.0:
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            astring: 1.8.6
+            source-map: 0.7.4
+
+    estree-util-visit@2.0.0:
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            '@types/unist': 3.0.2
+
+    estree-walker@3.0.3:
+        dependencies:
+            '@types/estree': 1.0.5
+
+    events@3.3.0: {}
+
+    extend@3.0.2: {}
+
+    fast-deep-equal@3.1.3: {}
+
+    fast-json-stable-stringify@2.1.0: {}
+
+    flat@5.0.2: {}
+
+    glob-to-regexp@0.4.1: {}
+
+    graceful-fs@4.2.11: {}
+
+    has-flag@4.0.0: {}
+
+    hast-util-to-estree@3.1.0:
+        dependencies:
+            '@types/estree': 1.0.5
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            comma-separated-tokens: 2.0.3
+            devlop: 1.1.0
+            estree-util-attach-comments: 3.0.0
+            estree-util-is-identifier-name: 3.0.0
+            hast-util-whitespace: 3.0.0
+            mdast-util-mdx-expression: 2.0.0
+            mdast-util-mdx-jsx: 3.1.2
+            mdast-util-mdxjs-esm: 2.0.1
+            property-information: 6.5.0
+            space-separated-tokens: 2.0.2
+            style-to-object: 0.4.4
+            unist-util-position: 5.0.0
+            zwitch: 2.0.4
+        transitivePeerDependencies:
+            - supports-color
+
+    hast-util-to-jsx-runtime@2.3.0:
+        dependencies:
+            '@types/estree': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/unist': 3.0.2
+            comma-separated-tokens: 2.0.3
+            devlop: 1.1.0
+            estree-util-is-identifier-name: 3.0.0
+            hast-util-whitespace: 3.0.0
+            mdast-util-mdx-expression: 2.0.0
+            mdast-util-mdx-jsx: 3.1.2
+            mdast-util-mdxjs-esm: 2.0.1
+            property-information: 6.5.0
+            space-separated-tokens: 2.0.2
+            style-to-object: 1.0.6
+            unist-util-position: 5.0.0
+            vfile-message: 4.0.2
+        transitivePeerDependencies:
+            - supports-color
+
+    hast-util-whitespace@3.0.0:
+        dependencies:
+            '@types/hast': 3.0.4
+
+    inline-style-parser@0.1.1: {}
+
+    inline-style-parser@0.2.3: {}
+
+    invariant@2.2.4:
+        dependencies:
+            loose-envify: 1.4.0
+
+    is-alphabetical@2.0.1: {}
+
+    is-alphanumerical@2.0.1:
+        dependencies:
+            is-alphabetical: 2.0.1
+            is-decimal: 2.0.1
+
+    is-decimal@2.0.1: {}
+
+    is-hexadecimal@2.0.1: {}
+
+    is-plain-obj@4.1.0: {}
+
+    is-plain-object@2.0.4:
+        dependencies:
+            isobject: 3.0.1
+
+    is-reference@3.0.2:
+        dependencies:
+            '@types/estree': 1.0.5
+
+    isobject@3.0.1: {}
+
+    jest-worker@27.5.1:
+        dependencies:
+            '@types/node': 20.14.1
+            merge-stream: 2.0.0
+            supports-color: 8.1.1
+
+    joi@17.13.1:
+        dependencies:
+            '@hapi/hoek': 9.3.0
+            '@hapi/topo': 5.1.0
+            '@sideway/address': 4.1.5
+            '@sideway/formula': 3.0.1
+            '@sideway/pinpoint': 2.0.0
+
+    js-tokens@4.0.0: {}
+
+    json-parse-even-better-errors@2.3.1: {}
+
+    json-schema-traverse@0.4.1: {}
+
+    kind-of@6.0.3: {}
+
+    loader-runner@4.3.0: {}
+
+    longest-streak@3.1.0: {}
+
+    loose-envify@1.4.0:
+        dependencies:
+            js-tokens: 4.0.0
+
+    markdown-extensions@2.0.0: {}
+
+    mdast-util-from-markdown@2.0.1:
+        dependencies:
+            '@types/mdast': 4.0.4
+            '@types/unist': 3.0.2
+            decode-named-character-reference: 1.0.2
+            devlop: 1.1.0
+            mdast-util-to-string: 4.0.0
+            micromark: 4.0.0
+            micromark-util-decode-numeric-character-reference: 2.0.1
+            micromark-util-decode-string: 2.0.0
+            micromark-util-normalize-identifier: 2.0.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            unist-util-stringify-position: 4.0.0
+        transitivePeerDependencies:
+            - supports-color
+
+    mdast-util-mdx-expression@2.0.0:
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            devlop: 1.1.0
+            mdast-util-from-markdown: 2.0.1
+            mdast-util-to-markdown: 2.1.0
+        transitivePeerDependencies:
+            - supports-color
+
+    mdast-util-mdx-jsx@3.1.2:
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            '@types/unist': 3.0.2
+            ccount: 2.0.1
+            devlop: 1.1.0
+            mdast-util-from-markdown: 2.0.1
+            mdast-util-to-markdown: 2.1.0
+            parse-entities: 4.0.1
+            stringify-entities: 4.0.4
+            unist-util-remove-position: 5.0.0
+            unist-util-stringify-position: 4.0.0
+            vfile-message: 4.0.2
+        transitivePeerDependencies:
+            - supports-color
+
+    mdast-util-mdx@3.0.0:
+        dependencies:
+            mdast-util-from-markdown: 2.0.1
+            mdast-util-mdx-expression: 2.0.0
+            mdast-util-mdx-jsx: 3.1.2
+            mdast-util-mdxjs-esm: 2.0.1
+            mdast-util-to-markdown: 2.1.0
+        transitivePeerDependencies:
+            - supports-color
+
+    mdast-util-mdxjs-esm@2.0.1:
+        dependencies:
+            '@types/estree-jsx': 1.0.5
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            devlop: 1.1.0
+            mdast-util-from-markdown: 2.0.1
+            mdast-util-to-markdown: 2.1.0
+        transitivePeerDependencies:
+            - supports-color
+
+    mdast-util-phrasing@4.1.0:
+        dependencies:
+            '@types/mdast': 4.0.4
+            unist-util-is: 6.0.0
+
+    mdast-util-to-hast@13.1.0:
+        dependencies:
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            '@ungap/structured-clone': 1.2.0
+            devlop: 1.1.0
+            micromark-util-sanitize-uri: 2.0.0
+            trim-lines: 3.0.1
+            unist-util-position: 5.0.0
+            unist-util-visit: 5.0.0
+            vfile: 6.0.1
+
+    mdast-util-to-markdown@2.1.0:
+        dependencies:
+            '@types/mdast': 4.0.4
+            '@types/unist': 3.0.2
+            longest-streak: 3.1.0
+            mdast-util-phrasing: 4.1.0
+            mdast-util-to-string: 4.0.0
+            micromark-util-decode-string: 2.0.0
+            unist-util-visit: 5.0.0
+            zwitch: 2.0.4
+
+    mdast-util-to-string@4.0.0:
+        dependencies:
+            '@types/mdast': 4.0.4
+
+    merge-stream@2.0.0: {}
+
+    micromark-core-commonmark@2.0.1:
+        dependencies:
+            decode-named-character-reference: 1.0.2
+            devlop: 1.1.0
+            micromark-factory-destination: 2.0.0
+            micromark-factory-label: 2.0.0
+            micromark-factory-space: 2.0.0
+            micromark-factory-title: 2.0.0
+            micromark-factory-whitespace: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-chunked: 2.0.0
+            micromark-util-classify-character: 2.0.0
+            micromark-util-html-tag-name: 2.0.0
+            micromark-util-normalize-identifier: 2.0.0
+            micromark-util-resolve-all: 2.0.0
+            micromark-util-subtokenize: 2.0.1
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-extension-mdx-expression@3.0.0:
+        dependencies:
+            '@types/estree': 1.0.5
+            devlop: 1.1.0
+            micromark-factory-mdx-expression: 2.0.1
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-events-to-acorn: 2.0.2
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-extension-mdx-jsx@3.0.0:
+        dependencies:
+            '@types/acorn': 4.0.6
+            '@types/estree': 1.0.5
+            devlop: 1.1.0
+            estree-util-is-identifier-name: 3.0.0
+            micromark-factory-mdx-expression: 2.0.1
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            vfile-message: 4.0.2
+
+    micromark-extension-mdx-md@2.0.0:
+        dependencies:
+            micromark-util-types: 2.0.0
+
+    micromark-extension-mdxjs-esm@3.0.0:
+        dependencies:
+            '@types/estree': 1.0.5
+            devlop: 1.1.0
+            micromark-core-commonmark: 2.0.1
+            micromark-util-character: 2.1.0
+            micromark-util-events-to-acorn: 2.0.2
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            unist-util-position-from-estree: 2.0.0
+            vfile-message: 4.0.2
+
+    micromark-extension-mdxjs@3.0.0:
+        dependencies:
+            acorn: 8.11.3
+            acorn-jsx: 5.3.2(acorn@8.11.3)
+            micromark-extension-mdx-expression: 3.0.0
+            micromark-extension-mdx-jsx: 3.0.0
+            micromark-extension-mdx-md: 2.0.0
+            micromark-extension-mdxjs-esm: 3.0.0
+            micromark-util-combine-extensions: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-factory-destination@2.0.0:
+        dependencies:
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-factory-label@2.0.0:
+        dependencies:
+            devlop: 1.1.0
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-factory-mdx-expression@2.0.1:
+        dependencies:
+            '@types/estree': 1.0.5
+            devlop: 1.1.0
+            micromark-util-character: 2.1.0
+            micromark-util-events-to-acorn: 2.0.2
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            unist-util-position-from-estree: 2.0.0
+            vfile-message: 4.0.2
+
+    micromark-factory-space@2.0.0:
+        dependencies:
+            micromark-util-character: 2.1.0
+            micromark-util-types: 2.0.0
+
+    micromark-factory-title@2.0.0:
+        dependencies:
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-factory-whitespace@2.0.0:
+        dependencies:
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-util-character@2.1.0:
+        dependencies:
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-util-chunked@2.0.0:
+        dependencies:
+            micromark-util-symbol: 2.0.0
+
+    micromark-util-classify-character@2.0.0:
+        dependencies:
+            micromark-util-character: 2.1.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-util-combine-extensions@2.0.0:
+        dependencies:
+            micromark-util-chunked: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-util-decode-numeric-character-reference@2.0.1:
+        dependencies:
+            micromark-util-symbol: 2.0.0
+
+    micromark-util-decode-string@2.0.0:
+        dependencies:
+            decode-named-character-reference: 1.0.2
+            micromark-util-character: 2.1.0
+            micromark-util-decode-numeric-character-reference: 2.0.1
+            micromark-util-symbol: 2.0.0
+
+    micromark-util-encode@2.0.0: {}
+
+    micromark-util-events-to-acorn@2.0.2:
+        dependencies:
+            '@types/acorn': 4.0.6
+            '@types/estree': 1.0.5
+            '@types/unist': 3.0.2
+            devlop: 1.1.0
+            estree-util-visit: 2.0.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+            vfile-message: 4.0.2
+
+    micromark-util-html-tag-name@2.0.0: {}
+
+    micromark-util-normalize-identifier@2.0.0:
+        dependencies:
+            micromark-util-symbol: 2.0.0
+
+    micromark-util-resolve-all@2.0.0:
+        dependencies:
+            micromark-util-types: 2.0.0
+
+    micromark-util-sanitize-uri@2.0.0:
+        dependencies:
+            micromark-util-character: 2.1.0
+            micromark-util-encode: 2.0.0
+            micromark-util-symbol: 2.0.0
+
+    micromark-util-subtokenize@2.0.1:
+        dependencies:
+            devlop: 1.1.0
+            micromark-util-chunked: 2.0.0
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+
+    micromark-util-symbol@2.0.0: {}
+
+    micromark-util-types@2.0.0: {}
+
+    micromark@4.0.0:
+        dependencies:
+            '@types/debug': 4.1.12
+            debug: 4.3.5
+            decode-named-character-reference: 1.0.2
+            devlop: 1.1.0
+            micromark-core-commonmark: 2.0.1
+            micromark-factory-space: 2.0.0
+            micromark-util-character: 2.1.0
+            micromark-util-chunked: 2.0.0
+            micromark-util-combine-extensions: 2.0.0
+            micromark-util-decode-numeric-character-reference: 2.0.1
+            micromark-util-encode: 2.0.0
+            micromark-util-normalize-identifier: 2.0.0
+            micromark-util-resolve-all: 2.0.0
+            micromark-util-sanitize-uri: 2.0.0
+            micromark-util-subtokenize: 2.0.1
+            micromark-util-symbol: 2.0.0
+            micromark-util-types: 2.0.0
+        transitivePeerDependencies:
+            - supports-color
+
+    mime-db@1.52.0: {}
+
+    mime-types@2.1.35:
+        dependencies:
+            mime-db: 1.52.0
+
+    ms@2.1.2: {}
+
+    neo-async@2.6.2: {}
+
+    node-releases@2.0.14: {}
+
+    object-assign@4.1.1: {}
+
+    parse-entities@4.0.1:
+        dependencies:
+            '@types/unist': 2.0.10
+            character-entities: 2.0.2
+            character-entities-legacy: 3.0.0
+            character-reference-invalid: 2.0.1
+            decode-named-character-reference: 1.0.2
+            is-alphanumerical: 2.0.1
+            is-decimal: 2.0.1
+            is-hexadecimal: 2.0.1
+
+    periscopic@3.1.0:
+        dependencies:
+            '@types/estree': 1.0.5
+            estree-walker: 3.0.3
+            is-reference: 3.0.2
+
+    picocolors@1.0.1: {}
+
+    prop-types@15.8.1:
+        dependencies:
+            loose-envify: 1.4.0
+            object-assign: 4.1.1
+            react-is: 16.13.1
+
+    property-information@6.5.0: {}
+
+    punycode@2.3.1: {}
+
+    randombytes@2.1.0:
+        dependencies:
+            safe-buffer: 5.2.1
+
+    react-dom@18.3.1(react@18.3.1):
+        dependencies:
+            loose-envify: 1.4.0
+            react: 18.3.1
+            scheduler: 0.23.2
+
+    react-fast-compare@3.2.2: {}
+
+    react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+        dependencies:
+            '@babel/runtime': 7.24.6
+            invariant: 2.2.4
+            prop-types: 15.8.1
+            react: 18.3.1
+            react-dom: 18.3.1(react@18.3.1)
+            react-fast-compare: 3.2.2
+            shallowequal: 1.1.0
+
+    react-helmet-async@2.0.5(react@18.3.1):
+        dependencies:
+            invariant: 2.2.4
+            react: 18.3.1
+            react-fast-compare: 3.2.2
+            shallowequal: 1.1.0
+
+    react-is@16.13.1: {}
+
+    react@18.3.1:
+        dependencies:
+            loose-envify: 1.4.0
+
+    regenerator-runtime@0.14.1: {}
+
+    remark-mdx@3.0.1:
+        dependencies:
+            mdast-util-mdx: 3.0.0
+            micromark-extension-mdxjs: 3.0.0
+        transitivePeerDependencies:
+            - supports-color
+
+    remark-parse@11.0.0:
+        dependencies:
+            '@types/mdast': 4.0.4
+            mdast-util-from-markdown: 2.0.1
+            micromark-util-types: 2.0.0
+            unified: 11.0.4
+        transitivePeerDependencies:
+            - supports-color
+
+    remark-rehype@11.1.0:
+        dependencies:
+            '@types/hast': 3.0.4
+            '@types/mdast': 4.0.4
+            mdast-util-to-hast: 13.1.0
+            unified: 11.0.4
+            vfile: 6.0.1
+
+    safe-buffer@5.2.1: {}
+
+    scheduler@0.23.2:
+        dependencies:
+            loose-envify: 1.4.0
+
+    schema-utils@3.3.0:
+        dependencies:
+            '@types/json-schema': 7.0.15
+            ajv: 6.12.6
+            ajv-keywords: 3.5.2(ajv@6.12.6)
+
+    serialize-javascript@6.0.2:
+        dependencies:
+            randombytes: 2.1.0
+
+    shallow-clone@3.0.1:
+        dependencies:
+            kind-of: 6.0.3
+
+    shallowequal@1.1.0: {}
+
+    source-map-support@0.5.21:
+        dependencies:
+            buffer-from: 1.1.2
+            source-map: 0.6.1
+
+    source-map@0.6.1: {}
+
+    source-map@0.7.4: {}
+
+    space-separated-tokens@2.0.2: {}
+
+    stringify-entities@4.0.4:
+        dependencies:
+            character-entities-html4: 2.1.0
+            character-entities-legacy: 3.0.0
+
+    style-to-object@0.4.4:
+        dependencies:
+            inline-style-parser: 0.1.1
+
+    style-to-object@1.0.6:
+        dependencies:
+            inline-style-parser: 0.2.3
+
+    supports-color@8.1.1:
+        dependencies:
+            has-flag: 4.0.0
+
+    tapable@2.2.1: {}
+
+    terser-webpack-plugin@5.3.10(webpack@5.91.0):
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.25
+            jest-worker: 27.5.1
+            schema-utils: 3.3.0
+            serialize-javascript: 6.0.2
+            terser: 5.31.0
+            webpack: 5.91.0
+
+    terser@5.31.0:
+        dependencies:
+            '@jridgewell/source-map': 0.3.6
+            acorn: 8.11.3
+            commander: 2.20.3
+            source-map-support: 0.5.21
+
+    trim-lines@3.0.1: {}
+
+    trough@2.2.0: {}
+
+    undici-types@5.26.5: {}
+
+    unified@11.0.4:
+        dependencies:
+            '@types/unist': 3.0.2
+            bail: 2.0.2
+            devlop: 1.1.0
+            extend: 3.0.2
+            is-plain-obj: 4.1.0
+            trough: 2.2.0
+            vfile: 6.0.1
+
+    unist-util-is@6.0.0:
+        dependencies:
+            '@types/unist': 3.0.2
+
+    unist-util-position-from-estree@2.0.0:
+        dependencies:
+            '@types/unist': 3.0.2
+
+    unist-util-position@5.0.0:
+        dependencies:
+            '@types/unist': 3.0.2
+
+    unist-util-remove-position@5.0.0:
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-visit: 5.0.0
+
+    unist-util-stringify-position@4.0.0:
+        dependencies:
+            '@types/unist': 3.0.2
+
+    unist-util-visit-parents@6.0.1:
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-is: 6.0.0
+
+    unist-util-visit@5.0.0:
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-is: 6.0.0
+            unist-util-visit-parents: 6.0.1
+
+    update-browserslist-db@1.0.16(browserslist@4.23.0):
+        dependencies:
+            browserslist: 4.23.0
+            escalade: 3.1.2
+            picocolors: 1.0.1
+
+    uri-js@4.4.1:
+        dependencies:
+            punycode: 2.3.1
+
+    utility-types@3.11.0: {}
+
+    vfile-message@4.0.2:
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-stringify-position: 4.0.0
+
+    vfile@6.0.1:
+        dependencies:
+            '@types/unist': 3.0.2
+            unist-util-stringify-position: 4.0.0
+            vfile-message: 4.0.2
+
+    watchpack@2.4.1:
+        dependencies:
+            glob-to-regexp: 0.4.1
+            graceful-fs: 4.2.11
+
+    webpack-merge@5.10.0:
+        dependencies:
+            clone-deep: 4.0.1
+            flat: 5.0.2
+            wildcard: 2.0.1
+
+    webpack-sources@3.2.3: {}
+
+    webpack@5.91.0:
+        dependencies:
+            '@types/eslint-scope': 3.7.7
+            '@types/estree': 1.0.5
+            '@webassemblyjs/ast': 1.12.1
+            '@webassemblyjs/wasm-edit': 1.12.1
+            '@webassemblyjs/wasm-parser': 1.12.1
+            acorn: 8.11.3
+            acorn-import-assertions: 1.9.0(acorn@8.11.3)
+            browserslist: 4.23.0
+            chrome-trace-event: 1.0.4
+            enhanced-resolve: 5.17.0
+            es-module-lexer: 1.5.3
+            eslint-scope: 5.1.1
+            events: 3.3.0
+            glob-to-regexp: 0.4.1
+            graceful-fs: 4.2.11
+            json-parse-even-better-errors: 2.3.1
+            loader-runner: 4.3.0
+            mime-types: 2.1.35
+            neo-async: 2.6.2
+            schema-utils: 3.3.0
+            tapable: 2.2.1
+            terser-webpack-plugin: 5.3.10(webpack@5.91.0)
+            watchpack: 2.4.1
+            webpack-sources: 3.2.3
+        transitivePeerDependencies:
+            - '@swc/core'
+            - esbuild
+            - uglify-js
+
+    wildcard@2.0.1: {}
+
+    zwitch@2.0.4: {}


### PR DESCRIPTION
Transitive `npm:` deps that contain peers were not being escaped.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
