### PR TITLE
fix: remove problematic chmod extract command in npm_package_store in favor of using a custom postinstall

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -122,6 +122,7 @@ npm.npm_translate_lock(
     custom_postinstalls = {
         "@aspect-test/c": "echo moo > cow.txt",
         "@aspect-test/c@2.0.2": "echo mooo >> cow.txt",
+        "pngjs": "chmod -R a+X *",  # fixes malformed tarball content file permissions in this package after extraction (see https://github.com/aspect-build/rules_js/issues/1637 for more details)
     },
     data = [
         "//:examples/npm_deps/patches/meaning-of-life@1.0.0-pnpm.patch",

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -221,9 +221,7 @@ def _npm_package_store_impl(ctx):
                 # npm packages are always published with one top-level directory inside the tarball,
                 # tho the name is not predictable we can use the --strip-components 1 argument with
                 # tar to strip one directory level. Some packages have directory permissions missing
-                # executable which make the directories not listable (pngjs@5.0.0 for example). Run
-                # `chmod -R a+X` to fix up these packages (https://stackoverflow.com/a/14634721).
-                # See https://github.com/aspect-build/rules_js/issues/1637 for more info.
+                # executable which make the directories not listable (pngjs@5.0.0 for example).
                 bsdtar = ctx.toolchains["@aspect_bazel_lib//lib:tar_toolchain_type"]
                 args = ctx.actions.args()
                 args.add(bsdtar.tarinfo.binary)
@@ -233,7 +231,7 @@ def _npm_package_store_impl(ctx):
                     tools = [bsdtar.tarinfo.binary],
                     inputs = depset(direct = [src], transitive = [bsdtar.default.files]),
                     outputs = [package_store_directory],
-                    command = "$1 --extract --no-same-owner --no-same-permissions --strip-components 1 --file $2 --directory $3 && chmod -R a+X $3/*",
+                    command = "$1 --extract --no-same-owner --no-same-permissions --strip-components 1 --file $2 --directory $3",
                     arguments = [args],
                     mnemonic = "NpmPackageExtract",
                     progress_message = "Extracting npm package {}@{}".format(package, version),


### PR DESCRIPTION
Addresses https://github.com/aspect-build/rules_js/issues/1637 (the original issue that brought in `chmod -R a+X *` as the fix). See Bazel Slack thread https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1723821643734399 for more context.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): for some users yes but unavoidable as this is fixing a blocking bug
- Suggested release notes appear below: yes

Backing out of the blanket chmod after npm package tarball extract since it can lead to exceeding MAX_ARGS on the command with the glob expansion in npm packages with a very large number of files.

Instead, users should opt-in packages such as `pngjs@5.0.0` that have malformed tarball content file permissions and require fixing with `chmod` with `custom_postinstalls`. For example,

```
npm_translate_lock(
    name = "npm",
    custom_postinstalls = {
        "pngjs": "chmod -R a+X *",
    },
    ...
```

### Test plan

- Covered by existing test cases

CI