### PR TITLE
perf(js_run_devserver): run fs delete operations in parallel

### DIFF
--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -302,7 +302,7 @@ async function deleteFiles(previousFiles, updatedFiles, sandbox) {
 
 // Sync list of files to the sandbox
 async function syncFiles(files, sandbox, writePerm) {
-    console.error(`+ Syncing ${files.length} files && folders...`)
+    console.error(`+ Syncing ${files.length} files & folders...`)
     const startTime = perf_hooks.performance.now()
 
     const [nodeModulesFiles, otherFiles] = partitionArray(


### PR DESCRIPTION
See individual commits. Primarily changing async fs operations to be run in parallel instead of sequentially.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
