### PR TITLE
docs: document exclude_types_from_npm_packages as deprecated

### DIFF
--- a/docs/npm_package.md
+++ b/docs/npm_package.md
@@ -64,8 +64,6 @@ using the `include_sources`, `include_transitive_sources`, `include_types`, `inc
 
 The two `include*_types` options may cause type-check actions to run, which slows down your
 development round-trip.
-You can pass the Bazel option `--@aspect_rules_js//npm:exclude_types_from_npm_packages`
-to override these two attributes for an individual `bazel` invocation, avoiding the type-check.
 
 As of rules_js 2.0, the recommended solution for avoiding eager type-checking when linking
 1p deps is to link `js_library` or any `JsInfo` producing targets directly without the

--- a/npm/BUILD.bazel
+++ b/npm/BUILD.bazel
@@ -10,12 +10,14 @@ exports_files(
 
 # Allows for faster dev roundtrip by excluding type-checking from libraries that are
 # internally used via npm_package
+# TODO(3.0): remove
 bool_flag(
     name = "exclude_types_from_npm_packages",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 
+# TODO(3.0): remove
 config_setting(
     name = "exclude_types_from_npm_packages_flag",
     flag_values = {":exclude_types_from_npm_packages": "true"},

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -195,8 +195,6 @@ def npm_package(
 
     The two `include*_types` options may cause type-check actions to run, which slows down your
     development round-trip.
-    You can pass the Bazel option `--@aspect_rules_js//npm:exclude_types_from_npm_packages`
-    to override these two attributes for an individual `bazel` invocation, avoiding the type-check.
 
     As of rules_js 2.0, the recommended solution for avoiding eager type-checking when linking
     1p deps is to link `js_library` or any `JsInfo` producing targets directly without the


### PR DESCRIPTION
With `js_library` always being recommended I think `npm_package` should be used almost exclusively for creating packages ready to be published and not for use as a runtime/type-checking dependency within the workspace.

The only remaining use case I can see for using `npm_package` instead of `js_library` would be to properly test a package in the same state it would be published. In that case this flag may still be useful, but is it worth maintaining for that use case?

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Deprecate `--@aspect_rules_js//npm:exclude_types_from_npm_packages`.

### Test plan

- Covered by existing test cases
