### PR TITLE
fix(pnpm): npm: aliases to self

### DIFF
--- a/e2e/pnpm_lockfiles/base/package.json
+++ b/e2e/pnpm_lockfiles/base/package.json
@@ -13,7 +13,7 @@
         "tslib": "^2.6.3",
         "typescript": "^5.4.5",
         "meaning-of-life": "1.0.0",
-        "is-odd": "3.0.1",
+        "is-odd": "npm:is-odd@3.0.1",
         "is-odd-alt-version": "npm:is-odd@^2.0.0",
         "uvu": "0.5.6",
         "@scoped/a": "workspace:*",

--- a/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
       alias-types-node: npm:@types/node@~16.18.11
       debug: ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53
       hello: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
-      is-odd: 3.0.1
+      is-odd: npm:is-odd@3.0.1
       is-odd-alt-version: npm:is-odd@^2.0.0
       jsonify: https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz
       meaning-of-life: 1.0.0

--- a/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         specifier: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
         version: '@gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello'
       is-odd:
-        specifier: 3.0.1
+        specifier: npm:is-odd@3.0.1
         version: 3.0.1
       is-odd-alt-version:
         specifier: npm:is-odd@^2.0.0

--- a/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         specifier: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
         version: '@gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello'
       is-odd:
-        specifier: 3.0.1
+        specifier: npm:is-odd@3.0.1
         version: 3.0.1
       is-odd-alt-version:
         specifier: npm:is-odd@^2.0.0

--- a/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         specifier: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
         version: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
       is-odd:
-        specifier: 3.0.1
+        specifier: npm:is-odd@3.0.1
         version: 3.0.1
       is-odd-alt-version:
         specifier: npm:is-odd@^2.0.0

--- a/npm/private/pnpm.bzl
+++ b/npm/private/pnpm.bzl
@@ -92,7 +92,7 @@ def _convert_v5_importer_dependency_map(specifiers, deps):
     for name, version in deps.items():
         specifier = specifiers.get(name)
 
-        if specifier.startswith("npm:"):
+        if specifier.startswith("npm:") and not specifier.startswith("npm:{}@".format(name)):
             # Keep the npm: specifier for aliased dependencies
             # convert v5 style aliases ([default_registry]/aliased/version) to npm:aliased@version
             alias, version = _strip_v5_v6_default_registry(version).lstrip("/").rsplit("/", 1)
@@ -238,7 +238,7 @@ def _convert_pnpm_v6_importer_dependency_map(deps):
         specifier = attributes.get("specifier")
         version = attributes.get("version")
 
-        if specifier.startswith("npm:"):
+        if specifier.startswith("npm:") and not specifier.startswith("npm:{}@".format(name)):
             # Keep the npm: specifier for aliased dependencies
             # convert v6 style aliases ([registry]/aliased@version) to npm:aliased@version
             alias, version = _split_name_at_version(_strip_v5_v6_default_registry(version).lstrip("/"))
@@ -391,10 +391,9 @@ def _convert_pnpm_v9_importer_dependency_map(deps):
         # Transition version[(patch)(peer)(data)] to a rules_js version format
         version = _convert_pnpm_v6_v9_version_peer_dep(version)
 
-        if specifier.startswith("npm:"):
+        if specifier.startswith("npm:") and not specifier.startswith("npm:{}@".format(name)):
             # Keep the npm: specifier for aliased dependencies
-            alias, version = version.rsplit("@", 1)
-            version = "npm:{}@{}".format(alias, version)
+            version = "npm:{}".format(version)
 
         result[name] = version
     return result


### PR DESCRIPTION
When a specifier uses `npm:` to reference itself the resolved version is just the raw version, where normally `npm:` specifiers result in `actual-pkg@version`.

Fix https://github.com/aspect-build/rules_js/issues/1843

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
