### PR TITLE
chore: update ci to bazel 7.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,14 +176,14 @@ jobs:
                 include:
                     - bazel-version:
                           major: 7
-                          version: 7.3.2
+                          version: 7.4.0
                       bzlmod: 1
                       os: windows
                       config: local
                       folder: e2e/bzlmod
                     - bazel-version:
                           major: 7
-                          version: 7.3.2
+                          version: 7.4.0
                       bzlmod: 1
                       os: macos
                       config: local


### PR DESCRIPTION
We updated `.bazelversion` but not CI.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
