### PR TITLE
doc: add callout for dependency on generate_bzl_library_targets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -226,6 +226,10 @@ $ bazel query @npm//... --output=location | grep bzl_library
 
 This shows locations on disk where the npm packages can be loaded.
 
+> [!NOTE]
+> These queries only work when `generate_bzl_library_targets = True` is passed to `npm_translate_lock`.
+> If you get no results, check the settings in your `MODULE.bazel` or `WORKSPACE` file and try again.
+
 To see the definition of one of these targets, you can run another `bazel query`:
 
 ```shell


### PR DESCRIPTION
When this attribute is not set in the call to `npm_translate_lock`, the queries return no results, the `package_json.bzl` file is not directly findable, and users may be very confused.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Manually confirmed the queries work after setting this setting but not before.
See also https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1724827171385349 .
