### PR TITLE
refactor: remote non-functional exclude_declarations_from_npm_packages alias

### DIFF
--- a/npm/BUILD.bazel
+++ b/npm/BUILD.bazel
@@ -16,13 +16,6 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
-# For backward compat
-# TODO(3.0): remove this backward compat flag
-alias(
-    name = "exclude_declarations_from_npm_packages",
-    actual = ":exclude_types_from_npm_packages",
-)
-
 config_setting(
     name = "exclude_types_from_npm_packages_flag",
     flag_values = {":exclude_types_from_npm_packages": "true"},


### PR DESCRIPTION
This alias was added for backward compat for the `--@aspect_rules_js//npm:exclude_declarations_from_npm_packages` config flag, which was renamed to `--@aspect_rules_js//npm:exclude_types_from_npm_packages` but it turns out that aliases don't work for config flags so the alias is non-functional:

```
ERROR: @aspect_rules_js//npm:exclude_declarations_from_npm_packages :: Unrecognized option: @aspect_rules_js//npm:exclude_declarations_from_npm_packages
```

---

### Changes are visible to end-users: no
