### PR TITLE
perf: minimize cost of checking bazel version

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -25,6 +25,7 @@ Advanced users may want to directly fetch a package from npm rather than start f
 [`npm_import`](./npm_import) does this.
 """
 
+load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":list_sources.bzl", "list_sources")
@@ -504,6 +505,9 @@ def npm_translate_lock(
 
         **kwargs: Internal use only
     """
+    if not bazel_lib_utils.is_bazel_6_or_greater():
+        # ctx.actions.declare_symlink was added in Bazel 6
+        fail("A minimum version of Bazel 6 required to use rules_js")
 
     # Gather undocumented attributes
     root_package = kwargs.pop("root_package", None)

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -2,7 +2,6 @@
 
 load("@aspect_bazel_lib//lib:paths.bzl", "relative_file")
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
-load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 INTERNAL_ERROR_MSG = "ERROR: rules_js internal error, please file an issue: https://github.com/aspect-build/rules_js/issues"
@@ -72,9 +71,6 @@ def _package_store_name(pnpm_name, pnpm_version):
         return "%s@%s" % (escaped_name, escaped_version)
 
 def _make_symlink(ctx, symlink_path, target_path):
-    if not bazel_lib_utils.is_bazel_6_or_greater():
-        # ctx.actions.declare_symlink was added in Bazel 6
-        fail("A minimum version of Bazel 6 required to use rules_js")
     symlink = ctx.actions.declare_symlink(symlink_path)
     ctx.actions.symlink(
         output = symlink,


### PR DESCRIPTION
This saves around .5s analysis time in our repo, extracted from https://github.com/aspect-build/rules_js/pull/1797

### Changes are visible to end-users: no

### Test plan
- Covered by existing test cases