### PR TITLE
Use canonical repo name for cross-repo `npm_translate_lock`

### DIFF
--- a/e2e/bzlmod/BUILD.bazel
+++ b/e2e/bzlmod/BUILD.bazel
@@ -57,3 +57,8 @@ build_test(
     name = "node_modules_test",
     targets = ["//:node_modules"],
 )
+
+build_test(
+    name = "other_module_binary_test",
+    targets = ["@other_module//:pyright"],
+)

--- a/e2e/bzlmod/BUILD.bazel
+++ b/e2e/bzlmod/BUILD.bazel
@@ -58,6 +58,7 @@ build_test(
     targets = ["//:node_modules"],
 )
 
+# Verifies that a `js_binary` target from another module can be built
 build_test(
     name = "other_module_binary_test",
     targets = ["@other_module//:pyright"],

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -4,6 +4,12 @@ local_path_override(
     path = "../..",
 )
 
+bazel_dep(name = "other_module")
+local_path_override(
+    module_name = "other_module",
+    path = "other_module",
+)
+
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 

--- a/e2e/bzlmod/other_module/.bazelignore
+++ b/e2e/bzlmod/other_module/.bazelignore
@@ -1,2 +1,1 @@
 node_modules
-other_module

--- a/e2e/bzlmod/other_module/.npmrc
+++ b/e2e/bzlmod/other_module/.npmrc
@@ -1,0 +1,4 @@
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false

--- a/e2e/bzlmod/other_module/BUILD.bazel
+++ b/e2e/bzlmod/other_module/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@npm_other_module//:defs.bzl", "npm_link_all_packages")
+load("@npm_other_module//:pyright/package_json.bzl", pyright = "bin")
+
+npm_link_all_packages(name = "node_modules")
+
+pyright.pyright_binary(
+    name = "pyright",
+    env = {"BAZEL_BINDIR": "."},  # Allow the binary to be run outside bazel
+    visibility = ["//visibility:public"],
+)

--- a/e2e/bzlmod/other_module/MODULE.bazel
+++ b/e2e/bzlmod/other_module/MODULE.bazel
@@ -1,0 +1,12 @@
+module(name = "other_module")
+
+bazel_dep(name = "aspect_rules_js", version = "0.0.0")
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
+npm.npm_translate_lock(
+    name = "npm_other_module",
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm_other_module")

--- a/e2e/bzlmod/other_module/WORKSPACE
+++ b/e2e/bzlmod/other_module/WORKSPACE
@@ -1,0 +1,2 @@
+# Marker file that this folder is the root of a Bazel workspace.
+# See MODULE.bazel for dependencies and setup.

--- a/e2e/bzlmod/other_module/package.json
+++ b/e2e/bzlmod/other_module/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "pyright": "1.1.373"
+    }
+}

--- a/e2e/bzlmod/other_module/pnpm-lock.yaml
+++ b/e2e/bzlmod/other_module/pnpm-lock.yaml
@@ -1,0 +1,37 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  prettier:
+    specifier: ^2.8.7
+    version: 2.8.7
+  pyright:
+    specifier: 1.1.373
+    version: 1.1.373
+
+packages:
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /prettier@2.8.7:
+    resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: false
+
+  /pyright@1.1.373:
+    resolution: {integrity: sha512-ZJSjqnHbeZowUnuAiojZqCLeY1XVzRIc2GvMFFNy/z6YSyJXwChPDQL5Jl2bavTvXNO0ITRmMBVvoKCRN7cc3g==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: false

--- a/e2e/pnpm_lockfiles/v54/snapshots/rollup3_package_json.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/rollup3_package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/e2e/pnpm_lockfiles/v54/snapshots/rollup_package_json.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/rollup_package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/e2e/pnpm_lockfiles/v60/snapshots/rollup3_package_json.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/rollup3_package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/e2e/pnpm_lockfiles/v60/snapshots/rollup_package_json.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/rollup_package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/e2e/pnpm_lockfiles/v61/snapshots/rollup3_package_json.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/rollup3_package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/e2e/pnpm_lockfiles/v61/snapshots/rollup_package_json.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/rollup_package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/e2e/pnpm_lockfiles/v90/snapshots/rollup3_package_json.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/rollup3_package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@3.29.4".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/e2e/pnpm_lockfiles/v90/snapshots/rollup_package_json.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/rollup_package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.14.0".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//<LOCKVERSION>:{}/dir".format(store_target_name),
+        directory = "@@//<LOCKVERSION>:{}/dir".format(store_target_name),
         path = "./dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//<LOCKVERSION>:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//<LOCKVERSION>:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -149,7 +149,8 @@ WARNING: Cannot determine home directory in order to load home `.npmrc` file in 
             lifecycle_hooks_execution_requirements = i.lifecycle_hooks_execution_requirements,
             lifecycle_hooks_use_default_shell_env = i.lifecycle_hooks_use_default_shell_env,
             link_packages = i.link_packages,
-            link_workspace = attr.link_workspace if attr.link_workspace else attr.pnpm_lock.workspace_name,
+            # attr.pnpm_lock.workspace_name is a canonical repository name, so it needs to be qualified with an extra '@'.
+            link_workspace = attr.link_workspace if attr.link_workspace else "@" + attr.pnpm_lock.workspace_name,
             npm_auth = i.npm_auth,
             npm_auth_basic = i.npm_auth_basic,
             npm_auth_password = i.npm_auth_password,

--- a/npm/private/test/snapshots/bzlmod/package_json.bzl
+++ b/npm/private/test/snapshots/bzlmod/package_json.bzl
@@ -7,14 +7,14 @@ def _rollup_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.70.2".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//:{}/dir".format(store_target_name),
+        directory = "@@//:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//:{}".format(store_target_name)],
+        data = ["@@//:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _rollup_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.70.2".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//:{}/dir".format(store_target_name),
+        directory = "@@//:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _rollup_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/rollup@2.70.2".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//:{}/dir".format(store_target_name),
+        directory = "@@//:{}/dir".format(store_target_name),
         path = "dist/bin/rollup",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//:{}".format(store_target_name)],
         **kwargs
     )
 

--- a/npm/private/test/snapshots/bzlmod/package_json_with_dashes.bzl
+++ b/npm/private/test/snapshots/bzlmod/package_json_with_dashes.bzl
@@ -7,14 +7,14 @@ def _webpack_bundle_analyzer_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/webpack-bundle-analyzer@4.5.0_bufferutil_4.0.7".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//:{}/dir".format(store_target_name),
+        directory = "@@//:{}/dir".format(store_target_name),
         path = "lib/bin/analyzer.js",
         tags = ["manual"],
     )
     _js_binary(
         name = "%s__js_binary" % name,
         entry_point = ":%s__entry_point" % name,
-        data = ["@//:{}".format(store_target_name)],
+        data = ["@@//:{}".format(store_target_name)],
         include_npm = kwargs.pop("include_npm", False),
         tags = ["manual"],
     )
@@ -29,14 +29,14 @@ def _webpack_bundle_analyzer_test_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/webpack-bundle-analyzer@4.5.0_bufferutil_4.0.7".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//:{}/dir".format(store_target_name),
+        directory = "@@//:{}/dir".format(store_target_name),
         path = "lib/bin/analyzer.js",
         tags = ["manual"],
     )
     _js_test(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//:{}".format(store_target_name)],
         **kwargs
     )
 
@@ -44,14 +44,14 @@ def _webpack_bundle_analyzer_binary_internal(name, link_root_name, **kwargs):
     store_target_name = ".aspect_rules_js/{}/webpack-bundle-analyzer@4.5.0_bufferutil_4.0.7".format(link_root_name)
     _directory_path(
         name = "%s__entry_point" % name,
-        directory = "@//:{}/dir".format(store_target_name),
+        directory = "@@//:{}/dir".format(store_target_name),
         path = "lib/bin/analyzer.js",
         tags = ["manual"],
     )
     _js_binary(
         name = name,
         entry_point = ":%s__entry_point" % name,
-        data = kwargs.pop("data", []) + ["@//:{}".format(store_target_name)],
+        data = kwargs.pop("data", []) + ["@@//:{}".format(store_target_name)],
         **kwargs
     )
 


### PR DESCRIPTION
This prevents an error such as the following when trying to run a `js_binary` defined in another module with Bzlmod:

```
ERROR: .../external/rules_pyright~/BUILD:6:23: no such package '@@[unknown repo 'rules_pyright~' requested from @@rules_pyright~]//': The repository '@@[unknown repo 'rules_pyright~' requested from @@rules_pyright~]' could not be resolved: No repository visible as '@rules_pyright~' from repository '@@rules_pyright~' and referenced by '@@rules_pyright~//:pyright__entry_point'
```

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed an issue when using `js_binary` from another module with Bzlmod.

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
