### PR TITLE
fix(npm): add missing patch copy action key

### DIFF
--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -355,7 +355,7 @@ WARNING: Implicitly using patch file `{patch}` since the `{package_json}` file c
                     package_json = label_store.label("package_json_root"),
                 )
                 fail(msg)
-            _copy_input_file(priv, rctx, label_store, patch_key)
+            _copy_input_file(priv, rctx, attr, label_store, patch_key)
 
 ################################################################################
 def _has_input_hash(priv, path):


### PR DESCRIPTION
I have no idea if this will have any side-effects or fixes, but my ide highlighted that the args were wrong 😨 

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
