### PR TITLE
perf: do not put files_runfiles in files + transitive_files

### DIFF
--- a/js/private/js_helpers.bzl
+++ b/js/private/js_helpers.bzl
@@ -204,9 +204,6 @@ def gather_runfiles(
         else:
             files_runfiles.append(d)
 
-    if len(files_runfiles) > 0:
-        transitive_files_depsets.append(depset(files_runfiles))
-
     # Merge the above with the transitive runfiles of data & deps.
     return ctx.runfiles(
         files = files_runfiles,


### PR DESCRIPTION
This shouldn't be needed in both `runfiles(files)` + `runfiles(transitive_files)`

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
