### PR TITLE
docs: Clarify that $npm_package.publish requires publishable = True

### DIFF
--- a/docs/npm_package.md
+++ b/docs/npm_package.md
@@ -24,7 +24,7 @@ A macro that packages sources into a directory (a tree artifact) and provides an
 
 This target can be used as the `src` attribute to `npm_link_package`.
 
-The macro also produces a target `[name].publish`, that can be run to publish to an npm registry.
+With `publishable = True` the macro also produces a target `[name].publish`, that can be run to publish to an npm registry.
 Under the hood, this target runs `npm publish`. You can pass arguments to npm by escaping them from Bazel using a double-hyphen,
 for example: `bazel run //path/to:my_package.publish -- --tag=next`
 

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -155,7 +155,7 @@ def npm_package(
 
     This target can be used as the `src` attribute to `npm_link_package`.
 
-    The macro also produces a target `[name].publish`, that can be run to publish to an npm registry.
+    With `publishable = True` the macro also produces a target `[name].publish`, that can be run to publish to an npm registry.
     Under the hood, this target runs `npm publish`. You can pass arguments to npm by escaping them from Bazel using a double-hyphen,
     for example: `bazel run //path/to:my_package.publish -- --tag=next`
 


### PR DESCRIPTION
This fact is already mentioned further down in the docs, but this commit makes it more apparent when only scanning the summary.

The default value for `publishable` was changed in https://github.com/aspect-build/rules_js/pull/1683.
