### PR TITLE
chore: remove unused rules_go dev dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,7 +48,6 @@ use_repo(bazel_lib_toolchains, "bsd_tar_toolchains")
 
 bazel_dep(name = "aspect_rules_lint", version = "1.0.2", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.50.1", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 
 host = use_extension(
@@ -240,15 +239,3 @@ use_repo(
     "acorn__8.4.0",
     "acorn__8.4.0__links",
 )
-
-# Used by formatter
-go_sdk = use_extension(
-    "@rules_go//go:extensions.bzl",
-    "go_sdk",
-    dev_dependency = True,
-)
-go_sdk.download(
-    name = "go_sdk",
-    version = "1.20.3",
-)
-use_repo(go_sdk, "go_sdk")

--- a/e2e/js_run_devserver/MODULE.bazel
+++ b/e2e/js_run_devserver/MODULE.bazel
@@ -6,7 +6,6 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.46.0", dev_dependency = True)
 
 pnpm = use_extension(
     "@aspect_rules_js//npm:extensions.bzl",
@@ -33,16 +32,3 @@ npm.npm_translate_lock(
     verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "npm")
-
-go_sdk = use_extension(
-    "@rules_go//go:extensions.bzl",
-    "go_sdk",
-    dev_dependency = True,
-)
-go_sdk.download(
-    name = "go_sdk",
-    version = "1.20.3",
-)
-use_repo(go_sdk, "go_sdk")
-
-register_toolchains("@go_sdk//:all")

--- a/e2e/js_run_devserver/WORKSPACE
+++ b/e2e/js_run_devserver/WORKSPACE
@@ -33,18 +33,6 @@ npm_repositories()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "80a98277ad1311dacd837f9b16db62887702e9f1d1c4c9f796d0121a46c8e184",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.20.5")
-
-http_archive(
     name = "com_github_ash2k_bazel_tools",
     sha256 = "a911dab6711bc12a00f02cc94b66ced7dc57650e382ebd4f17c9cdb8ec2cbd56",
     strip_prefix = "bazel-tools-2add5bb84c2837a82a44b57e83c7414247aed43a",

--- a/e2e/webpack_devserver/MODULE.bazel
+++ b/e2e/webpack_devserver/MODULE.bazel
@@ -6,7 +6,6 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.46.0", dev_dependency = True)
 
 npm = use_extension(
     "@aspect_rules_js//npm:extensions.bzl",
@@ -27,16 +26,3 @@ pnpm = use_extension(
     dev_dependency = True,
 )
 use_repo(pnpm, "pnpm")
-
-go_sdk = use_extension(
-    "@rules_go//go:extensions.bzl",
-    "go_sdk",
-    dev_dependency = True,
-)
-go_sdk.download(
-    name = "go_sdk",
-    version = "1.20.3",
-)
-use_repo(go_sdk, "go_sdk")
-
-register_toolchains("@go_sdk//:all")

--- a/e2e/webpack_devserver/WORKSPACE
+++ b/e2e/webpack_devserver/WORKSPACE
@@ -27,18 +27,6 @@ npm_repositories()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "80a98277ad1311dacd837f9b16db62887702e9f1d1c4c9f796d0121a46c8e184",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.20.5")
-
-http_archive(
     name = "com_github_ash2k_bazel_tools",
     sha256 = "a911dab6711bc12a00f02cc94b66ced7dc57650e382ebd4f17c9cdb8ec2cbd56",
     strip_prefix = "bazel-tools-2add5bb84c2837a82a44b57e83c7414247aed43a",

--- a/e2e/webpack_devserver_esm/MODULE.bazel
+++ b/e2e/webpack_devserver_esm/MODULE.bazel
@@ -6,7 +6,6 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.46.0", dev_dependency = True)
 
 npm = use_extension(
     "@aspect_rules_js//npm:extensions.bzl",
@@ -27,16 +26,3 @@ pnpm = use_extension(
     dev_dependency = True,
 )
 use_repo(pnpm, "pnpm")
-
-go_sdk = use_extension(
-    "@rules_go//go:extensions.bzl",
-    "go_sdk",
-    dev_dependency = True,
-)
-go_sdk.download(
-    name = "go_sdk",
-    version = "1.20.3",
-)
-use_repo(go_sdk, "go_sdk")
-
-register_toolchains("@go_sdk//:all")

--- a/e2e/webpack_devserver_esm/WORKSPACE
+++ b/e2e/webpack_devserver_esm/WORKSPACE
@@ -27,18 +27,6 @@ npm_repositories()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "80a98277ad1311dacd837f9b16db62887702e9f1d1c4c9f796d0121a46c8e184",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.20.5")
-
-http_archive(
     name = "com_github_ash2k_bazel_tools",
     sha256 = "a911dab6711bc12a00f02cc94b66ced7dc57650e382ebd4f17c9cdb8ec2cbd56",
     strip_prefix = "bazel-tools-2add5bb84c2837a82a44b57e83c7414247aed43a",


### PR DESCRIPTION
I don't know why this was here? The e2e rules_docker test specifies it's there to fix a rules_docker bug so I left it there.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
