### PR TITLE
npm package untar to not use remote-cache

### DIFF
--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -238,6 +238,9 @@ def _npm_package_store_impl(ctx):
                         "--directory",
                         package_store_directory.path,
                     ],
+                    execution_requirements = {
+                        "no-remote-cache": "1",
+                    }
                     mnemonic = "NpmPackageExtract",
                     progress_message = "Extracting npm package {}@{}".format(package, version),
                 )


### PR DESCRIPTION
It's pretty meaningless to use remote-cache for npm untar action. All npm packages are small.
- If there's a few files in the tarball, untar would be instant anyway
- If there's a lot of files in the barball, untar would be instant, but it takes long time to upload to remote cache

![image](https://github.com/user-attachments/assets/e493900e-8f9c-485c-8228-978595a9af8b)
