### PR TITLE
perf: do not check JsInfo hasattr for always-set attributes

### DIFF
--- a/js/private/js_helpers.bzl
+++ b/js/private/js_helpers.bzl
@@ -19,7 +19,7 @@ def gather_transitive_sources(sources, targets):
     transitive = [
         target[JsInfo].transitive_sources
         for target in targets
-        if JsInfo in target and hasattr(target[JsInfo], "transitive_sources")
+        if JsInfo in target
     ]
     return depset([], transitive = [sources] + transitive)
 
@@ -38,7 +38,7 @@ def gather_transitive_types(types, targets):
     transitive = [
         target[JsInfo].transitive_types
         for target in targets
-        if JsInfo in target and hasattr(target[JsInfo], "transitive_types")
+        if JsInfo in target
     ]
     return depset([], transitive = [types] + transitive)
 
@@ -56,7 +56,7 @@ def gather_npm_sources(srcs, deps):
     return depset([], transitive = [
         target[JsInfo].npm_sources
         for target in srcs + deps
-        if JsInfo in target and hasattr(target[JsInfo], "npm_sources")
+        if JsInfo in target
     ])
 
 def gather_npm_package_store_infos(targets):
@@ -275,15 +275,15 @@ def gather_files_from_js_infos(
     for target in targets:
         if JsInfo in target:
             js_info = target[JsInfo]
-            if include_sources and hasattr(js_info, "sources"):
+            if include_sources:
                 files_depsets.append(js_info.sources)
-            if include_types and hasattr(js_info, "types"):
+            if include_types:
                 files_depsets.append(js_info.types)
-            if include_transitive_sources and hasattr(js_info, "transitive_sources"):
+            if include_transitive_sources:
                 files_depsets.append(js_info.transitive_sources)
-            if include_transitive_types and hasattr(js_info, "transitive_types"):
+            if include_transitive_types:
                 files_depsets.append(js_info.transitive_types)
-            if include_npm_sources and hasattr(js_info, "npm_sources"):
+            if include_npm_sources:
                 files_depsets.append(js_info.npm_sources)
 
     return depset([], transitive = files_depsets)

--- a/js/private/js_library.bzl
+++ b/js/private/js_library.bzl
@@ -179,14 +179,14 @@ def _gather_sources_and_types(ctx, targets, files):
     sources = depset(sources, transitive = [
         target[JsInfo].sources
         for target in targets
-        if JsInfo in target and hasattr(target[JsInfo], "sources")
+        if JsInfo in target
     ])
 
     # types as depset
     types = depset(types, transitive = [
         target[JsInfo].types
         for target in targets
-        if JsInfo in target and hasattr(target[JsInfo], "types")
+        if JsInfo in target
     ])
 
     return (sources, types)

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -73,7 +73,7 @@ def _npm_package_impl(ctx):
     npm_package_store_infos = [
         target[JsInfo].npm_package_store_infos
         for target in ctx.attr.srcs
-        if JsInfo in target and hasattr(target[JsInfo], "npm_package_store_infos")
+        if JsInfo in target
     ]
     npm_package_store_infos.append(js_lib_helpers.gather_npm_package_store_infos(
         targets = ctx.attr.data,


### PR DESCRIPTION
If we state that all these attributes are "required" on `JsInfo` and we enforce that in the `js_info` factory then we can avoid checking if the attributes are present everywhere we access them.

See alternative: https://github.com/aspect-build/rules_js/pull/1791

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
