### PR TITLE
fix(npm): invalid export of package/resolved.json

### DIFF
--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -19,6 +19,9 @@ BZL_FILES = {
     # global
     "defs.bzl": "@REPO_NAME//:defs.bzl",
 
+    # resolved.json reference
+    "is-odd_resolved.json": "@REPO_NAME//VERSION:is-odd/resolved.json",
+
     # hasBin, optional deps, deps
     "rollup_links_defs.bzl": "@REPO_NAME__rollup__2.14.0__links//:defs.bzl",
     "rollup_package_json.bzl": "@REPO_NAME__rollup__2.14.0//VERSION:package_json.bzl",

--- a/e2e/pnpm_lockfiles/v54/snapshots/is-odd_resolved.json
+++ b/e2e/pnpm_lockfiles/v54/snapshots/is-odd_resolved.json
@@ -1,0 +1,1 @@
+{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}

--- a/e2e/pnpm_lockfiles/v60/snapshots/is-odd_resolved.json
+++ b/e2e/pnpm_lockfiles/v60/snapshots/is-odd_resolved.json
@@ -1,0 +1,1 @@
+{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}

--- a/e2e/pnpm_lockfiles/v61/snapshots/is-odd_resolved.json
+++ b/e2e/pnpm_lockfiles/v61/snapshots/is-odd_resolved.json
@@ -1,0 +1,1 @@
+{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}

--- a/e2e/pnpm_lockfiles/v90/snapshots/is-odd_resolved.json
+++ b/e2e/pnpm_lockfiles/v90/snapshots/is-odd_resolved.json
@@ -1,0 +1,1 @@
+{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJ<LOCKVERSION>yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -286,14 +286,15 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             build_file = "{}/{}".format(link_package, "BUILD.bazel") if link_package else "BUILD.bazel"
             if build_file not in rctx_files:
                 rctx_files[build_file] = []
-            resolved_json_file_path = "{}/{}/{}".format(link_package, _import.package, _RESOLVED_JSON_FILENAME).lstrip("/")
+            resolved_json_rel_path = "{}/{}".format(_import.package, _RESOLVED_JSON_FILENAME) if _import.package else _RESOLVED_JSON_FILENAME
+            resolved_json_file_path = "{}/{}".format(link_package, resolved_json_rel_path) if link_package else resolved_json_rel_path
             rctx.file(resolved_json_file_path, json.encode({
                 # Allow consumers to auto-detect this filetype
                 "$schema": "https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock",
                 "version": _import.version,
                 "integrity": _import.integrity,
             }))
-            rctx_files[build_file].append("exports_files([\"{}\"])".format(resolved_json_file_path))
+            rctx_files[build_file].append("exports_files([\"{}\"])".format(resolved_json_rel_path))
             if _import.package_info.get("has_bin"):
                 if rctx.attr.generate_bzl_library_targets:
                     rctx_files[build_file].append("""load("@bazel_skylib//:bzl_library.bzl", "bzl_library")""")


### PR DESCRIPTION
The generated `@npm//v61/BUILD.bazel` had:
```
export_files(["v61/is-odd/resolved.json"])
```

Which should not have the `v61/` because this is the `v61/BUILD`. The majority of use cases the lockfile is in the root and we don't see this problem.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:
