### PR TITLE
refactor: sort lock translation action cache content

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,26 +2,26 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "@@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2065072158
-pnpm-lock.yaml=-1309835144
-examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch=-442666336
-package.json=-275319675
-pnpm-workspace.yaml=-1178830835
 examples/js_binary/package.json=-41174383
 examples/linked_empty_node_modules/package.json=-1039372825
 examples/macro/package.json=857146175
 examples/npm_deps/package.json=-1377141392
+examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch=-442666336
 examples/npm_package/libs/lib_a/package.json=-1377103079
 examples/npm_package/packages/pkg_a/package.json=1006424040
 examples/npm_package/packages/pkg_b/package.json=1041247977
+examples/npm_package/packages/pkg_d/package.json=1110895851
 examples/webpack_cli/package.json=1911342006
 js/private/coverage/bundle/package.json=-1543718929
 js/private/image/package.json=-1260474848
 js/private/test/image/package.json=-687546763
 js/private/test/js_run_devserver/package.json=-260856079
 js/private/worker/src/package.json=1608383745
-npm/private/test/package.json=600650131
-npm/private/test/vendored/lodash-4.17.21.tgz=-1206623349
 npm/private/test/npm_package/package.json=-1991705133
+npm/private/test/package.json=600650131
 npm/private/test/vendored/is-odd/package.json=1041695223
+npm/private/test/vendored/lodash-4.17.21.tgz=-1206623349
 npm/private/test/vendored/semver-max/package.json=578664053
-examples/npm_package/packages/pkg_d/package.json=1110895851
+package.json=-275319675
+pnpm-lock.yaml=-1309835144
+pnpm-workspace.yaml=-1178830835

--- a/e2e/gyp_no_install_script/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/gyp_no_install_script/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,5 +1,6 @@
+# @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-pnpm-lock.yaml=-1826220926
 package.json=848163255
+pnpm-lock.yaml=-1826220926

--- a/e2e/npm_translate_lock/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/npm_translate_lock/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,5 +1,6 @@
+# @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2033575378
-pnpm-lock.yaml=1358762538
 package.json=745661930
+pnpm-lock.yaml=1358762538

--- a/e2e/npm_translate_lock_auth/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/npm_translate_lock_auth/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,5 +1,6 @@
+# @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=490827635
-pnpm-lock.yaml=-995168758
 package.json=-1644858971
+pnpm-lock.yaml=-995168758

--- a/e2e/npm_translate_lock_empty/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/npm_translate_lock_empty/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,5 +1,6 @@
+# @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=0
-pnpm-lock.yaml=-2084333585
 package.json=-1109566459
+pnpm-lock.yaml=-2084333585

--- a/e2e/npm_translate_lock_git+ssh/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/npm_translate_lock_git+ssh/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,5 +2,5 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-pnpm-lock.yaml=-43506523
 package.json=-1742353198
+pnpm-lock.yaml=-43506523

--- a/e2e/npm_translate_package_lock/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/npm_translate_package_lock/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-pnpm-lock.yaml=-178127055
 package-lock.json=-481311766
-transform_package_json.js=1969027032
 package.json=2104879777
+pnpm-lock.yaml=-178127055
+transform_package_json.js=1969027032

--- a/e2e/npm_translate_yarn_lock/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/npm_translate_yarn_lock/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-pnpm-lock.yaml=-955788740
-yarn.lock=181112961
-transform_package_json.js=-487875007
 package.json=805760788
+pnpm-lock.yaml=-955788740
+transform_package_json.js=-487875007
+yarn.lock=181112961

--- a/e2e/pnpm_workspace/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/pnpm_workspace/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,14 +2,14 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-pnpm-lock.yaml=1498964476
-package.json=-716078204
-pnpm-workspace.yaml=-67685769
 app/a/package.json=574382986
 app/b/package.json=795450875
 app/c/package.json=1357235418
 lib/a/package.json=1162557353
 lib/b/package.json=1400635148
 lib/c/package.json=1015268365
+package.json=-716078204
+pnpm-lock.yaml=1498964476
+pnpm-workspace.yaml=-67685769
 vendored/a/package.json=-174142441
 vendored/b/package.json=536664170

--- a/e2e/pnpm_workspace_deps/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/pnpm_workspace_deps/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,9 +2,9 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-pnpm-lock.yaml=493967008
-package.json=959251505
-pnpm-workspace.yaml=-2026278039
-lib/package.json=-275126300
 lib-dupes/package.json=-1457142261
+lib/package.json=-275126300
+package.json=959251505
+pnpm-lock.yaml=493967008
+pnpm-workspace.yaml=-2026278039
 tests/package.json=-1421585247

--- a/e2e/pnpm_workspace_rerooted/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE1MzU4OTk=
+++ b/e2e/pnpm_workspace_rerooted/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE1MzU4OTk=
@@ -2,13 +2,13 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//root:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-root/pnpm-lock.yaml=1614347268
-package.json=282559383
 app/a/package.json=1612579590
 app/b/package.json=-339939821
 app/c/package.json=-700457890
 lib/a/package.json=-671330085
 lib/b/package.json=1400635148
 lib/c/package.json=1015268365
+package.json=282559383
+root/pnpm-lock.yaml=1614347268
 root/pnpm-workspace.yaml=1861018878
 vendored/a/package.json=-174142441

--- a/e2e/pnpm_workspace_rerooted/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzAwMTUzNTg5OQ==
+++ b/e2e/pnpm_workspace_rerooted/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzAwMTUzNTg5OQ==
@@ -1,6 +1,6 @@
+# @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "@//root:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
-root/pnpm-lock.yaml=908786604
 app/a/package.json=1612579590
 app/b/package.json=3339939821
 app/c/package.json=3700457890
@@ -8,5 +8,6 @@ lib/a/package.json=3671330085
 lib/b/package.json=1400635148
 lib/c/package.json=1015268365
 root/package.json=3418505195
+root/pnpm-lock.yaml=908786604
 root/pnpm-workspace.yaml=905087073
 vendored/a/package.json=3174142441

--- a/e2e/update_pnpm_lock_with_import/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/update_pnpm_lock_with_import/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,8 +1,9 @@
+# @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-pnpm-lock.yaml=-650998153
-yarn.lock=-220129002
 package.json=772510069
+pnpm-lock.yaml=-650998153
 pnpm-workspace.yaml=-79388955
 workspace_package/package.json=-643240351
+yarn.lock=-220129002

--- a/e2e/verify_patches/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/verify_patches/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,6 +1,7 @@
+# @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=664934919
-pnpm-lock.yaml=1942329872
 package.json=-480432219
+pnpm-lock.yaml=1942329872
 pnpm-workspace.yaml=1764181114

--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -384,16 +384,21 @@ def _action_cache_miss(priv, rctx, label_store):
 
 ################################################################################
 def _write_action_cache(priv, rctx, label_store):
-    contents = [
-        "# @generated",
-        "# Input hashes for repository rule npm_translate_lock(name = \"{}\", pnpm_lock = \"{}\").".format(helpers.to_apparent_repo_name(priv["rctx_name"]), str(label_store.label("pnpm_lock"))),
-        "# This file should be checked into version control along with the pnpm-lock.yaml file.",
-    ]
+    header = """# @generated
+# Input hashes for repository rule npm_translate_lock(name = \"{}\", pnpm_lock = \"{}\").
+# This file should be checked into version control along with the pnpm-lock.yaml file.
+""".format(helpers.to_apparent_repo_name(priv["rctx_name"]), str(label_store.label("pnpm_lock")))
+
+    contents = []
     for key, value in priv["input_hashes"].items():
         contents.append("{}={}".format(key, value))
+
+    # Sort to reduce diffs when the file is updated
+    contents = sorted(contents)
+
     rctx.file(
         label_store.repository_path("action_cache"),
-        "\n".join(contents) + "\n",
+        header + "\n".join(contents) + "\n",
     )
     utils.reverse_force_copy(
         rctx,


### PR DESCRIPTION
`dict.items` has no guaranteed order, even if it did I assume the items are added in a non-guaranteed order.

This sorts the elements to ensure the order listed in the action cache is consistent which will minimize diffs when updated.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
