### PR TITLE
chore: fixup pattern for try-import of user.bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,11 +18,13 @@ build --incompatible_enable_cc_toolchain_resolution
 # Mock versioning command to test the --stamp behavior
 build --workspace_status_command="echo BUILD_SCM_VERSION 1.2.3"
 
-# Load any settings specific to the current user.
-# .bazelrc.user should appear in .gitignore so that settings are not shared with team members
-# This needs to be last statement in this
-# config, as the user configuration should be able to overwrite flags from this file.
-# See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
-# (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
-# rather than user.bazelrc as suggested in the Bazel docs)
-try-import %workspace%/.bazelrc.user
+# Don’t want to push a rules author to update their deps if not needed.
+# https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies
+# https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
+common --check_direct_dependencies=off
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/.aspect/bazelrc/user.bazelrc


### PR DESCRIPTION
```
try-import %workspace%/.aspect/bazelrc/user.bazelrc
```

is the established pattern for our rule sets where we have the bazel-lib presets in place

__plus__

Don’t want to push a rules author to update their deps if not needed.

https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies

https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0

Setting this flag in our the rule sets we maintain.