### PR TITLE
perf: reduce use of bazel_skylib paths.join

### DIFF
--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -1,6 +1,5 @@
 "npm_link_package_store rule"
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//js:providers.bzl", "JsInfo", "js_info")
 load(":npm_package_store_info.bzl", "NpmPackageStoreInfo")
 load(":utils.bzl", "utils")
@@ -84,7 +83,7 @@ def _npm_link_package_store_impl(ctx):
 
     for bin_name, bin_path in ctx.attr.bins.items():
         bin_file = ctx.actions.declare_file("node_modules/.bin/{}".format(bin_name))
-        bin_path = paths.normalize("../{}/{}".format(package, bin_path))
+        bin_path = "../{}/{}".format(package, bin_path)
         ctx.actions.write(
             bin_file,
             _BIN_TMPL.format(bin_path = bin_path),

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -78,13 +78,13 @@ def _npm_link_package_store_impl(ctx):
 
     # symlink the package's path in the package store to the root of the node_modules
     # "node_modules/{package}" so it is available as a direct dependency
-    root_symlink_path = paths.join("node_modules", package)
+    root_symlink_path = "node_modules/{}".format(package)
 
     files = [utils.make_symlink(ctx, root_symlink_path, package_store_directory.path)]
 
     for bin_name, bin_path in ctx.attr.bins.items():
-        bin_file = ctx.actions.declare_file(paths.join("node_modules", ".bin", bin_name))
-        bin_path = paths.normalize(paths.join("..", package, bin_path))
+        bin_file = ctx.actions.declare_file("node_modules/.bin/{}".format(bin_name))
+        bin_path = paths.normalize("../{}/{}".format(package, bin_path))
         ctx.actions.write(
             bin_file,
             _BIN_TMPL.format(bin_path = bin_path),

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -283,10 +283,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                         add_to_scoped_targets = """            scope_targets["{package_scope}"] = scope_targets["{package_scope}"] + [link_targets[-1]] if "{package_scope}" in scope_targets else [link_targets[-1]]""".format(package_scope = package_scope)
                         links_bzl[link_package].append(add_to_scoped_targets)
         for link_package in _import.link_packages.keys():
-            build_file = paths.normalize("{}/{}".format(link_package, "BUILD.bazel") if link_package else "BUILD.bazel")
+            build_file = "{}/{}".format(link_package, "BUILD.bazel") if link_package else "BUILD.bazel"
             if build_file not in rctx_files:
                 rctx_files[build_file] = []
-            resolved_json_file_path = paths.normalize("{}/{}/{}".format(link_package, _import.package, _RESOLVED_JSON_FILENAME).lstrip("/"))
+            resolved_json_file_path = "{}/{}/{}".format(link_package, _import.package, _RESOLVED_JSON_FILENAME).lstrip("/")
             rctx.file(resolved_json_file_path, json.encode({
                 # Allow consumers to auto-detect this filetype
                 "$schema": "https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock",
@@ -306,7 +306,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                             package_name = link_package.split("/")[-1] or _import.package.split("/")[-1],
                         ),
                     ))
-                package_json_bzl_file_path = paths.normalize("{}/{}/{}".format(link_package, _import.package, _PACKAGE_JSON_BZL_FILENAME) if link_package else "{}/{}".format(_import.package, _PACKAGE_JSON_BZL_FILENAME))
+                package_json_bzl_file_path = "{}/{}/{}".format(link_package, _import.package, _PACKAGE_JSON_BZL_FILENAME) if link_package else "{}/{}".format(_import.package, _PACKAGE_JSON_BZL_FILENAME)
                 repo_package_json_bzl = "@@{repo_name}//{link_package}:{package_json_bzl}".format(
                     repo_name = _import.name,
                     link_package = link_package,


### PR DESCRIPTION
In most scenarios we don't need all the logic detecting empty segments or detecting absolute paths in individual parts.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
