### PR TITLE
build: do not run e2e/runfiles on non-bzlmod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,10 @@ jobs:
                           major: 6
                       bzlmod: 0
                       folder: e2e/gyp_no_install_script
+                    # @bazel/runfiles seems broken with non-bzlmod + bazel7
+                    # https://github.com/bazel-contrib/rules_nodejs/issues/3797
+                    - bzlmod: 0
+                      folder: e2e/runfiles
                 include:
                     - bazel-version:
                           major: 7

--- a/e2e/runfiles/WORKSPACE
+++ b/e2e/runfiles/WORKSPACE
@@ -1,2 +1,25 @@
-# The presence of this file causes WORKSPACE to be ignored when bzlmod is enabled.
-# See https://docs.google.com/document/d/1JtXIVnXyFZ4bmbiBCr5gsTH4-opZAFf5DMMb-54kES0/edit#heading=h.y054fjub9max
+local_repository(
+    name = "aspect_rules_js",
+    path = "../..",
+)
+
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@aspect_rules_js//js:toolchains.bzl", "DEFAULT_NODE_VERSION", "rules_js_register_toolchains")
+
+rules_js_register_toolchains(node_version = DEFAULT_NODE_VERSION)
+
+load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock")
+
+npm_translate_lock(
+    name = "npm",
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+
+load("@npm//:repositories.bzl", "npm_repositories")
+
+npm_repositories()

--- a/e2e/runfiles/WORKSPACE.bzlmod
+++ b/e2e/runfiles/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# The presence of this file causes WORKSPACE to be ignored when bzlmod is enabled.
+# See https://docs.google.com/document/d/1JtXIVnXyFZ4bmbiBCr5gsTH4-opZAFf5DMMb-54kES0/edit#heading=h.y054fjub9max

--- a/examples/runfiles/BUILD.bazel
+++ b/examples/runfiles/BUILD.bazel
@@ -11,6 +11,12 @@ js_test(
         ":node_modules/@bazel/runfiles",
     ],
     entry_point = "test.js",
+    # @bazel/runfiles seems broken with non-bzlmod + bazel7
+    # https://github.com/bazel-contrib/rules_nodejs/issues/3797
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:bzlmod": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 # Path of file must start similar to `test_fixture.md` in order to regression-test a


### PR DESCRIPTION
See https://github.com/bazel-contrib/rules_nodejs/issues/3797

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
