### PR TITLE
chore: remove stray TODO

### DIFF
--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -449,7 +449,6 @@ def npm_package(
         )
         srcs = srcs + [files_target]
 
-    # TODO(2.0): switch to false
     if publishable:
         js_binary(
             name = "{}.publish".format(name),


### PR DESCRIPTION
When the `publishable` attribute was added, the default was already `False`, so there is no TODO to DO
