### PR TITLE
fix(npm): use bazel 8 rctx.watch for pnpm-lock

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -99,6 +99,9 @@ def _npm_translate_lock_impl(rctx):
     if not rctx.attr.pnpm_lock:
         _bootstrap_import(rctx, state)
 
+    if rctx.attr.pnpm_lock and hasattr(rctx, "watch"):
+        rctx.watch(rctx.attr.pnpm_lock)
+
     if state.should_update_pnpm_lock():
         # Run `pnpm install --lockfile-only` or `pnpm import` if its inputs have changed since last update
         if state.action_cache_miss():


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan
- Manual testing; please provide instructions so we can reproduce:

Used: https://github.com/aspect-build/rules_js/issues/2070 as reproduction steps

Create e package.json with atleast one package with a strict version.
Add Bazel build with update_pnpm_lock set to False
Run Bazel build
Change the version of the package
Run bazel query for this package similar to: `bazel query "filter('is-odd', kind(npm_package, //...))" --output=build`

Expected: New version to be observed
Real: Older version is observed
After fix real: New version is observed
