### PR TITLE
fix: fix issue with bzlmod toolchain registration by bumping minimum rules_nodejs to 6.1.2

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -33,7 +33,7 @@ bazel_dep(name = "aspect_rules_js", version = "${TAG:1}")
 ####### Node.js version #########
 # By default you get the node version from DEFAULT_NODE_VERSION in @rules_nodejs//nodejs:repositories.bzl
 # Optionally you can pin a different node version:
-bazel_dep(name = "rules_nodejs", version = "6.1.0")
+bazel_dep(name = "rules_nodejs", version = "6.1.2")
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 node.toolchain(node_version = "16.14.2")
 #################################

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")
-bazel_dep(name = "rules_nodejs", version = "6.1.0")
+bazel_dep(name = "rules_nodejs", version = "6.1.2")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 use_repo(node, "nodejs_darwin_amd64")

--- a/e2e/js_image_oci/MODULE.bazel
+++ b/e2e/js_image_oci/MODULE.bazel
@@ -7,8 +7,8 @@ local_path_override(
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "container_structure_test", version = "1.16.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "5.8.2", dev_dependency = True)
-bazel_dep(name = "rules_oci", version = "1.7.6", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_oci", version = "2.0.0-alpha2", dev_dependency = True)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(

--- a/e2e/js_image_oci/WORKSPACE
+++ b/e2e/js_image_oci/WORKSPACE
@@ -35,21 +35,18 @@ npm_repositories()
 
 http_archive(
     name = "rules_oci",
-    sha256 = "647f4c6fd092dc7a86a7f79892d4b1b7f1de288bdb4829ca38f74fd430fcd2fe",
-    strip_prefix = "rules_oci-1.7.6",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.6/rules_oci-v1.7.6.tar.gz",
+    sha256 = "e96d70faa4bace3e09fdb1d7d1441b838920f491588889ff9a7e2615afca5799",
+    strip_prefix = "rules_oci-2.0.0-alpha2",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.0.0-alpha2/rules_oci-v2.0.0-alpha2.tar.gz",
 )
 
 load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 
 rules_oci_dependencies()
 
-load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
+load("@rules_oci//oci:repositories.bzl", "oci_register_toolchains")
 
-oci_register_toolchains(
-    name = "oci",
-    crane_version = LATEST_CRANE_VERSION,
-)
+oci_register_toolchains(name = "oci")
 
 ## Pull base images
 load("@rules_oci//oci:pull.bzl", "oci_pull")

--- a/e2e/pnpm_lockfiles/MODULE.bazel
+++ b/e2e/pnpm_lockfiles/MODULE.bazel
@@ -24,7 +24,7 @@ PNPM_LOCK_TEST_CASES = [
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
 
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/e2e/pnpm_repo_install/MODULE.bazel
+++ b/e2e/pnpm_repo_install/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_nodejs", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
 
 node = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -6,7 +6,7 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
 
 node = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/e2e/pnpm_workspace_rerooted/MODULE.bazel
+++ b/e2e/pnpm_workspace_rerooted/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_nodejs", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
 
 node = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/e2e/vendored_node/MODULE.bazel
+++ b/e2e/vendored_node/MODULE.bazel
@@ -5,6 +5,6 @@ local_path_override(
 )
 
 bazel_dep(name = "platforms", version = "0.0.9", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
 
 register_toolchains("//toolchains:all")

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -6,7 +6,7 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
 
 node = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -16,9 +16,9 @@ def rules_js_dependencies():
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "dddd60acc3f2f30359bef502c9d788f67e33814b0ddd99aa27c5a15eb7a41b8c",
-        strip_prefix = "rules_nodejs-6.1.0",
-        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.0/rules_nodejs-v6.1.0.tar.gz",
+        sha256 = "b6016a89a12a3d339ece93f2b3988f5e812f452ad497bc963634646ff4aa100b",
+        strip_prefix = "rules_nodejs-6.1.2",
+        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.2/rules_nodejs-v6.1.2.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_js/issues/1530 by bringing in the rules_nodejs fix https://github.com/bazelbuild/rules_nodejs/pull/3750 which was released with rules_nodejs [v6.1.2](https://github.com/bazelbuild/rules_nodejs/releases/tag/v6.1.2).

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Minimum Aspect bazel-lib version is now 6.1.2

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:

On darwin, where the issue #1530 occurs, ran `bazel test //src:image_test` and confirmed it currently fails on `main` and passes with this fix.

Without fix:

```
--- FAIL
duration: 180.569083ms
stderr: /app/src/bin.runfiles/_main/src/bin_node_bin/node: line 5: /app/src/bin.runfiles/_main/../rules_nodejs~~node~nodejs_darwin_arm64/bin/nodejs/bin/node: cannot execute binary file: Exec format error
```

With fix test passes.