### PR TITLE
perf: persist None instead of empty depsets in JsInfo

### DIFF
--- a/js/private/js_helpers.bzl
+++ b/js/private/js_helpers.bzl
@@ -19,7 +19,7 @@ def gather_transitive_sources(sources, targets):
     transitive = [
         target[JsInfo].transitive_sources
         for target in targets
-        if JsInfo in target and hasattr(target[JsInfo], "transitive_sources")
+        if JsInfo in target and target[JsInfo].transitive_sources != None
     ]
     return depset([], transitive = [sources] + transitive)
 
@@ -38,7 +38,7 @@ def gather_transitive_types(types, targets):
     transitive = [
         target[JsInfo].transitive_types
         for target in targets
-        if JsInfo in target and hasattr(target[JsInfo], "transitive_types")
+        if JsInfo in target and target[JsInfo].transitive_types != None
     ]
     return depset([], transitive = [types] + transitive)
 
@@ -56,7 +56,7 @@ def gather_npm_sources(srcs, deps):
     return depset([], transitive = [
         target[JsInfo].npm_sources
         for target in srcs + deps
-        if JsInfo in target and hasattr(target[JsInfo], "npm_sources")
+        if JsInfo in target and target[JsInfo].npm_sources != None
     ])
 
 def gather_npm_package_store_infos(targets):
@@ -73,7 +73,7 @@ def gather_npm_package_store_infos(targets):
     npm_package_store_infos = [
         target[JsInfo].npm_package_store_infos
         for target in targets
-        if JsInfo in target
+        if JsInfo in target and target[JsInfo].npm_package_store_infos
     ]
 
     return depset([], transitive = npm_package_store_infos)
@@ -275,15 +275,15 @@ def gather_files_from_js_infos(
     for target in targets:
         if JsInfo in target:
             js_info = target[JsInfo]
-            if include_sources and hasattr(js_info, "sources"):
+            if include_sources and js_info.sources != None:
                 files_depsets.append(js_info.sources)
-            if include_types and hasattr(js_info, "types"):
+            if include_types and js_info.types != None:
                 files_depsets.append(js_info.types)
-            if include_transitive_sources and hasattr(js_info, "transitive_sources"):
+            if include_transitive_sources and js_info.transitive_sources != None:
                 files_depsets.append(js_info.transitive_sources)
-            if include_transitive_types and hasattr(js_info, "transitive_types"):
+            if include_transitive_types and js_info.transitive_types != None:
                 files_depsets.append(js_info.transitive_types)
-            if include_npm_sources and hasattr(js_info, "npm_sources"):
+            if include_npm_sources and js_info.npm_sources != None:
                 files_depsets.append(js_info.npm_sources)
 
     return depset([], transitive = files_depsets)

--- a/js/private/js_info.bzl
+++ b/js/private/js_info.bzl
@@ -92,39 +92,27 @@ WARNING: js_info 'transitive_npm_linked_package_files' is deprecated. Use 'npm_s
         msg = "Expected target to be a Label but got {}".format(type(target))
         fail(msg)
 
-    if sources == None:
-        sources = depset()
-    elif type(sources) != "depset":
+    if sources != None and type(sources) != "depset":
         msg = "Expected sources to be a depset but got {}".format(type(sources))
         fail(msg)
 
-    if types == None:
-        types = depset()
-    elif type(types) != "depset":
+    if types != None and type(types) != "depset":
         msg = "Expected types to be a depset but got {}".format(type(types))
         fail(msg)
 
-    if transitive_sources == None:
-        transitive_sources = depset()
-    elif type(transitive_sources) != "depset":
+    if transitive_sources != None and type(transitive_sources) != "depset":
         msg = "Expected transitive_sources to be a depset but got {}".format(type(transitive_sources))
         fail(msg)
 
-    if transitive_types == None:
-        transitive_types = depset()
-    elif type(transitive_types) != "depset":
+    if transitive_types != None and type(transitive_types) != "depset":
         msg = "Expected transitive_types to be a depset but got {}".format(type(transitive_types))
         fail(msg)
 
-    if npm_sources == None:
-        npm_sources = depset()
-    elif type(npm_sources) != "depset":
+    if npm_sources != None and type(npm_sources) != "depset":
         msg = "Expected npm_sources to be a depset but got {}".format(type(npm_sources))
         fail(msg)
 
-    if npm_package_store_infos == None:
-        npm_package_store_infos = depset()
-    elif type(npm_package_store_infos) != "depset":
+    if npm_package_store_infos != None and type(npm_package_store_infos) != "depset":
         msg = "Expected npm_package_store_infos to be a depset but got {}".format(type(npm_package_store_infos))
         fail(msg)
 

--- a/js/private/js_library.bzl
+++ b/js/private/js_library.bzl
@@ -179,14 +179,14 @@ def _gather_sources_and_types(ctx, targets, files):
     sources = depset(sources, transitive = [
         target[JsInfo].sources
         for target in targets
-        if JsInfo in target and hasattr(target[JsInfo], "sources")
+        if JsInfo in target and target[JsInfo].sources != None
     ])
 
     # types as depset
     types = depset(types, transitive = [
         target[JsInfo].types
         for target in targets
-        if JsInfo in target and hasattr(target[JsInfo], "types")
+        if JsInfo in target and target[JsInfo].types != None
     ])
 
     return (sources, types)

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -108,7 +108,7 @@ def _npm_link_package_store_impl(ctx):
             target = ctx.label,
             npm_sources = transitive_files_depset,
             # only propagate non-dev npm dependencies to use as direct dependencies when linking downstream npm_package targets with npm_link_package
-            npm_package_store_infos = depset([store_info]) if not store_info.dev else depset(),
+            npm_package_store_infos = depset([store_info]) if not store_info.dev else None,
         ),
     ]
     if OutputGroupInfo in ctx.attr.src:

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -73,7 +73,7 @@ def _npm_package_impl(ctx):
     npm_package_store_infos = [
         target[JsInfo].npm_package_store_infos
         for target in ctx.attr.srcs
-        if JsInfo in target and hasattr(target[JsInfo], "npm_package_store_infos")
+        if JsInfo in target and target[JsInfo].npm_package_store_infos != None
     ]
     npm_package_store_infos.append(js_lib_helpers.gather_npm_package_store_infos(
         targets = ctx.attr.data,

--- a/npm/private/npm_package_internal.bzl
+++ b/npm/private/npm_package_internal.bzl
@@ -33,7 +33,7 @@ def _npm_package_internal_impl(ctx):
             package = ctx.attr.package,
             version = ctx.attr.version,
             src = dst,
-            npm_package_store_infos = depset(),
+            npm_package_store_infos = None,
         ),
     ]
 

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -265,17 +265,19 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
                 # party npm deps; it is not used for 1st party deps
                 direct_ref_deps[dep] = dep_aliases
 
-        for store in ctx.attr.src[NpmPackageInfo].npm_package_store_infos.to_list():
-            dep_package = store.package
-            dep_package_store_directory = store.package_store_directory
+        src_npm_package_store_infos = ctx.attr.src[NpmPackageInfo].npm_package_store_infos
+        if src_npm_package_store_infos != None:
+            for store in src_npm_package_store_infos.to_list():
+                dep_package = store.package
+                dep_package_store_directory = store.package_store_directory
 
-            # only link npm package store deps from NpmPackageInfo if they have _not_ already been linked directly
-            # from deps; fixes https://github.com/aspect-build/rules_js/issues/1110.
-            if dep_package_store_directory not in linked_package_store_directories:
-                # "node_modules/{package_store_root}/{package_store_name}/node_modules/{package}"
-                dep_symlink_path = "node_modules/{}/{}/node_modules/{}".format(utils.package_store_root, package_store_name, dep_package)
-                files.append(utils.make_symlink(ctx, dep_symlink_path, dep_package_store_directory.path))
-                npm_package_store_infos.append(store)
+                # only link npm package store deps from NpmPackageInfo if they have _not_ already been linked directly
+                # from deps; fixes https://github.com/aspect-build/rules_js/issues/1110.
+                if dep_package_store_directory not in linked_package_store_directories:
+                    # "node_modules/{package_store_root}/{package_store_name}/node_modules/{package}"
+                    dep_symlink_path = "node_modules/{}/{}/node_modules/{}".format(utils.package_store_root, package_store_name, dep_package)
+                    files.append(utils.make_symlink(ctx, dep_symlink_path, dep_package_store_directory.path))
+                    npm_package_store_infos.append(store)
     elif ctx.attr.src and JsInfo in ctx.attr.src:
         jsinfo = ctx.attr.src[JsInfo]
 


### PR DESCRIPTION
This way when we collect transitive depsets of these it will be a significantly smaller tree in some cases. Smaller, but only because empty `depset`s are not there. Do empty depsets make any difference?

Alternative to https://github.com/aspect-build/rules_js/pull/1786

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
