### PR TITLE
fix: properly report errors when lock file cannot be parsed

### DIFF
--- a/npm/private/pnpm.bzl
+++ b/npm/private/pnpm.bzl
@@ -531,12 +531,12 @@ def _parse_lockfile(parsed, err):
         A tuple of (importers dict, packages dict, patched_dependencies dict, error string)
     """
     if err != None or parsed == None or parsed == {}:
-        return {}, {}, {}, err
+        return {}, {}, {}, -1, err if err != None else "could not parse Yaml config"
 
     if not types.is_dict(parsed):
-        return {}, {}, {}, "lockfile should be a starlark dict"
+        return {}, {}, {}, -1, "lockfile should be a starlark dict"
     if not parsed.get("lockfileVersion", False):
-        return {}, {}, {}, "expected lockfileVersion key in lockfile"
+        return {}, {}, {}, -1, "expected lockfileVersion key in lockfile"
 
     # Lockfile version may be a float such as 5.4 or a string such as '6.0'
     lockfile_version = str(parsed["lockfileVersion"])


### PR DESCRIPTION
The function returns only 4 arguments upon errors, but 5 are expected and returned when everything succeeded.