### PR TITLE
perf: avoid js_info param validation on default values

### DIFF
--- a/js/private/js_info.bzl
+++ b/js/private/js_info.bzl
@@ -15,9 +15,9 @@ JsInfo = provider(
 
 def js_info(
         target,
-        sources = depset(),
+        sources = None,
         types = None,
-        transitive_sources = depset(),
+        transitive_sources = None,
         transitive_types = None,
         npm_sources = None,
         npm_package_store_infos = None,
@@ -87,34 +87,44 @@ WARNING: js_info 'transitive_npm_linked_package_files' is deprecated. Use 'npm_s
         fail(msg)
 
     # Default to depset()
-    if types == None:
-        types = depset()
-    if transitive_types == None:
-        transitive_types = depset()
-    if npm_sources == None:
-        npm_sources = depset()
-    if npm_package_store_infos == None:
-        npm_package_store_infos = depset()
 
     if type(target) != "Label":
         msg = "Expected target to be a Label but got {}".format(type(target))
         fail(msg)
-    if type(sources) != "depset":
+
+    if sources == None:
+        sources = depset()
+    elif type(sources) != "depset":
         msg = "Expected sources to be a depset but got {}".format(type(sources))
         fail(msg)
-    if type(types) != "depset":
+
+    if types == None:
+        types = depset()
+    elif type(types) != "depset":
         msg = "Expected types to be a depset but got {}".format(type(types))
         fail(msg)
-    if type(transitive_sources) != "depset":
+
+    if transitive_sources == None:
+        transitive_sources = depset()
+    elif type(transitive_sources) != "depset":
         msg = "Expected transitive_sources to be a depset but got {}".format(type(transitive_sources))
         fail(msg)
-    if type(transitive_types) != "depset":
+
+    if transitive_types == None:
+        transitive_types = depset()
+    elif type(transitive_types) != "depset":
         msg = "Expected transitive_types to be a depset but got {}".format(type(transitive_types))
         fail(msg)
-    if type(npm_sources) != "depset":
+
+    if npm_sources == None:
+        npm_sources = depset()
+    elif type(npm_sources) != "depset":
         msg = "Expected npm_sources to be a depset but got {}".format(type(npm_sources))
         fail(msg)
-    if type(npm_package_store_infos) != "depset":
+
+    if npm_package_store_infos == None:
+        npm_package_store_infos = depset()
+    elif type(npm_package_store_infos) != "depset":
         msg = "Expected npm_package_store_infos to be a depset but got {}".format(type(npm_package_store_infos))
         fail(msg)
 


### PR DESCRIPTION
If we're using default params then there's no reason to do `type(p)` to validate them.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
