### PR TITLE
devserver: use readline instead of reading from raw stdin

### DIFF
--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -4,6 +4,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as child_process from 'node:child_process'
 import * as crypto from 'node:crypto'
+import * as readline from 'node:readline'
 
 // Globals
 const RUNFILES_ROOT = path.join(
@@ -452,10 +453,11 @@ async function main(args, sandbox) {
         })
 
         // Process stdin data in order using a promise chain.
-        let syncing = Promise.resolve()
-        process.stdin.on('data', async (chunk) => {
-            return (syncing = syncing.then(() => processChunk(chunk)))
-        })
+        let syncing = Promise.resolve();
+        const rl = readline.createInterface({ input: process.stdin });
+        rl.on('line', (line) => {
+            syncing = syncing.then(() => processChunk(line));
+        });
 
         async function processChunk(chunk) {
             try {


### PR DESCRIPTION
Without this change, it is theoretically possible for the `IBAZEL_*` messages to be combined in to one chunk, or have one message be split across other chunks. This would cause the `.includes` checks to either fail to see a message, or only see one message when in reality both were present.

### Changes are visible to end-users: no

### Test plan

This is somewhat difficult to test as it depends on timing. It does seem to reliably happen when the devserver is first starting up and receives a bunch of messages quickly as it hasn't processed any of them yet.