### PR TITLE
fix: fix permission denied failure on buildbarn RBE

### DIFF
--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -233,7 +233,7 @@ def _npm_package_store_impl(ctx):
                     tools = [bsdtar.tarinfo.binary],
                     inputs = depset(direct = [src], transitive = [bsdtar.default.files]),
                     outputs = [package_store_directory],
-                    command = "$1 --extract --no-same-owner --no-same-permissions --strip-components 1 --file $2 --directory $3 && chmod -R a+X $3",
+                    command = "$1 --extract --no-same-owner --no-same-permissions --strip-components 1 --file $2 --directory $3 && chmod -R a+X $3/*",
                     arguments = [args],
                     mnemonic = "NpmPackageExtract",
                     progress_message = "Extracting npm package {}@{}".format(package, version),


### PR DESCRIPTION
It seems buildbarn can be configured such that it protects the output directory of an action from being touched. This changes the chmod in `npm_package_store` to act on the contents of the output directory instead of on the directory itself.

See https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1723821643734399 more context.
