### PR TITLE
refactor: fix locale spam from tar

### DIFF
--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -245,8 +245,9 @@ def _npm_package_store_impl(ctx):
                     # Workaround https://github.com/bazelbuild/bazel-central-registry/issues/2256
                     # Always override the locale to give better hermeticity.
                     # See https://github.com/bazelbuild/rules_java/blob/767e4410850453a10ccf89aa1cededf9de05c72e/toolchains/utf8_environment.bzl
+                    # and https://github.com/libarchive/libarchive/blob/65196fdd1a385f22114f245a9002ee8dc899f2c4/tar/bsdtar.c#L192
                     env = {
-                        "LC_CTYPE":
+                        "LC_ALL":
                         # # macOS doesn't have the C.UTF-8 locale, but en_US.UTF-8 is available and works the same way.
                         "en_US.UTF-8" if is_macos else
                         # The default UTF-8 locale on all recent Linux distributions. It is also available in Cygwin and MSYS2.


### PR DESCRIPTION
Based on feedback from users, we have to set this specific env variable for bsdtar or every invocation prints
```
INFO: From Extracting npm package @opentelemetry/sdk-metrics@1.27.0_at_opentelemetry_api_1.4.1:
tar: Failed to set default locale
```

---

### Changes are visible to end-users: no
