### PR TITLE
fix: handle js_library 1p deps correctly in js_run_devserver

### DIFF
--- a/e2e/webpack_devserver/.bazelignore
+++ b/e2e/webpack_devserver/.bazelignore
@@ -1,2 +1,3 @@
 node_modules
 mylib/node_modules
+mypkg/node_modules

--- a/e2e/webpack_devserver/mylib/BUILD.bazel
+++ b/e2e/webpack_devserver/mylib/BUILD.bazel
@@ -1,10 +1,16 @@
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 
-npm_package(
+npm_link_all_packages(name = "node_modules")
+
+js_library(
     name = "pkg",
     srcs = [
         "index.js",
         "package.json",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        ":node_modules",
+    ],
 )

--- a/e2e/webpack_devserver/mypkg/BUILD.bazel
+++ b/e2e/webpack_devserver/mypkg/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "index.js",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/webpack_devserver/mypkg/index.js
+++ b/e2e/webpack_devserver/mypkg/index.js
@@ -1,5 +1,5 @@
 const packageJson = require('./package.json')
 const chalk = require('chalk')
 module.exports = {
-    name: () => chalk.green(packageJson.name),
+    name: () => chalk.blue(packageJson.name),
 }

--- a/e2e/webpack_devserver/mypkg/package.json
+++ b/e2e/webpack_devserver/mypkg/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@mycorp/mypkg",
+    "dependencies": {
+        "chalk": "^4"
+    }
+}

--- a/e2e/webpack_devserver/package.json
+++ b/e2e/webpack_devserver/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "lodash": "4.17.21",
-        "@mycorp/mylib": "workspace:*"
+        "@mycorp/mylib": "workspace:*",
+        "@mycorp/mypkg": "workspace:*"
     }
 }

--- a/e2e/webpack_devserver/pnpm-lock.yaml
+++ b/e2e/webpack_devserver/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@mycorp/mylib':
         specifier: workspace:*
         version: link:mylib
+      '@mycorp/mypkg':
+        specifier: workspace:*
+        version: link:mypkg
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -32,6 +35,12 @@ importers:
         version: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.1)
 
   mylib:
+    dependencies:
+      chalk:
+        specifier: ^4
+        version: 4.1.2
+
+  mypkg:
     dependencies:
       chalk:
         specifier: ^4

--- a/e2e/webpack_devserver/pnpm-workspace.yaml
+++ b/e2e/webpack_devserver/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
     - '.'
     - 'mylib'
+    - 'mypkg'

--- a/e2e/webpack_devserver/src/index.js
+++ b/e2e/webpack_devserver/src/index.js
@@ -1,11 +1,15 @@
 import _ from 'lodash'
-import { name } from '@mycorp/mylib'
+import { name as mylibname } from '@mycorp/mylib'
+import { name as mypkgname } from '@mycorp/mypkg'
 
 function component() {
     const element = document.createElement('div')
 
     // Lodash, currently included via a script, is required for this line to work
-    element.innerHTML = _.join(['Hello', 'webpack', name()], ' ')
+    element.innerHTML = _.join(
+        ['Hello', 'webpack', mylibname(), mypkgname()],
+        ' '
+    )
 
     return element
 }

--- a/e2e/webpack_devserver_esm/.bazelignore
+++ b/e2e/webpack_devserver_esm/.bazelignore
@@ -1,2 +1,3 @@
 node_modules
 mylib/node_modules
+mypkg/node_modules

--- a/e2e/webpack_devserver_esm/mylib/BUILD.bazel
+++ b/e2e/webpack_devserver_esm/mylib/BUILD.bazel
@@ -1,10 +1,16 @@
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 
-npm_package(
+npm_link_all_packages(name = "node_modules")
+
+js_library(
     name = "pkg",
     srcs = [
         "index.js",
         "package.json",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        ":node_modules",
+    ],
 )

--- a/e2e/webpack_devserver_esm/mypkg/BUILD.bazel
+++ b/e2e/webpack_devserver_esm/mypkg/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "index.js",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/webpack_devserver_esm/mypkg/index.js
+++ b/e2e/webpack_devserver_esm/mypkg/index.js
@@ -1,5 +1,5 @@
 import packageJson from './package.json'
 import chalk from 'chalk'
 export function name() {
-    return chalk.green(packageJson.name)
+    return chalk.blue(packageJson.name)
 }

--- a/e2e/webpack_devserver_esm/mypkg/package.json
+++ b/e2e/webpack_devserver_esm/mypkg/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@mycorp/mypkg",
+    "dependencies": {
+        "chalk": "^4"
+    }
+}

--- a/e2e/webpack_devserver_esm/package.json
+++ b/e2e/webpack_devserver_esm/package.json
@@ -9,6 +9,7 @@
     },
     "dependencies": {
         "lodash": "4.17.21",
-        "@mycorp/mylib": "workspace:*"
+        "@mycorp/mylib": "workspace:*",
+        "@mycorp/mypkg": "workspace:*"
     }
 }

--- a/e2e/webpack_devserver_esm/pnpm-lock.yaml
+++ b/e2e/webpack_devserver_esm/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@mycorp/mylib':
         specifier: workspace:*
         version: link:mylib
+      '@mycorp/mypkg':
+        specifier: workspace:*
+        version: link:mypkg
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -32,6 +35,12 @@ importers:
         version: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.1)
 
   mylib:
+    dependencies:
+      chalk:
+        specifier: ^4
+        version: 4.1.2
+
+  mypkg:
     dependencies:
       chalk:
         specifier: ^4

--- a/e2e/webpack_devserver_esm/pnpm-workspace.yaml
+++ b/e2e/webpack_devserver_esm/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
     - '.'
     - 'mylib'
+    - 'mypkg'

--- a/e2e/webpack_devserver_esm/serve_test.sh
+++ b/e2e/webpack_devserver_esm/serve_test.sh
@@ -24,6 +24,7 @@ ibazel_pid="$!"
 function _exit {
     kill "$ibazel_pid"
     git checkout src/index.html >/dev/null 2>&1
+    git checkout mypkg/index.js >/dev/null 2>&1
     git checkout mylib/index.js >/dev/null 2>&1
     rm -f "$ibazel_logs"
 }
@@ -46,8 +47,15 @@ if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "Getting St
     exit 1
 fi
 
+# from @mycorp/mypkg
 if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk__WEBPACK_IMPORTED_MODULE_1___default().blue(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)"; then
     echo "ERROR: http://localhost:8080/main.js to contain 'chalk__WEBPACK_IMPORTED_MODULE_1___default().blue(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)'"
+    exit 1
+fi
+
+# from @mycorp/mylib
+if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk__WEBPACK_IMPORTED_MODULE_1___default().blue(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)"; then
+    echo "ERROR: http://localhost:8080/main.js to contain 'chalk__WEBPACK_IMPORTED_MODULE_1___default().green(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)'"
     exit 1
 fi
 
@@ -61,43 +69,67 @@ if ! curl http://localhost:8080/index.html --fail 2>/dev/null | grep "Goodbye"; 
     exit 1
 fi
 
-_sedi 's#blue#red#' mylib/index.js
+_sedi 's#blue#red#' mypkg/index.js
 
-echo "Waiting 5 seconds for ibazel rebuild after change to mylib/index.js..."
+echo "Waiting 5 seconds for ibazel rebuild after change to mypkg/index.js..."
 sleep 5
 
+# from @mycorp/mypkg
 if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk__WEBPACK_IMPORTED_MODULE_1___default().red(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)"; then
     echo "ERROR: Expected http://localhost:8080/main.js to contain 'chalk__WEBPACK_IMPORTED_MODULE_1___default().red(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)'"
     exit 1
 fi
 
-count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/index.js" "$ibazel_logs" || true)
+_sedi 's#green#cyan#' mylib/index.js
+
+echo "Waiting 5 seconds for ibazel rebuild after change to mylib/index.js..."
+sleep 5
+
+# from @mycorp/mylib
+if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk__WEBPACK_IMPORTED_MODULE_1___default().cyan(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)"; then
+    echo "ERROR: Expected http://localhost:8080/main.js to contain 'chalk__WEBPACK_IMPORTED_MODULE_1___default().cyan(_package_json__WEBPACK_IMPORTED_MODULE_0__.name)'"
+    exit 1
+fi
+
+count=$(grep -c "Syncing symlink node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib (1p)" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "ERROR: expected to have synced @mycorp/mylib symlink 1 time but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/index.js" "$ibazel_logs" || true)
 if [[ "$count" -ne 2 ]]; then
-    echo "ERROR: expected to have synced @mycorp/mylib/index.js 2 times but found ${count}"
+    echo "ERROR: expected to have synced @mycorp/mypkg/index.js 2 times but found ${count}"
     exit 1
 fi
 
-count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/index.js since its timestamp has not changed" "$ibazel_logs" || true)
-if [[ "$count" -ne 1 ]]; then
-    echo "ERROR: expected to have skipped @mycorp/mylib/index.js due to timestamp 1 time but found ${count}"
+count=$(grep -c "Syncing file mylib/index.js" "$ibazel_logs" || true)
+if [[ "$count" -ne 2 ]]; then
+    echo "ERROR: expected to have synced mylib/index.js 2 times but found ${count}"
     exit 1
 fi
 
-count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json" "$ibazel_logs" || true)
-if [[ "$count" -ne 1 ]]; then
-    echo "ERROR: expected to have synced @mycorp/mylib/package.json 1 time but found ${count}"
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/index.js since its timestamp has not changed" "$ibazel_logs" || true)
+if [[ "$count" -ne 2 ]]; then
+    echo "ERROR: expected to have skipped @mycorp/mypkg/index.js due to timestamp 2 times but found ${count}"
     exit 1
 fi
 
-count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json since its timestamp has not changed" "$ibazel_logs" || true)
+count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/package.json" "$ibazel_logs" || true)
 if [[ "$count" -ne 1 ]]; then
-    echo "ERROR: expected to have skipped @mycorp/mylib/package.json due to timestamp 1 time but found ${count}"
+    echo "ERROR: expected to have synced @mycorp/mypkg/package.json 1 time but found ${count}"
     exit 1
 fi
 
-count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib/package.json since contents have not changed" "$ibazel_logs" || true)
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/package.json since its timestamp has not changed" "$ibazel_logs" || true)
+if [[ "$count" -ne 2 ]]; then
+    echo "ERROR: expected to have skipped @mycorp/mypkg/package.json due to timestamp 2 times but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/package.json since contents have not changed" "$ibazel_logs" || true)
 if [[ "$count" -ne 1 ]]; then
-    echo "ERROR: expected to have skipped @mycorp/mylib/package.json due to contents 1 time but found ${count}"
+    echo "ERROR: expected to have skipped @mycorp/mypkg/package.json due to contents 1 times but found ${count}"
     exit 1
 fi
 

--- a/e2e/webpack_devserver_esm/src/index.js
+++ b/e2e/webpack_devserver_esm/src/index.js
@@ -1,11 +1,15 @@
 import _ from 'lodash'
-import { name } from '@mycorp/mylib'
+import { name as mylibname } from '@mycorp/mylib'
+import { name as mypkgname } from '@mycorp/mypkg'
 
 function component() {
     const element = document.createElement('div')
 
     // Lodash, currently included via a script, is required for this line to work
-    element.innerHTML = _.join(['Hello', 'webpack', name()], ' ')
+    element.innerHTML = _.join(
+        ['Hello', 'webpack', mylibname(), mypkgname()],
+        ' '
+    )
 
     return element
 }

--- a/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
+++ b/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
@@ -1,6 +1,6 @@
 import {
     isNodeModulePath,
-    is1pVirtualStoreDep,
+    is1pPackageStoreDep,
     friendlyFileSize,
 } from '../../js_run_devserver.mjs'
 
@@ -23,18 +23,18 @@ for (const p of isNodeModulePath_false) {
     }
 }
 
-// is1pVirtualStoreDep
-const is1pVirtualStoreDep_true = [
+// is1pPackageStoreDep
+const is1pPackageStoreDep_true = [
     'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/@mycorp/pkg',
     'some/path/node_modules/.aspect_rules_js/mycorp-pkg@0.0.0/node_modules/mycorp-pkg',
 ]
-for (const p of is1pVirtualStoreDep_true) {
-    if (!is1pVirtualStoreDep(p)) {
+for (const p of is1pPackageStoreDep_true) {
+    if (!is1pPackageStoreDep(p)) {
         console.error(`ERROR: expected ${p} to be a 1p package store dep`)
         process.exit(1)
     }
 }
-const is1pVirtualStoreDep_false = [
+const is1pPackageStoreDep_false = [
     'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/mycorp/pkg',
     'some/path/node_modules/.aspect_rules_js/@mycorp+pkg0.0.0/node_modules/@mycorp/pkg',
     'some/path/node_modules/.aspect_rules_js/mycorp+pkg@0.0.0/node_modules/@mycorp/pkg',
@@ -46,8 +46,8 @@ const is1pVirtualStoreDep_false = [
     'some/path/node_modules/.aspect_rules_js/eval@0.1.6/node_modules/eval',
     'some/path/node_modules/.aspect_rules_js/eval@0.1.6/node_modules/acorn',
 ]
-for (const p of is1pVirtualStoreDep_false) {
-    if (is1pVirtualStoreDep(p)) {
+for (const p of is1pPackageStoreDep_false) {
+    if (is1pPackageStoreDep(p)) {
         console.error(`ERROR: expected ${p} to not be a 1p package store dep`)
         process.exit(1)
     }


### PR DESCRIPTION
Fixes syncing of 1p js_library (JsInfo) linked deps in js_run_devserver.

The code was already handling detecting of 1p deps in the transitive 1p dep case. To handle js_library 1p deps we only needed to ensure that the 1p directory that the symlink in the package store was pointing to is copied first for the dep to be detected as 1p.

---

### Test plan

e2e/webpack_devserver & e2e/webpack_devserver_esm test cases updated to include js_library linked 1p deps and verified manually that the sync works as expected:

```
Starting js_run_devserver //:dev
+ Syncing 18 files && folders...
+ Syncing 6 non-node_modules files & folders...
Syncing file package.json (347 B)
Syncing file webpack.config.js (554 B)
Syncing file mylib/package.json (83 B)
Syncing file src/index.js (448 B)
Syncing file mylib/index.js (144 B)
Syncing file src/index.html (189 B)
+ Syncing 2 first party package store dep(s)
Syncing symlink node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib (1p)
Syncing file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/package.json (83 B)
Syncing file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/index.js (144 B)
+ Syncing 10 other node_modules files
Syncing symlink node_modules/@bazel/ibazel (bazel-out)
Syncing symlink node_modules/lodash (bazel-out)
Syncing symlink node_modules/webpack-cli (bazel-out)
Syncing symlink mylib/node_modules/chalk (bazel-out)
Syncing symlink node_modules/html-webpack-plugin (bazel-out)
Syncing symlink node_modules/webpack (bazel-out)
Syncing symlink node_modules/@mycorp/mylib (1p)
Syncing symlink node_modules/webpack-dev-server (bazel-out)
Syncing symlink node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/chalk (bazel-out)
Syncing symlink node_modules/@mycorp/mypkg (1p)
19 files synced in 65 ms
```

You can see that `node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib` is correctly synced as a  "1p" symlink now