### PR TITLE
fix: delete old files & folders on each js_run_devserver sync

### DIFF
--- a/e2e/webpack_devserver/BUILD.bazel
+++ b/e2e/webpack_devserver/BUILD.bazel
@@ -23,6 +23,7 @@ js_run_devserver(
     ],
     data = [
         "package.json",
+        "src/404.html",
         "src/index.html",
         "src/index.js",
         "webpack.config.js",
@@ -41,6 +42,7 @@ js_run_devserver(
     ],
     data = [
         "package.json",
+        "src/404.html",
         "src/index.html",
         "src/index.js",
         "webpack.config.cjs",

--- a/e2e/webpack_devserver/src/404.html
+++ b/e2e/webpack_devserver/src/404.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>404</title>
+    </head>
+    <body>
+        404
+    </body>
+</html>

--- a/e2e/webpack_devserver_esm/BUILD.bazel
+++ b/e2e/webpack_devserver_esm/BUILD.bazel
@@ -23,6 +23,7 @@ js_run_devserver(
     ],
     data = [
         "package.json",
+        "src/404.html",
         "src/index.html",
         "src/index.js",
         "webpack.config.mjs",

--- a/e2e/webpack_devserver_esm/serve_test.sh
+++ b/e2e/webpack_devserver_esm/serve_test.sh
@@ -26,6 +26,7 @@ function _exit {
     git checkout src/index.html >/dev/null 2>&1
     git checkout mypkg/index.js >/dev/null 2>&1
     git checkout mylib/index.js >/dev/null 2>&1
+    git checkout BUILD.bazel >/dev/null 2>&1
     rm -f "$ibazel_logs"
 }
 trap _exit EXIT
@@ -91,45 +92,96 @@ if ! curl http://localhost:8080/main.js --fail 2>/dev/null | grep "chalk__WEBPAC
     exit 1
 fi
 
+_sedi 's#"src/404.html",##' BUILD.bazel
+
+echo "Waiting 10 seconds for ibazel rebuild after change to BUILD.bazel..."
+sleep 10
+
+git checkout BUILD.bazel >/dev/null 2>&1
+
+echo "Waiting 10 seconds for ibazel rebuild after change to BUILD.bazel..."
+sleep 10
+
+echo "Checking log file $ibazel_logs"
+
 count=$(grep -c "Syncing symlink node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib (1p)" "$ibazel_logs" || true)
 if [[ "$count" -ne 1 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
     echo "ERROR: expected to have synced @mycorp/mylib symlink 1 time but found ${count}"
     exit 1
 fi
 
 count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/index.js" "$ibazel_logs" || true)
 if [[ "$count" -ne 2 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
     echo "ERROR: expected to have synced @mycorp/mypkg/index.js 2 times but found ${count}"
     exit 1
 fi
 
 count=$(grep -c "Syncing file mylib/index.js" "$ibazel_logs" || true)
 if [[ "$count" -ne 2 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
     echo "ERROR: expected to have synced mylib/index.js 2 times but found ${count}"
     exit 1
 fi
 
 count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/index.js since its timestamp has not changed" "$ibazel_logs" || true)
-if [[ "$count" -ne 2 ]]; then
-    echo "ERROR: expected to have skipped @mycorp/mypkg/index.js due to timestamp 2 times but found ${count}"
+if [[ "$count" -ne 4 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
+    echo "ERROR: expected to have skipped @mycorp/mypkg/index.js due to timestamp 4 times but found ${count}"
     exit 1
 fi
 
 count=$(grep -c "Syncing file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/package.json" "$ibazel_logs" || true)
 if [[ "$count" -ne 1 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
     echo "ERROR: expected to have synced @mycorp/mypkg/package.json 1 time but found ${count}"
     exit 1
 fi
 
 count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/package.json since its timestamp has not changed" "$ibazel_logs" || true)
-if [[ "$count" -ne 2 ]]; then
-    echo "ERROR: expected to have skipped @mycorp/mypkg/package.json due to timestamp 2 times but found ${count}"
+if [[ "$count" -ne 4 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
+    echo "ERROR: expected to have skipped @mycorp/mypkg/package.json due to timestamp 4 times but found ${count}"
     exit 1
 fi
 
 count=$(grep -c "Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/package.json since contents have not changed" "$ibazel_logs" || true)
 if [[ "$count" -ne 1 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
     echo "ERROR: expected to have skipped @mycorp/mypkg/package.json due to contents 1 times but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Deleting src/404.html" "$ibazel_logs" || true)
+if [[ "$count" -ne 1 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
+    echo "ERROR: expected to have deleted src/404.html 1 time but found ${count}"
+    exit 1
+fi
+
+count=$(grep -c "Syncing file src/404.html" "$ibazel_logs" || true)
+if [[ "$count" -ne 2 ]]; then
+    echo "==========="
+    cat "$ibazel_logs"
+    echo "==========="
+    echo "ERROR: expected to have synced src/404.html 2 times but found ${count}"
     exit 1
 fi
 

--- a/e2e/webpack_devserver_esm/src/404.html
+++ b/e2e/webpack_devserver_esm/src/404.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>404</title>
+    </head>
+    <body>
+        404
+    </body>
+</html>


### PR DESCRIPTION
`js_run_devserver` is aware of all of the files to sync per sync so it is easy enough to delete files that are no longer synced out of the custom sandbox on each sync.

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:

Run `ibazel run //:dev` in `e2e/webpack_devserver` and manually delete a synced file such as `src/404.html`. Expected output is:

```
Deleting src/404.html
1 file/folder deleted in 1 ms
+ Syncing 18 files && folders...
+ Syncing 6 non-node_modules files & folders...
Skipping file mylib/index.js since its timestamp has not changed
Skipping file mylib/package.json since its timestamp has not changed
Skipping file package.json since its timestamp has not changed
Skipping file src/index.html since its timestamp has not changed
Skipping file src/index.js since its timestamp has not changed
Skipping file webpack.config.js since its timestamp has not changed
+ Syncing 2 first party package store dep(s)
Skipping file node_modules/.aspect_rules_js/@mycorp+mylib@0.0.0/node_modules/@mycorp/mylib since its timestamp has not changed
Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/index.js since its timestamp has not changed
Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/@mycorp/mypkg/package.json since its timestamp has not changed
+ Syncing 10 other node_modules files
Skipping file mylib/node_modules/chalk since its timestamp has not changed
Skipping file node_modules/@bazel/ibazel since its timestamp has not changed
Skipping file node_modules/html-webpack-plugin since its timestamp has not changed
Skipping file node_modules/lodash since its timestamp has not changed
Skipping file node_modules/webpack-cli since its timestamp has not changed
Skipping file node_modules/webpack-dev-server since its timestamp has not changed
Skipping file node_modules/webpack since its timestamp has not changed
Skipping file node_modules/@mycorp/mylib since its timestamp has not changed
Skipping file node_modules/.aspect_rules_js/@mycorp+mypkg@0.0.0/node_modules/chalk since its timestamp has not changed
Skipping file node_modules/@mycorp/mypkg since its timestamp has not changed
```