### PR TITLE
fix(npm): support pnpm v9.7+ patches without version specifier

### DIFF
--- a/e2e/pnpm_lockfiles/MODULE.bazel
+++ b/e2e/pnpm_lockfiles/MODULE.bazel
@@ -19,6 +19,7 @@ PNPM_LOCK_TEST_CASES = [
     "isaacs-cliui-v90.yaml",
     "docusaurus-direct-peer-v6.yaml",
     "docusaurus-direct-peer-v9.yaml",
+    "versionless-patch-v9.yaml",
 ]
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")

--- a/e2e/pnpm_lockfiles/README.md
+++ b/e2e/pnpm_lockfiles/README.md
@@ -12,3 +12,4 @@ cases run on each of those lockfiles.
 -   `override-with-alias-url-v9` - a package overridden with a different package
 -   `tarball-no-url-v54` - a package with a tarball but not a full URL
 -   `docusaurus-direct-peer-v*` - a direct dependency with a (peer=123) in the `importers` including within `npm:` dependencies
+-   `versionless-patch-v9`: pnpm v9.7+ allows patches without a version specifier

--- a/e2e/pnpm_lockfiles/WORKSPACE
+++ b/e2e/pnpm_lockfiles/WORKSPACE
@@ -18,6 +18,7 @@ PNPM_LOCK_TEST_CASES = [
     "isaacs-cliui-v90.yaml",
     "docusaurus-direct-peer-v6.yaml",
     "docusaurus-direct-peer-v9.yaml",
+    "versionless-patch-v9.yaml",
 ]
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
@@ -70,6 +71,7 @@ load("@docusaurus-direct-peer-v9//:repositories.bzl", npm_repositories_direct_wi
 load("@isaacs-cliui-v90//:repositories.bzl", npm_repositories_isaacs_cliui_v90 = "npm_repositories")
 load("@override-with-alias-url-v9//:repositories.bzl", npm_repositories_override_with_alias_v90 = "npm_repositories")
 load("@tarball-no-url-v54//:repositories.bzl", npm_repositories_tarball_no_url_v54 = "npm_repositories")
+load("@versionless-patch-v9//:repositories.bzl", npm_repositories_versionless_patch_v9 = "npm_repositories")
 
 npm_repositories_tarball_no_url_v54()
 
@@ -80,3 +82,5 @@ npm_repositories_isaacs_cliui_v90()
 npm_repositories_direct_with_peers_v6()
 
 npm_repositories_direct_with_peers_v9()
+
+npm_repositories_versionless_patch_v9()

--- a/e2e/pnpm_lockfiles/cases/BUILD.bazel
+++ b/e2e/pnpm_lockfiles/cases/BUILD.bazel
@@ -1,9 +1,11 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@docusaurus-direct-peer-v6//:defs.bzl", docusaurus_direct_with_peers_v6_link_all = "npm_link_all_packages")
 load("@docusaurus-direct-peer-v9//:defs.bzl", docusaurus_direct_with_peers_v9_link_all = "npm_link_all_packages")
 load("@isaacs-cliui-v90//:defs.bzl", isaacs_cliui_v90_link_all = "npm_link_all_packages")
 load("@override-with-alias-url-v9//:defs.bzl", override_with_alias_link_all = "npm_link_all_packages")
 load("@tarball-no-url-v54//:defs.bzl", tarball_no_url_link_all = "npm_link_all_packages")
+load("@versionless-patch-v9//:defs.bzl", versionless_patch_link_all = "npm_link_all_packages")
 
 exports_files(glob(["*.yaml"]))
 
@@ -51,4 +53,22 @@ build_test(
         # ":docusaurus_direct_with_peers_v6-modules",
         # ":docusaurus_direct_with_peers_v6-modules/@docusaurus/module-type-aliases",
     ],
+)
+
+versionless_patch_link_all(name = "versionless_patch_link_all-modules")
+
+build_test(
+    name = "versionless_patch_targets",
+    targets = [
+        ":versionless_patch_link_all-modules",
+        ":versionless_patch_link_all-modules/@aspect-test/e",
+    ],
+)
+
+js_test(
+    name = "versionless_patch_test",
+    data = [
+        ":versionless_patch_link_all-modules/@aspect-test/e",
+    ],
+    entry_point = "versionless-patch.spec.js",
 )

--- a/e2e/pnpm_lockfiles/cases/patches/aspect-test-e-pnpm.patch
+++ b/e2e/pnpm_lockfiles/cases/patches/aspect-test-e-pnpm.patch
@@ -1,0 +1,10 @@
+diff --git a/index.js b/index.js
+index 0e29dc2..6ae6e90 100644
+--- a/index.js
++++ b/index.js
+@@ -1,4 +1,5 @@
+ const packageJson = require('./package.json')
+ module.exports = {
+   id: () => `${packageJson.name}@${packageJson.version}`,
++  PATCHED: 123,
+ }

--- a/e2e/pnpm_lockfiles/cases/versionless-patch-v9.yaml
+++ b/e2e/pnpm_lockfiles/cases/versionless-patch-v9.yaml
@@ -1,0 +1,28 @@
+lockfileVersion: '9.0'
+
+settings:
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
+
+patchedDependencies:
+    '@aspect-test/e':
+        hash: nc75t5kilw6vcobzaxylgmmg74
+        path: patches/aspect-test-e-pnpm.patch
+
+importers:
+    .:
+        dependencies:
+            '@aspect-test/e':
+                specifier: ^1.0.0
+                version: 1.0.0(patch_hash=nc75t5kilw6vcobzaxylgmmg74)
+
+packages:
+    '@aspect-test/e@1.0.0':
+        resolution:
+            {
+                integrity: sha512-GyAxHYKN650db+xnimHnL2LPz65ilmQsVhCasWA7drDNQn/rfmPiEVMzjRiS7m46scXIERaBmiJMzYDf0bIUbA==,
+            }
+        hasBin: true
+
+snapshots:
+    '@aspect-test/e@1.0.0(patch_hash=nc75t5kilw6vcobzaxylgmmg74)': {}

--- a/e2e/pnpm_lockfiles/cases/versionless-patch.spec.js
+++ b/e2e/pnpm_lockfiles/cases/versionless-patch.spec.js
@@ -1,0 +1,5 @@
+const libE = require('@aspect-test/e')
+
+if (libE.PATCHED !== 123) {
+    throw new Error('Failed to patch @aspect-test/e')
+}

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -327,7 +327,7 @@ def _get_npm_imports(importers, packages, patched_dependencies, only_built_depen
 
         translate_patches, patches_keys = _gather_values_from_matching_names(True, attr.patches, name, friendly_name, unfriendly_name)
 
-        pnpm_patch = patched_dependencies.get(friendly_name, {}).get("path", None)
+        pnpm_patch = patched_dependencies.get(friendly_name, patched_dependencies.get(name, None))
         pnpm_patched = pnpm_patch != None
 
         if len(translate_patches) > 0 and pnpm_patched:
@@ -340,7 +340,7 @@ ERROR: can not apply both `pnpm.patchedDependencies` and `npm_translate_lock(pat
 
         # Apply patch from `pnpm.patchedDependencies` first
         if pnpm_patched:
-            patch_path = "//%s:%s" % (attr.pnpm_lock.package, pnpm_patch)
+            patch_path = "//%s:%s" % (attr.pnpm_lock.package, pnpm_patch.get("path"))
             patches.append(patch_path)
 
             # pnpm patches are always applied with -p1


### PR DESCRIPTION
Fix #2031

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

PNPM v9.7+ supports `pnpm.patchedDependencies` specifiers with no version specified.

### Test plan

- New test cases added
