### PR TITLE
perf: do not double process lifecycle_hooks* attributes in bzlmod

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -3,10 +3,11 @@ See https://bazel.build/docs/bzlmod#extension-definition
 """
 
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
+load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@bazel_features//:features.bzl", "bazel_features")
 load("//npm:repositories.bzl", "npm_import", "pnpm_repository", _DEFAULT_PNPM_VERSION = "DEFAULT_PNPM_VERSION", _LATEST_PNPM_VERSION = "LATEST_PNPM_VERSION")
 load("//npm/private:npm_import.bzl", "npm_import_lib", "npm_import_links_lib")
-load("//npm/private:npm_translate_lock.bzl", "npm_translate_lock", "npm_translate_lock_lib")
+load("//npm/private:npm_translate_lock.bzl", "npm_translate_lock_lib", "npm_translate_lock_rule")
 load("//npm/private:npm_translate_lock_helpers.bzl", npm_translate_lock_helpers = "helpers")
 load("//npm/private:npm_translate_lock_macro_helpers.bzl", macro_helpers = "helpers")
 load("//npm/private:npm_translate_lock_state.bzl", "npm_translate_lock_state")
@@ -20,6 +21,10 @@ LATEST_PNPM_VERSION = _LATEST_PNPM_VERSION
 _DEFAULT_PNPM_REPO_NAME = "pnpm"
 
 def _npm_extension_impl(module_ctx):
+    if not bazel_lib_utils.is_bazel_6_or_greater():
+        # ctx.actions.declare_symlink was added in Bazel 6
+        fail("A minimum version of Bazel 6 required to use rules_js")
+
     for mod in module_ctx.modules:
         for attr in mod.tags.npm_translate_lock:
             _npm_translate_lock_bzlmod(attr)
@@ -39,7 +44,7 @@ def _npm_extension_impl(module_ctx):
     return module_ctx.extension_metadata()
 
 def _npm_translate_lock_bzlmod(attr):
-    npm_translate_lock(
+    npm_translate_lock_rule(
         name = attr.name,
         bins = attr.bins,
         custom_postinstalls = attr.custom_postinstalls,
@@ -47,12 +52,6 @@ def _npm_translate_lock_bzlmod(attr):
         dev = attr.dev,
         external_repository_action_cache = attr.external_repository_action_cache,
         generate_bzl_library_targets = attr.generate_bzl_library_targets,
-        lifecycle_hooks = attr.lifecycle_hooks,
-        lifecycle_hooks_envs = attr.lifecycle_hooks_envs,
-        lifecycle_hooks_execution_requirements = attr.lifecycle_hooks_execution_requirements,
-        lifecycle_hooks_exclude = attr.lifecycle_hooks_exclude,
-        lifecycle_hooks_no_sandbox = attr.lifecycle_hooks_no_sandbox,
-        lifecycle_hooks_use_default_shell_env = attr.lifecycle_hooks_use_default_shell_env,
         link_workspace = attr.link_workspace,
         no_optional = attr.no_optional,
         npmrc = attr.npmrc,
@@ -69,7 +68,6 @@ def _npm_translate_lock_bzlmod(attr):
         quiet = attr.quiet,
         replace_packages = attr.replace_packages,
         root_package = attr.root_package,
-        run_lifecycle_hooks = attr.run_lifecycle_hooks,
         update_pnpm_lock = attr.update_pnpm_lock,
         use_home_npmrc = attr.use_home_npmrc,
         verify_node_modules_ignored = attr.verify_node_modules_ignored,

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -515,13 +515,12 @@ def npm_translate_lock(
     repositories_bzl_filename = kwargs.pop("repositories_bzl_filename", None)
     defs_bzl_filename = kwargs.pop("defs_bzl_filename", None)
     generate_bzl_library_targets = kwargs.pop("generate_bzl_library_targets", None)
-    bzlmod = kwargs.pop("bzlmod", False)
 
     if len(kwargs):
         msg = "Invalid npm_translate_lock parameter '{}'".format(kwargs.keys()[0])
         fail(msg)
 
-    if not bzlmod and pnpm_version != None:
+    if pnpm_version != None:
         _pnpm_repository(name = "pnpm", pnpm_version = pnpm_version)
 
     if yarn_lock:
@@ -599,7 +598,7 @@ def npm_translate_lock(
         use_pnpm = use_pnpm,
         yq_toolchain_prefix = yq_toolchain_prefix,
         npm_package_target_name = npm_package_target_name,
-        bzlmod = bzlmod,
+        bzlmod = False,
     )
 
 def list_patches(name, out = None, include_patterns = ["*.diff", "*.patch"], exclude_patterns = []):

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -455,7 +455,7 @@ ERROR: can not apply both `pnpm.patchedDependencies` and `npm_translate_lock(pat
             lifecycle_hooks = lifecycle_hooks,
             lifecycle_hooks_env = lifecycle_hooks_env,
             lifecycle_hooks_execution_requirements = lifecycle_hooks_execution_requirements,
-            lifecycle_hooks_use_default_shell_env = lifecycle_hooks_use_default_shell_env[0] == "true" if lifecycle_hooks else False,
+            lifecycle_hooks_use_default_shell_env = lifecycle_hooks_use_default_shell_env and lifecycle_hooks_use_default_shell_env[0] == "true",
             npm_auth = npm_auth_bearer,
             npm_auth_basic = npm_auth_basic,
             npm_auth_username = npm_auth_username,


### PR DESCRIPTION
These are processed differently in bzlmod in extensions.bzl where the bzlmod invocation of `npm_import` is done.

See what is no longer unnecessarily duplicated in bzlmod: https://github.com/aspect-build/rules_js/blob/b6e94d3d1b09c34cbdb70e1515f1a147b3b0fa9a/npm/private/npm_translate_lock.bzl#L512-L562

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
