### PR TITLE
chore: enable bazel6 ci tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
                     # Don't run replace_packages test with bzlmod+Bazel 6 due to use of Bazel 7 bzlmod features
                     - bazel-version:
                           major: 6
-                    - bzlmod: 1
+                      bzlmod: 1
                       folder: e2e/npm_translate_lock_replace_packages
                     # Don't run bzlmod tests with Bazel 6 to reduce the size of the test matrix
                     - bazel-version:


### PR DESCRIPTION
This seems to have been an accident and disabled all bazel6 testing by default.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
