### PR TITLE
test: override bazel-lib in e2e/bzlmod to include windows fix

### DIFF
--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -11,6 +11,15 @@ local_path_override(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.9.0", dev_dependency = True)
+
+# TODO: upgrade and remove override to include d042d563c6a91f7e11f66c42c83429199bd3d5d9
+archive_override(
+    module_name = "aspect_bazel_lib",
+    integrity = "sha256-iboa/H1J/MVDaY1OC/Ev0FUbu6SovyimC1cTkVmBC/c=",
+    strip_prefix = "bazel-lib-d042d563c6a91f7e11f66c42c83429199bd3d5d9",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/archive/d042d563c6a91f7e11f66c42c83429199bd3d5d9.tar.gz"],
+)
+
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
 


### PR DESCRIPTION
To include the bazel-lib windows fixes: https://github.com/bazel-contrib/bazel-lib/commit/d042d563c6a91f7e11f66c42c83429199bd3d5d9

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
