### PR TITLE
fix: upgrade bazel-lib to include run_binary param parsing fix

### DIFF
--- a/.aspect/bazelrc/convenience.bazelrc
+++ b/.aspect/bazelrc/convenience.bazelrc
@@ -3,7 +3,7 @@
 build --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
-# fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
+# fail. This makes the log noisier in exchange for reducing the time-to-feedback on test failures for
 # users.
 # Docs: https://bazel.build/docs/user-manual#test-output
 test --test_output=errors

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -68,7 +68,7 @@ build --incompatible_default_to_explicit_init_py
 common --incompatible_disallow_empty_glob
 
 # Always download coverage files for tests from the remote cache. By default, coverage files are not
-# downloaded on test result cahce hits when --remote_download_minimal is enabled, making it impossible
+# downloaded on test result cache hits when --remote_download_minimal is enabled, making it impossible
 # to generate a full coverage report.
 # Docs: https://bazel.build/reference/command-line-reference#flag--experimental_fetch_all_coverage_outputs
 # detching remote cache results

--- a/.github/workflows/bazel7.bazelrc
+++ b/.github/workflows/bazel7.bazelrc
@@ -1,8 +1,12 @@
 # Speed up all builds by not checking if external repository files have been modified.
 # Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java#L244
-build --noexperimental_check_external_repository_files
-fetch --noexperimental_check_external_repository_files
-query --noexperimental_check_external_repository_files
+common --noexperimental_check_external_repository_files
+
+# Don't report when the root module's lower bound for a dependency happens to be less than the resolved version.
+# This is expected and should NOT prompt an engineer to update our lower bound to match.
+# WARNING: For repository 'aspect_bazel_lib', the root module requires module version aspect_bazel_lib@1.30.2,
+# but got aspect_bazel_lib@1.31.2 in the resolved dependency graph.
+common --check_direct_dependencies=off
 
 # Directories used by sandboxed non-worker execution may be reused to avoid unnecessary setup costs.
 # Save time on Sandbox creation and deletion when many of the same kind of action run during the

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 
 # Lower-bounds (minimum) versions for direct runtime dependencies.
 # Do not bump these unless rules_js requires a newer version to function.
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
+bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")

--- a/js/private/test/js_binary_sh/BUILD.bazel
+++ b/js/private/test/js_binary_sh/BUILD.bazel
@@ -162,11 +162,11 @@ build_test(
 assert_contains(
     name = "regexy-args-1",
     actual = ":regexy-stdout",
-    expected = "--arg1='/{{[{]?(.*?)[}]?}}/'",
+    expected = "--arg1=/{{[{]?(.*?)[}]?}}/",
 )
 
 assert_contains(
     name = "regexy-args-2",
     actual = ":regexy-stdout",
-    expected = "--arg2='/{%(.*?)%}/'",
+    expected = "--arg2=/{%(.*?)%}/",
 )


### PR DESCRIPTION
This is to include https://github.com/bazel-contrib/bazel-lib/commit/73d021fb368c67be40ae204a62cfa789e14515a7 which fixed a bug in `run_binary` and therefore `js_run_binary`.

Currently the rules_js WORKSPACE deps have this fix but bzlmod does not. This change upgrades the minimum bazel-lib version to include this fix.

The updated assertions align with running node outside bazel on the cli:
```
> echo 'console.log(`${process.argv[2]} + ${process.argv[3]}`)' | node - --x='3' '4'

--x=3 + 4
```

The stdout has no quotes despite the arguments being quoted. The tests updated in this change show rules_js now does the same.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
