### PR TITLE
Add support for `+` in canonical repo names

### DIFF
--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -12,6 +12,7 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
+bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
 
 npm = use_extension(
     "@aspect_rules_js//npm:extensions.bzl",

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -516,7 +516,8 @@ def _is_url(url):
 
 ################################################################################
 def _to_apparent_repo_name(canonical_name):
-    return canonical_name[canonical_name.rfind("~") + 1:]
+    # Bazel 7 uses `~` as the canonical name separator by default, Bazel 8 always uses `+`.
+    return canonical_name[max(canonical_name.rfind("~"), canonical_name.rfind("+")) + 1:]
 
 ################################################################################
 def _verify_node_modules_ignored(rctx, importers, root_package):


### PR DESCRIPTION
Also add a missing Bzlmod dependency that otherwise fails the example with `--noenable_workspace`.

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

<!-- Delete any which do not apply -->

- Manual testing; please provide instructions so we can reproduce:
```
bazel build //examples/... --incompatible_use_plus_in_repo_names
```
