### PR TITLE
chore: bump minimum rules_nodejs to 6.2.0

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -33,7 +33,7 @@ bazel_dep(name = "aspect_rules_js", version = "${TAG:1}")
 ####### Node.js version #########
 # By default you get the node version from DEFAULT_NODE_VERSION in @rules_nodejs//nodejs:repositories.bzl
 # Optionally you can pin a different node version:
-bazel_dep(name = "rules_nodejs", version = "6.1.2")
+bazel_dep(name = "rules_nodejs", version = "6.2.0")
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 node.toolchain(node_version = "16.14.2")
 #################################

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")
-bazel_dep(name = "rules_nodejs", version = "6.1.2")
+bazel_dep(name = "rules_nodejs", version = "6.2.0")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 use_repo(node, "nodejs_darwin_amd64")

--- a/e2e/js_image_oci/MODULE.bazel
+++ b/e2e/js_image_oci/MODULE.bazel
@@ -7,7 +7,7 @@ local_path_override(
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "container_structure_test", version = "1.16.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
 bazel_dep(name = "rules_oci", version = "2.0.0-alpha2", dev_dependency = True)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)

--- a/e2e/pnpm_lockfiles/MODULE.bazel
+++ b/e2e/pnpm_lockfiles/MODULE.bazel
@@ -24,7 +24,7 @@ PNPM_LOCK_TEST_CASES = [
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
 
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/e2e/pnpm_repo_install/MODULE.bazel
+++ b/e2e/pnpm_repo_install/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
 
 node = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/e2e/pnpm_workspace/MODULE.bazel
+++ b/e2e/pnpm_workspace/MODULE.bazel
@@ -6,7 +6,7 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
 
 node = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/e2e/pnpm_workspace_rerooted/MODULE.bazel
+++ b/e2e/pnpm_workspace_rerooted/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
 
 node = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/e2e/vendored_node/MODULE.bazel
+++ b/e2e/vendored_node/MODULE.bazel
@@ -5,6 +5,6 @@ local_path_override(
 )
 
 bazel_dep(name = "platforms", version = "0.0.9", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
 
 register_toolchains("//toolchains:all")

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -6,7 +6,7 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
 
 node = use_extension(
     "@rules_nodejs//nodejs:extensions.bzl",

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -16,9 +16,9 @@ def rules_js_dependencies():
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "b6016a89a12a3d339ece93f2b3988f5e812f452ad497bc963634646ff4aa100b",
-        strip_prefix = "rules_nodejs-6.1.2",
-        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.2/rules_nodejs-v6.1.2.tar.gz",
+        sha256 = "87c6171c5be7b69538d4695d9ded29ae2626c5ed76a9adeedce37b63c73bef67",
+        strip_prefix = "rules_nodejs-6.2.0",
+        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Ensures users pick up https://github.com/bazelbuild/rules_nodejs/pull/3760 fix which is a footgun that should be avoided.