### PR TITLE
build: disable aspect_bazelrc_presets tests in non-bzlmod

### DIFF
--- a/.aspect/bazelrc/BUILD.bazel
+++ b/.aspect/bazelrc/BUILD.bazel
@@ -12,4 +12,9 @@ write_aspect_bazelrc_presets(
         "javascript",
         "performance",
     ],
+    # Disable the tests with non-bzlmod which may have a different @aspect_bazel_lib version
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:bzlmod": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )


### PR DESCRIPTION
`main` is currently failing with non-bzlmod due to workspace and bzlmod resolving to different versions

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
