### PR TITLE
feat(js_image_layer): Add 'pure' option suitable for distroless image (without bash)

### DIFF
--- a/docs/js_image_layer.md
+++ b/docs/js_image_layer.md
@@ -19,7 +19,7 @@ js_image_layer(
 ## js_image_layer
 
 <pre>
-js_image_layer(<a href="#js_image_layer-name">name</a>, <a href="#js_image_layer-binary">binary</a>, <a href="#js_image_layer-compression">compression</a>, <a href="#js_image_layer-generate_empty_layers">generate_empty_layers</a>, <a href="#js_image_layer-owner">owner</a>, <a href="#js_image_layer-platform">platform</a>, <a href="#js_image_layer-root">root</a>)
+js_image_layer(<a href="#js_image_layer-name">name</a>, <a href="#js_image_layer-binary">binary</a>, <a href="#js_image_layer-compression">compression</a>, <a href="#js_image_layer-generate_empty_layers">generate_empty_layers</a>, <a href="#js_image_layer-owner">owner</a>, <a href="#js_image_layer-platform">platform</a>, <a href="#js_image_layer-pure">pure</a>, <a href="#js_image_layer-root">root</a>)
 </pre>
 
 Create container image layers from js_binary targets.
@@ -272,6 +272,7 @@ container_image(
 | <a id="js_image_layer-generate_empty_layers"></a>generate_empty_layers |  Generate layers even if they are empty.<br><br>Helpful when using js_image_layer with rules_docker. See https://github.com/aspect-build/rules_js/pull/1714 for more info   | Boolean | optional |  `False`  |
 | <a id="js_image_layer-owner"></a>owner |  Owner of the entries, in `GID:UID` format. By default `0:0` (root, root) is used.   | String | optional |  `"0:0"`  |
 | <a id="js_image_layer-platform"></a>platform |  Platform to transition.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="js_image_layer-pure"></a>pure |  Generate layers without Bazel specific sources and NodeJS<br><br>Remove from layers: - NodeJS - NodeJS patches - Bazel wrapper (js_binary) - Runfiles directories<br><br>Required for using in distroless images. See https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md   | Boolean | optional |  `False`  |
 | <a id="js_image_layer-root"></a>root |  Path where the files from js_binary will reside in. eg: /apps/app1 or /app   | String | optional |  `""`  |
 
 

--- a/e2e/js_image_oci/MODULE.bazel
+++ b/e2e/js_image_oci/MODULE.bazel
@@ -35,7 +35,19 @@ oci.pull(
         "linux/s390x",
     ],
 )
-use_repo(oci, "debian")
+oci.pull(
+    name = "distroless_node",
+    digest = "sha256:3cb543d5a3cec9ec76500f597fb9f71b7f2fc85e2845d6537debd387336f97c1",
+    image = "gcr.io/distroless/nodejs18-debian12",
+    platforms = [
+        "linux/amd64",
+        "linux/arm/v7",
+        "linux/arm64/v8",
+        "linux/ppc64le",
+        "linux/s390x",
+    ],
+)
+use_repo(oci, "debian", "distroless_node")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 use_repo(node, "nodejs_toolchains")

--- a/e2e/js_image_oci/WORKSPACE
+++ b/e2e/js_image_oci/WORKSPACE
@@ -67,6 +67,19 @@ oci_pull(
     ],
 )
 
+oci_pull(
+    name = "distroless_node",
+    digest = "sha256:3cb543d5a3cec9ec76500f597fb9f71b7f2fc85e2845d6537debd387336f97c1",
+    image = "gcr.io/distroless/nodejs18-debian12",
+    platforms = [
+        "linux/amd64",
+        "linux/arm/v7",
+        "linux/arm64/v8",
+        "linux/ppc64le",
+        "linux/s390x",
+    ],
+)
+
 ###
 # Setup container_structure_test
 ###

--- a/e2e/js_image_oci/src/BUILD.bazel
+++ b/e2e/js_image_oci/src/BUILD.bazel
@@ -42,6 +42,25 @@ js_binary(
     entry_point = "main.js",
 )
 
+js_binary(
+    name = "bin_pure",
+    args = ["foo"],
+    chdir = package_name(),
+    # skip copying so we can test external source directories
+    copy_data_to_bin = False,
+    data = [
+        "ascii.art",
+        ":proto",
+        "//:node_modules/@mycorp/pkg-a",
+        "//:node_modules/@mycorp/pkg-b",
+        "//:node_modules/chalk",
+        "@repo//:dir",
+        "@repo//:source_txt",
+        "@repo//:sources",
+    ],
+    entry_point = "main-pure.js",
+)
+
 # FIXME: due to bzlmod Node.js toolchain issuehttps://github.com/aspect-build/rules_js/issues/1530,
 # on MacOS, this target must be built with `--extra_toolchains` to select right the linux Node.js
 # toolchain for the image layer:
@@ -53,6 +72,18 @@ js_image_layer(
         "@platforms//cpu:arm64": ":linux_arm64",
         "@platforms//cpu:x86_64": ":linux_amd64",
     }),
+    root = "/app",
+    visibility = ["//visibility:__pkg__"],
+)
+
+js_image_layer(
+    name = "layers_pure",
+    binary = ":bin_pure",
+    platform = select({
+        "@platforms//cpu:arm64": ":linux_arm64",
+        "@platforms//cpu:x86_64": ":linux_amd64",
+    }),
+    pure = True,
     root = "/app",
     visibility = ["//visibility:__pkg__"],
 )
@@ -75,10 +106,31 @@ oci_image(
     }),
 )
 
+oci_image(
+    name = "image_pure",
+    # Pure js_image_layer bring only build result and deps, so we need nodejs in our image
+    base = "@distroless_node",
+    # By default, entrypoint is nodejs
+    cmd = ["src/main-pure.js"],
+    tars = [
+        ":layers_pure",
+    ],
+    visibility = ["//visibility:public"],
+    workdir = "/app",
+)
+
 container_structure_test(
     name = "image_test",
     configs = ["test.yaml"],
     image = ":image",
+    # ./image_test.image: line 214: /usr/bin/docker: No such file or directory
+    tags = ["no-remote-exec"],
+)
+
+container_structure_test(
+    name = "image_pure_test",
+    configs = ["test-pure.yaml"],
+    image = ":image_pure",
     # ./image_test.image: line 214: /usr/bin/docker: No such file or directory
     tags = ["no-remote-exec"],
 )
@@ -92,4 +144,11 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["e2e_js_image_oci:latest"],
+)
+
+# bazel run //src:image_pure_tarball --extra_toolchains=@nodejs_toolchains//:linux_arm64_toolchain_target
+oci_tarball(
+    name = "image_pure_tarball",
+    image = ":image_pure",
+    repo_tags = ["e2e_js_image_oci_pure:latest"],
 )

--- a/e2e/js_image_oci/src/main-pure.js
+++ b/e2e/js_image_oci/src/main-pure.js
@@ -1,0 +1,57 @@
+const chalk = require('chalk')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const space = ' '
+const art = fs.readFileSync(__dirname + '/ascii.art')
+
+console.log(chalk.italic.green(art))
+console.log(
+    chalk.bold.bgRed(' OS '),
+    space,
+    chalk.redBright(process.platform, os.version(), os.arch())
+)
+console.log(
+    chalk.bold.bgMagenta(' CWD '),
+    space,
+    chalk.magentaBright(process.cwd())
+)
+console.log('')
+
+const pkgA = require('@mycorp/pkg-a')
+console.log(`@mycorp/pkg-a acorn@${pkgA.getAcornVersion()}`)
+console.log(`@mycorp/pkg-a uuid@${pkgA.getUuidVersion()}`)
+console.log('')
+
+const pkgB = require('@mycorp/pkg-b')
+console.log(`@mycorp/pkg-b acorn@${pkgB.getAcornVersion()}`)
+console.log(`@mycorp/pkg-b uuid@${pkgB.getUuidVersion()}`)
+console.log('')
+
+console.log(
+    chalk.bold.bgYellow(' SOURCE CHECK '),
+    space,
+    chalk.yellowBright(
+        fs.existsSync('source.txt')
+    )
+)
+console.log(
+    chalk.bold.bgMagenta(' DIRECTORY CHECK '),
+    space,
+    chalk.magentaBright(fs.existsSync('dir/source.txt'))
+)
+console.log(
+    chalk.bold.bgMagenta(' SOURCE DIRECTORY CHECK '),
+    space,
+    chalk.magentaBright(
+        fs.existsSync('srcdir/source.txt')
+    )
+)
+console.log(
+    chalk.bold.bgWhite(' PROTO CHECK '),
+    space,
+    chalk.whiteBright(
+        fs.existsSync('google/cloud/speech/v1p1beta1/speech_proto-descriptor-set.proto.bin')
+    )
+)

--- a/e2e/js_image_oci/src/test-pure.yaml
+++ b/e2e/js_image_oci/src/test-pure.yaml
@@ -1,0 +1,19 @@
+schemaVersion: 2.0.0
+
+commandTests:
+    - name: 'smoke'
+      command: '/nodejs/bin/node'
+      args: ['/app/src/main-pure.js']
+      expectedOutput:
+          [
+              'OS',
+              ' CWD    /app',
+              '@mycorp/pkg-a acorn@7.4.0',
+              '@mycorp/pkg-a uuid@9.0.1',
+              '@mycorp/pkg-b acorn@7.4.0',
+              '@mycorp/pkg-b uuid@8.3.2',
+              ' SOURCE CHECK    true',
+              ' DIRECTORY CHECK    true',
+              ' PROTO CHECK    true',
+              ' SOURCE DIRECTORY CHECK    true',
+          ]


### PR DESCRIPTION
In our company, we use distroless images (with installed NodeJS), so basic `js_image_layer` isn't suitable for our needs, as it creates a Bazel-like structure with nodejs, nodejs patches, and runfiles.

We have added the ability to generate layers similar to a native/pure NodeJS application, including only:
- Sources
- Node_modules

I believe this is a common scenario where it is necessary to generate a layer without Bazel-specific sources/wrappers. 

The `pure` option does the following:
- Removes NodeJS
- Removes NodeJS patches
- Removes js_binary wrappers
- Preserves the structure without the runfiles tree

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- New test cases added
