### PR TITLE
fix: do not put sources+types into NpmPackageStoreInfo.files

### DIFF
--- a/examples/linked_consumer/BUILD.bazel
+++ b/examples/linked_consumer/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
+load("@aspect_rules_js//js:defs.bzl", "js_info_files", "js_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages(name = "node_modules")
@@ -21,4 +23,78 @@ js_test(
         ":node_modules/@lib/test2",
     ],
     entry_point = "test_pkg_deps_linked.js",
+)
+
+# Test that sources & test can be pulled from a linked js_library the same
+# as they can be pulled out of an unlinked js_library
+js_info_files(
+    name = "unlinked_sources",
+    srcs = ["//examples/linked_lib:lib"],
+    include_npm_sources = False,
+    include_sources = True,
+    include_transitive_sources = True,
+    include_transitive_types = False,
+    include_types = False,
+)
+
+js_info_files(
+    name = "linked_sources",
+    srcs = [":node_modules/@lib/test2"],
+    include_npm_sources = False,
+    include_sources = True,
+    include_transitive_sources = True,
+    include_transitive_types = False,
+    include_types = False,
+)
+
+copy_to_directory(
+    name = "unlinked_sources_dir",
+    srcs = [":unlinked_sources"],
+)
+
+copy_to_directory(
+    name = "linked_sources_dir",
+    srcs = [":linked_sources"],
+)
+
+diff_test(
+    name = "sources_test",
+    file1 = ":unlinked_sources_dir",
+    file2 = ":linked_sources_dir",
+)
+
+js_info_files(
+    name = "linked_types",
+    srcs = [":node_modules/@lib/test2"],
+    include_npm_sources = False,
+    include_sources = False,
+    include_transitive_sources = False,
+    include_transitive_types = True,
+    include_types = True,
+)
+
+js_info_files(
+    name = "unlinked_types",
+    srcs = ["//examples/linked_lib:lib"],
+    include_npm_sources = False,
+    include_sources = False,
+    include_transitive_sources = False,
+    include_transitive_types = True,
+    include_types = True,
+)
+
+copy_to_directory(
+    name = "unlinked_types_dir",
+    srcs = [":unlinked_types"],
+)
+
+copy_to_directory(
+    name = "linked_types_dir",
+    srcs = [":linked_types"],
+)
+
+diff_test(
+    name = "types_test",
+    file1 = ":unlinked_types_dir",
+    file2 = ":linked_types_dir",
 )

--- a/examples/linked_lib/BUILD.bazel
+++ b/examples/linked_lib/BUILD.bazel
@@ -9,6 +9,8 @@ js_library(
     name = "pkg",
     srcs = [
         "index.js",
+        "one.d.ts",
+        "one.js",
         "package.json",
     ],
     visibility = ["//visibility:public"],

--- a/examples/linked_lib/one.d.ts
+++ b/examples/linked_lib/one.d.ts
@@ -1,0 +1,1 @@
+export declare const one = 1

--- a/examples/linked_lib/one.js
+++ b/examples/linked_lib/one.js
@@ -1,0 +1,4 @@
+'use strict'
+exports.__esModule = true
+exports.one = void 0
+exports.one = 1

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -92,34 +92,19 @@ def _npm_link_package_store_impl(ctx):
         )
         files.append(bin_file)
 
-    files_depset = depset(files, transitive = [
-        store_info.files,
-        store_js_info.npm_sources,
-        store_js_info.sources,
-    ])
-    transitive_files_depset = depset(files, transitive = [
+    npm_sources = depset(files, transitive = [
         store_info.transitive_files,
         store_js_info.npm_sources,
-        store_js_info.transitive_sources,
     ])
 
     providers = [
-        # TODO: delete? all rules_js+tests pass without...
-        DefaultInfo(
-            # Only provide direct files in DefaultInfo files
-            files = files_depset,
-            # Include all transitives in runfiles so that this target can be used in the data
-            # of a generic binary target such as sh_binary
-            runfiles = ctx.runfiles(transitive_files = transitive_files_depset),
-        ),
         js_info(
             target = ctx.label,
-            # TODO: if no other JsInfo properties are set, where do they come from?
-
-            # Add the additional files required for linking
-            # TODO: why does this need store_js_info.sources for rules_ts tests!?
-            # ... shouldn't sources=store_js_info.sources be used instead?
-            npm_sources = transitive_files_depset,
+            sources = store_js_info.sources,
+            transitive_sources = store_js_info.transitive_sources,
+            types = store_js_info.types,
+            transitive_types = store_js_info.transitive_types,
+            npm_sources = npm_sources,
             # only propagate non-dev npm dependencies to use as direct dependencies when linking downstream npm_package targets with npm_link_package
             npm_package_store_infos = depset([store_info]) if not store_info.dev else depset(),
         ),


### PR DESCRIPTION
The `NpmPackageStoreInfo` `files` and `transitive_files` now only contain the files/symlinks required to put the package into the store. All sources + types are only in the `JsInfo` which was already passed around throughout these targets but now must be read in addition to the `NpmPackageStoreInfo`.

Close #1847

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added, see rules_ts: https://github.com/aspect-build/rules_ts/pull/651
