### PR TITLE
test(npm): add tests for odd package names

### DIFF
--- a/e2e/pnpm_lockfiles/base/aliases-test.js
+++ b/e2e/pnpm_lockfiles/base/aliases-test.js
@@ -5,6 +5,19 @@ if (require('@aspect-test/a') !== require('@aspect-test/a2')) {
     )
 }
 
+// Various other aliases with odd scoping
+for (const pkg of [
+    '@aspect-test/a2',
+    'aspect-test-a-no-scope',
+    'aspect-test-a/no-at',
+    '@aspect-test-a-bad-scope',
+    '@aspect-test-custom-scope/a',
+]) {
+    if (require('@aspect-test/a') !== require(pkg)) {
+        throw new Error(`${pkg} should be alias of @aspect-test/a`)
+    }
+}
+
 // `alias-types-node` and `@types/node` should be importable and equal
 if (
     require('alias-types-node/package.json') !==

--- a/e2e/pnpm_lockfiles/base/package.json
+++ b/e2e/pnpm_lockfiles/base/package.json
@@ -4,6 +4,10 @@
     "dependencies": {
         "@aspect-test/a": "^5.0.2",
         "@aspect-test/a2": "npm:@aspect-test/a",
+        "aspect-test-a-no-scope": "npm:@aspect-test/a",
+        "aspect-test-a/no-at": "npm:@aspect-test/a",
+        "@aspect-test-a-bad-scope": "npm:@aspect-test/a",
+        "@aspect-test-custom-scope/a": "npm:@aspect-test/a",
         "@isaacs/cliui": "8.0.2",
         "debug": "ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53",
         "hello": "https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello",
@@ -20,6 +24,7 @@
         "is-odd-v2": "npm:is-odd@2.0.0",
         "is-odd-v3": "npm:is-odd@3.0.0",
         "uvu": "0.5.6",
+        "scoped/bad": "link:../projects/b",
         "@scoped/a": "workspace:*",
         "@scoped/b": "link:../projects/b",
         "@scoped/c": "file:../projects/c",

--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -56,6 +56,10 @@ def lockfile_test(name = None):
         data = [
             ":node_modules/@aspect-test/a",
             ":node_modules/@aspect-test/a2",
+            ":node_modules/aspect-test-a-no-scope",
+            ":node_modules/aspect-test-a/no-at",
+            ":node_modules/@aspect-test-a-bad-scope",
+            ":node_modules/@aspect-test-custom-scope/a",
             ":node_modules/@types/node",
             ":node_modules/alias-only-sizzle",
             ":node_modules/alias-types-node",
@@ -77,6 +81,7 @@ def lockfile_test(name = None):
             ":node_modules",
 
             # Direct 'dependencies'
+            ":node_modules/@aspect-test",  # target for the scope
             ":node_modules/@aspect-test/a",
 
             # Direct 'devDependencies'
@@ -101,10 +106,12 @@ def lockfile_test(name = None):
             ":node_modules/@isaacs/cliui",
 
             # link:, workspace:, file:, ./rel/path
+            ":node_modules/@scoped",  # target for the scope
             ":node_modules/@scoped/a",
             ":node_modules/@scoped/b",
             ":node_modules/@scoped/c",
             ":node_modules/@scoped/d",
+            ":node_modules/scoped/bad",
 
             # Packages involving overrides
             ":node_modules/is-odd",
@@ -120,7 +127,13 @@ def lockfile_test(name = None):
             ":node_modules/@aspect-test/a2",
             # npm: alias to registry-scoped packages
             ":node_modules/alias-types-node",
-            ":node_modules/is-odd-alias",
+            # npm: alias adding/removing or odd @scopes
+            ":node_modules/aspect-test-a/no-at",
+            ":node_modules/aspect-test-a-no-scope",
+            ":node_modules/@aspect-test-a-bad-scope",
+            ":node_modules/@aspect-test-custom-scope",  # target for the scope
+            ":node_modules/@aspect-test-custom-scope/a",
+
             # npm: alias to alternate versions
             ":node_modules/is-odd-v0",
             ":node_modules/is-odd-v1",

--- a/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
@@ -18,6 +18,8 @@ importers:
 
   .:
     specifiers:
+      '@aspect-test-a-bad-scope': npm:@aspect-test/a
+      '@aspect-test-custom-scope/a': npm:@aspect-test/a
       '@aspect-test/a': ^5.0.2
       '@aspect-test/a2': npm:@aspect-test/a
       '@aspect-test/b': 5.0.2
@@ -31,6 +33,8 @@ importers:
       '@types/node': 16.18.11
       alias-only-sizzle: npm:@types/sizzle@~2.3.8
       alias-types-node: npm:@types/node@~16.18.11
+      aspect-test-a-no-scope: npm:@aspect-test/a
+      aspect-test-a/no-at: npm:@aspect-test/a
       debug: ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53
       hello: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
       is-odd: npm:is-odd@3.0.1
@@ -43,10 +47,13 @@ importers:
       meaning-of-life: 1.0.0
       rollup: 2.14.0
       rollup-plugin-with-peers: npm:@rollup/plugin-typescript@8.2.1
+      scoped/bad: link:../projects/b
       tslib: ^2.6.3
       typescript: 5.5.2
       uvu: 0.5.6
     dependencies:
+      '@aspect-test-a-bad-scope': /@aspect-test/a/5.0.2
+      '@aspect-test-custom-scope/a': /@aspect-test/a/5.0.2
       '@aspect-test/a': 5.0.2
       '@aspect-test/a2': /@aspect-test/a/5.0.2
       '@isaacs/cliui': 8.0.2
@@ -54,6 +61,8 @@ importers:
       '@scoped/b': link:../projects/b
       '@scoped/c': file:../projects/c
       '@scoped/d': link:../projects/d
+      aspect-test-a-no-scope: /@aspect-test/a/5.0.2
+      aspect-test-a/no-at: /@aspect-test/a/5.0.2
       debug: github.com/ngokevin/debug/9742c5f383a6f8046241920156236ade8ec30d53
       hello: '@gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello'
       is-odd: 3.0.1
@@ -66,6 +75,7 @@ importers:
       meaning-of-life: 1.0.0_o3deharooos255qt5xdujc3cuq
       rollup: 2.14.0
       rollup-plugin-with-peers: /@rollup/plugin-typescript/8.2.1_ommloj5qql5ba6x5wuiluawhoi
+      scoped/bad: link:../projects/b
       tslib: 2.6.3
       typescript: 5.5.2
       uvu: 0.5.6

--- a/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
@@ -18,6 +18,12 @@ importers:
 
   .:
     dependencies:
+      '@aspect-test-a-bad-scope':
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
+      '@aspect-test-custom-scope/a':
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
       '@aspect-test/a':
         specifier: ^5.0.2
         version: 5.0.2
@@ -42,6 +48,12 @@ importers:
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
+      aspect-test-a-no-scope:
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
+      aspect-test-a/no-at:
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
       debug:
         specifier: ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53
         version: github.com/ngokevin/debug/9742c5f383a6f8046241920156236ade8ec30d53
@@ -78,6 +90,9 @@ importers:
       rollup-plugin-with-peers:
         specifier: npm:@rollup/plugin-typescript@8.2.1
         version: /@rollup/plugin-typescript@8.2.1(rollup@2.14.0)(tslib@2.6.3)(typescript@5.5.2)
+      scoped/bad:
+        specifier: link:../projects/b
+        version: link:../projects/b
       tslib:
         specifier: ^2.6.3
         version: 2.6.3

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -151,12 +151,22 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         store_58(name = "{}/wrap-ansi".format(name))
     if link:
         if bazel_package == "<LOCKVERSION>":
+            link_4(name = "{}/@aspect-test-a-bad-scope".format(name))
+            link_targets.append("//{}:{}/@aspect-test-a-bad-scope".format(bazel_package, name))
+            link_4(name = "{}/@aspect-test-custom-scope/a".format(name))
+            link_targets.append("//{}:{}/@aspect-test-custom-scope/a".format(bazel_package, name))
+            scope_targets["@aspect-test-custom-scope"] = scope_targets["@aspect-test-custom-scope"] + [link_targets[-1]] if "@aspect-test-custom-scope" in scope_targets else [link_targets[-1]]
             link_4(name = "{}/@aspect-test/a".format(name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
             link_4(name = "{}/@aspect-test/a2".format(name))
             link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
+            link_4(name = "{}/aspect-test-a-no-scope".format(name))
+            link_targets.append("//{}:{}/aspect-test-a-no-scope".format(bazel_package, name))
+            link_4(name = "{}/aspect-test-a/no-at".format(name))
+            link_targets.append("//{}:{}/aspect-test-a/no-at".format(bazel_package, name))
+            scope_targets["aspect-test-a"] = scope_targets["aspect-test-a"] + [link_targets[-1]] if "aspect-test-a" in scope_targets else [link_targets[-1]]
             link_5(name = "{}/@aspect-test/b".format(name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
@@ -359,6 +369,41 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_targets.append(":{}/@scoped/d".format(name))
             scope_targets["@scoped"] = scope_targets["@scoped"] + [link_targets[-1]] if "@scoped" in scope_targets else [link_targets[-1]]
 
+    if is_root:
+        _npm_package_store(
+            name = ".aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+            src = "//projects/b:pkg",
+            package = "scoped/bad",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == native.package_name():
+            # terminal target for direct dependencies
+            _npm_link_package_store(
+                name = "{}/scoped/bad".format(name),
+                src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+
+            # filegroup target that provides a single file which is
+            # package directory for use in $(execpath) and $(rootpath)
+            native.filegroup(
+                name = "{}/scoped/bad/dir".format(name),
+                srcs = [":{}/scoped/bad".format(name)],
+                output_group = "package_directory",
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+            link_targets.append(":{}/scoped/bad".format(name))
+            scope_targets["scoped"] = scope_targets["scoped"] + [link_targets[-1]] if "scoped" in scope_targets else [link_targets[-1]]
+
     for scope, scoped_targets in scope_targets.items():
         _js_library(
             name = "{}/{}".format(name, scope),
@@ -383,8 +428,12 @@ def npm_link_targets(name = "node_modules", package = None):
 
     if link:
         if bazel_package == "<LOCKVERSION>":
+            link_targets.append("//{}:{}/@aspect-test-a-bad-scope".format(bazel_package, name))
+            link_targets.append("//{}:{}/@aspect-test-custom-scope/a".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
+            link_targets.append("//{}:{}/aspect-test-a-no-scope".format(bazel_package, name))
+            link_targets.append("//{}:{}/aspect-test-a/no-at".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/c".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/e".format(bazel_package, name))
@@ -424,4 +473,8 @@ def npm_link_targets(name = "node_modules", package = None):
     for link_package in ["<LOCKVERSION>"]:
         if link_package == bazel_package:
             link_targets.append("//{}:{}/@scoped/d".format(bazel_package, name))
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == bazel_package:
+            link_targets.append("//{}:{}/scoped/bad".format(bazel_package, name))
     return link_targets

--- a/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
@@ -22,6 +22,12 @@ importers:
 
   .:
     dependencies:
+      '@aspect-test-a-bad-scope':
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
+      '@aspect-test-custom-scope/a':
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
       '@aspect-test/a':
         specifier: ^5.0.2
         version: 5.0.2
@@ -46,6 +52,12 @@ importers:
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
+      aspect-test-a-no-scope:
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
+      aspect-test-a/no-at:
+        specifier: npm:@aspect-test/a
+        version: /@aspect-test/a@5.0.2
       debug:
         specifier: ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53
         version: github.com/ngokevin/debug/9742c5f383a6f8046241920156236ade8ec30d53
@@ -82,6 +94,9 @@ importers:
       rollup-plugin-with-peers:
         specifier: npm:@rollup/plugin-typescript@8.2.1
         version: /@rollup/plugin-typescript@8.2.1(rollup@2.14.0)(tslib@2.6.3)(typescript@5.5.2)
+      scoped/bad:
+        specifier: link:../projects/b
+        version: link:../projects/b
       tslib:
         specifier: ^2.6.3
         version: 2.6.3

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -151,12 +151,22 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         store_58(name = "{}/wrap-ansi".format(name))
     if link:
         if bazel_package == "<LOCKVERSION>":
+            link_4(name = "{}/@aspect-test-a-bad-scope".format(name))
+            link_targets.append("//{}:{}/@aspect-test-a-bad-scope".format(bazel_package, name))
+            link_4(name = "{}/@aspect-test-custom-scope/a".format(name))
+            link_targets.append("//{}:{}/@aspect-test-custom-scope/a".format(bazel_package, name))
+            scope_targets["@aspect-test-custom-scope"] = scope_targets["@aspect-test-custom-scope"] + [link_targets[-1]] if "@aspect-test-custom-scope" in scope_targets else [link_targets[-1]]
             link_4(name = "{}/@aspect-test/a".format(name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
             link_4(name = "{}/@aspect-test/a2".format(name))
             link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
+            link_4(name = "{}/aspect-test-a-no-scope".format(name))
+            link_targets.append("//{}:{}/aspect-test-a-no-scope".format(bazel_package, name))
+            link_4(name = "{}/aspect-test-a/no-at".format(name))
+            link_targets.append("//{}:{}/aspect-test-a/no-at".format(bazel_package, name))
+            scope_targets["aspect-test-a"] = scope_targets["aspect-test-a"] + [link_targets[-1]] if "aspect-test-a" in scope_targets else [link_targets[-1]]
             link_5(name = "{}/@aspect-test/b".format(name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
@@ -359,6 +369,41 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_targets.append(":{}/@scoped/d".format(name))
             scope_targets["@scoped"] = scope_targets["@scoped"] + [link_targets[-1]] if "@scoped" in scope_targets else [link_targets[-1]]
 
+    if is_root:
+        _npm_package_store(
+            name = ".aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+            src = "//projects/b:pkg",
+            package = "scoped/bad",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == native.package_name():
+            # terminal target for direct dependencies
+            _npm_link_package_store(
+                name = "{}/scoped/bad".format(name),
+                src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+
+            # filegroup target that provides a single file which is
+            # package directory for use in $(execpath) and $(rootpath)
+            native.filegroup(
+                name = "{}/scoped/bad/dir".format(name),
+                srcs = [":{}/scoped/bad".format(name)],
+                output_group = "package_directory",
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+            link_targets.append(":{}/scoped/bad".format(name))
+            scope_targets["scoped"] = scope_targets["scoped"] + [link_targets[-1]] if "scoped" in scope_targets else [link_targets[-1]]
+
     for scope, scoped_targets in scope_targets.items():
         _js_library(
             name = "{}/{}".format(name, scope),
@@ -383,8 +428,12 @@ def npm_link_targets(name = "node_modules", package = None):
 
     if link:
         if bazel_package == "<LOCKVERSION>":
+            link_targets.append("//{}:{}/@aspect-test-a-bad-scope".format(bazel_package, name))
+            link_targets.append("//{}:{}/@aspect-test-custom-scope/a".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
+            link_targets.append("//{}:{}/aspect-test-a-no-scope".format(bazel_package, name))
+            link_targets.append("//{}:{}/aspect-test-a/no-at".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/c".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/e".format(bazel_package, name))
@@ -424,4 +473,8 @@ def npm_link_targets(name = "node_modules", package = None):
     for link_package in ["<LOCKVERSION>"]:
         if link_package == bazel_package:
             link_targets.append("//{}:{}/@scoped/d".format(bazel_package, name))
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == bazel_package:
+            link_targets.append("//{}:{}/scoped/bad".format(bazel_package, name))
     return link_targets

--- a/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
 
   .:
     dependencies:
+      '@aspect-test-a-bad-scope':
+        specifier: npm:@aspect-test/a
+        version: '@aspect-test/a@5.0.2'
+      '@aspect-test-custom-scope/a':
+        specifier: npm:@aspect-test/a
+        version: '@aspect-test/a@5.0.2'
       '@aspect-test/a':
         specifier: ^5.0.2
         version: 5.0.2
@@ -43,6 +49,12 @@ importers:
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
+      aspect-test-a-no-scope:
+        specifier: npm:@aspect-test/a
+        version: '@aspect-test/a@5.0.2'
+      aspect-test-a/no-at:
+        specifier: npm:@aspect-test/a
+        version: '@aspect-test/a@5.0.2'
       debug:
         specifier: ngokevin/debug#9742c5f383a6f8046241920156236ade8ec30d53
         version: https://codeload.github.com/ngokevin/debug/tar.gz/9742c5f383a6f8046241920156236ade8ec30d53
@@ -79,6 +91,9 @@ importers:
       rollup-plugin-with-peers:
         specifier: npm:@rollup/plugin-typescript@8.2.1
         version: '@rollup/plugin-typescript@8.2.1(rollup@2.14.0)(tslib@2.6.3)(typescript@5.5.2)'
+      scoped/bad:
+        specifier: link:../projects/b
+        version: link:../projects/b
       tslib:
         specifier: ^2.6.3
         version: 2.6.3

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -151,12 +151,22 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         store_58(name = "{}/wrap-ansi".format(name))
     if link:
         if bazel_package == "<LOCKVERSION>":
+            link_4(name = "{}/@aspect-test-a-bad-scope".format(name))
+            link_targets.append("//{}:{}/@aspect-test-a-bad-scope".format(bazel_package, name))
+            link_4(name = "{}/@aspect-test-custom-scope/a".format(name))
+            link_targets.append("//{}:{}/@aspect-test-custom-scope/a".format(bazel_package, name))
+            scope_targets["@aspect-test-custom-scope"] = scope_targets["@aspect-test-custom-scope"] + [link_targets[-1]] if "@aspect-test-custom-scope" in scope_targets else [link_targets[-1]]
             link_4(name = "{}/@aspect-test/a".format(name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
             link_4(name = "{}/@aspect-test/a2".format(name))
             link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
+            link_4(name = "{}/aspect-test-a-no-scope".format(name))
+            link_targets.append("//{}:{}/aspect-test-a-no-scope".format(bazel_package, name))
+            link_4(name = "{}/aspect-test-a/no-at".format(name))
+            link_targets.append("//{}:{}/aspect-test-a/no-at".format(bazel_package, name))
+            scope_targets["aspect-test-a"] = scope_targets["aspect-test-a"] + [link_targets[-1]] if "aspect-test-a" in scope_targets else [link_targets[-1]]
             link_5(name = "{}/@aspect-test/b".format(name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             scope_targets["@aspect-test"] = scope_targets["@aspect-test"] + [link_targets[-1]] if "@aspect-test" in scope_targets else [link_targets[-1]]
@@ -359,6 +369,41 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_targets.append(":{}/@scoped/d".format(name))
             scope_targets["@scoped"] = scope_targets["@scoped"] + [link_targets[-1]] if "@scoped" in scope_targets else [link_targets[-1]]
 
+    if is_root:
+        _npm_package_store(
+            name = ".aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+            src = "//projects/b:pkg",
+            package = "scoped/bad",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == native.package_name():
+            # terminal target for direct dependencies
+            _npm_link_package_store(
+                name = "{}/scoped/bad".format(name),
+                src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+
+            # filegroup target that provides a single file which is
+            # package directory for use in $(execpath) and $(rootpath)
+            native.filegroup(
+                name = "{}/scoped/bad/dir".format(name),
+                srcs = [":{}/scoped/bad".format(name)],
+                output_group = "package_directory",
+                visibility = ["//visibility:public"],
+                tags = ["manual"],
+            )
+            link_targets.append(":{}/scoped/bad".format(name))
+            scope_targets["scoped"] = scope_targets["scoped"] + [link_targets[-1]] if "scoped" in scope_targets else [link_targets[-1]]
+
     for scope, scoped_targets in scope_targets.items():
         _js_library(
             name = "{}/{}".format(name, scope),
@@ -383,8 +428,12 @@ def npm_link_targets(name = "node_modules", package = None):
 
     if link:
         if bazel_package == "<LOCKVERSION>":
+            link_targets.append("//{}:{}/@aspect-test-a-bad-scope".format(bazel_package, name))
+            link_targets.append("//{}:{}/@aspect-test-custom-scope/a".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/a".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/a2".format(bazel_package, name))
+            link_targets.append("//{}:{}/aspect-test-a-no-scope".format(bazel_package, name))
+            link_targets.append("//{}:{}/aspect-test-a/no-at".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/b".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/c".format(bazel_package, name))
             link_targets.append("//{}:{}/@aspect-test/e".format(bazel_package, name))
@@ -424,4 +473,8 @@ def npm_link_targets(name = "node_modules", package = None):
     for link_package in ["<LOCKVERSION>"]:
         if link_package == bazel_package:
             link_targets.append("//{}:{}/@scoped/d".format(bazel_package, name))
+
+    for link_package in ["<LOCKVERSION>"]:
+        if link_package == bazel_package:
+            link_targets.append("//{}:{}/scoped/bad".format(bazel_package, name))
     return link_targets


### PR DESCRIPTION
I saw an alias such as `foo/bar` somewhere and there are probably some edge cases here to fix or watch for bugs when refactoring. This just adds tests ensuring it doesn't crash.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
