### PR TITLE
fix(npm): correct use of pnpm lockfile dev flag

### DIFF
--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -277,7 +277,7 @@ def _get_npm_imports(importers, packages, patched_dependencies, only_built_depen
         friendly_version = package_info.get("friendly_version")
         deps = package_info.get("dependencies")
         optional_deps = package_info.get("optional_dependencies")
-        dev = package_info.get("dev")
+        dev_only = package_info.get("dev_only")
         optional = package_info.get("optional")
         requires_build = package_info.get("requires_build")
         transitive_closure = package_info.get("transitive_closure")
@@ -302,12 +302,14 @@ def _get_npm_imports(importers, packages, patched_dependencies, only_built_depen
             msg = "expected package {} resolution to have an integrity or tarball field but found none".format(package_key)
             fail(msg)
 
-        if attr.prod and dev:
-            # when prod attribute is set, skip devDependencies
+        if attr.prod and dev_only:
+            # When prod attribute is set, skip deps explicitly marked as dev in the lockfile.
+            #
+            # NOTE: this only excludes packages explicitly marked as dev-only in the lockfile
+            # to avoid further processing. Some packages may be used as both dev and non-dev within
+            # the workspace and therefor will not be marked as dev in the lockfile.
             continue
-        if attr.dev and not dev:
-            # when dev attribute is set, skip (non-dev) dependencies
-            continue
+
         if attr.no_optional and optional:
             # when no_optional attribute is set, skip optionalDependencies
             continue
@@ -465,7 +467,7 @@ ERROR: can not apply both `pnpm.patchedDependencies` and `npm_translate_lock(pat
             version = version,
             bins = bins,
             package_info = package_info,
-            dev = dev,
+            dev = dev_only,
             replace_package = replace_package,
         )
 

--- a/npm/private/pnpm.bzl
+++ b/npm/private/pnpm.bzl
@@ -32,13 +32,13 @@ def _new_import_info(dependencies, dev_dependencies, optional_dependencies):
 #
 # Metadata may come from different locations depending on the lockfile, this struct should
 # have data normalized across lockfiles.
-def _new_package_info(id, name, dependencies, optional_dependencies, dev, has_bin, optional, requires_build, version, friendly_version, resolution):
+def _new_package_info(id, name, dependencies, optional_dependencies, dev_only, has_bin, optional, requires_build, version, friendly_version, resolution):
     return {
         "id": id,
         "name": name,
         "dependencies": dependencies,
         "optional_dependencies": optional_dependencies,
-        "dev": dev,
+        "dev_only": dev_only,
         "has_bin": has_bin,
         "optional": optional,
         "requires_build": requires_build,
@@ -195,7 +195,7 @@ def _convert_v5_packages(packages):
             friendly_version = friendly_version,
             dependencies = _convert_pnpm_v5_package_dependency_map(package_snapshot.get("dependencies", {})),
             optional_dependencies = _convert_pnpm_v5_package_dependency_map(package_snapshot.get("optionalDependencies", {})),
-            dev = package_snapshot.get("dev", False),
+            dev_only = package_snapshot.get("dev", False),
             has_bin = package_snapshot.get("hasBin", False),
             optional = package_snapshot.get("optional", False),
             requires_build = package_snapshot.get("requiresBuild", False),
@@ -362,7 +362,7 @@ def _convert_v6_packages(packages):
             friendly_version = friendly_version,
             dependencies = _convert_pnpm_v6_package_dependency_map(package_snapshot.get("dependencies", {})),
             optional_dependencies = _convert_pnpm_v6_package_dependency_map(package_snapshot.get("optionalDependencies", {})),
-            dev = package_snapshot.get("dev", False),
+            dev_only = package_snapshot.get("dev", False),
             has_bin = package_snapshot.get("hasBin", False),
             optional = package_snapshot.get("optional", False),
             requires_build = package_snapshot.get("requiresBuild", False),
@@ -492,7 +492,7 @@ def _convert_v9_packages(packages, snapshots):
             friendly_version = friendly_version,
             dependencies = _convert_pnpm_v9_package_dependency_map(snapshots, package_snapshot.get("dependencies", {})),
             optional_dependencies = _convert_pnpm_v9_package_dependency_map(snapshots, package_snapshot.get("optionalDependencies", {})),
-            dev = None,  # TODO(pnpm9): must inspect importers.*.devDependencies?
+            dev_only = None,  # NOTE: pnpm v9+ no longer marks packages as dev-only
             has_bin = package_data.get("hasBin", False),
             optional = package_snapshot.get("optional", False),
             requires_build = None,  # Unknown from lockfile in v9

--- a/npm/private/test/parse_pnpm_lock_tests.bzl
+++ b/npm/private/test/parse_pnpm_lock_tests.bzl
@@ -34,7 +34,7 @@ expected_packages = {
             "@aspect-test/d": "2.0.0_at_aspect-test_c_1.0.0",
         },
         "optional_dependencies": {},
-        "dev": False,
+        "dev_only": False,
         "has_bin": True,
         "optional": False,
         "requires_build": False,
@@ -171,7 +171,7 @@ def _parse_lockfile_v9_test_impl(ctx):
     # NOTE: unknown properties in >=v9
     v9_expected_packages = dict(expected_packages)
     v9_expected_packages["@aspect-test/a@5.0.0"] = dict(v9_expected_packages["@aspect-test/a@5.0.0"])
-    v9_expected_packages["@aspect-test/a@5.0.0"]["dev"] = None
+    v9_expected_packages["@aspect-test/a@5.0.0"]["dev_only"] = None
     v9_expected_packages["@aspect-test/a@5.0.0"]["requires_build"] = None
 
     expected = (


### PR DESCRIPTION
Fix the usage of the lockfile `dev` flag, rename vars where possible to better indicate the meaning.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce: https://github.com/jbedard/rules_js/commit/cf3f12a7194e62b8194afa596fc0213b23df7bd8 and toggling `npm_translate_lock` `dev` and `prod` flags.
