### PR TITLE
fix(npm): support patches, lifecycle hooks for non-directory file: packages

### DIFF
--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -283,10 +283,6 @@ def _get_npm_imports(importers, packages, patched_dependencies, only_built_depen
         transitive_closure = package_info.get("transitive_closure")
         resolution = package_info.get("resolution")
 
-        if version.startswith("file:"):
-            # this package is treated as a first-party dep
-            continue
-
         resolution_type = resolution.get("type", None)
         if resolution_type == "directory":
             # this package is treated as a first-party dep


### PR DESCRIPTION
Packages referencing files such as tarballs or URLs should support patches, lifecycle hooks etc. It is only file: references to directories that should not.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
