### PR TITLE
Update pnpm workspace example in docs to avoid edge cases

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,21 +109,15 @@ $ bazel fetch @npm//...
 
 ### Using pnpm workspaces
 
-Here's an example `pnpm-workspace.yaml` file which will automatically discover all packages in the repository, based on the existence of a `package.json` file.
+Here's an example `pnpm-workspace.yaml` file which will find all projects listed under `deeply_nested_project`, `users`, and `experimental`, based on the existence of a `package.json` file.
+
 Make sure to place this file at the root of the repository.
 
 ```yaml
 packages:
-  # Include all directories in the workspace
-  - '*'
-  # Include all subdirectories at any depth
-  - '**/*'
-  # Exclude node_modules folders anywhere in the tree
-  - '!**/node_modules/**'
-  # Exclude node_modules folder in root
-  - '!node_modules'
-  # Exclude anything inside bazel dirs
-  - '!bazel-*/**'
+  - 'deeply_nested_project/**'
+  - 'users/**'
+  - 'experimental/**'
 ```
 
 ### Link the node_modules

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,7 +109,7 @@ $ bazel fetch @npm//...
 
 ### Using pnpm workspaces
 
-Here's an example `pnpm-workspace.yaml` file which will find all projects listed under `deeply_nested_project`, `users`, and `experimental`, based on the existence of a `package.json` file.
+Here's an example `pnpm-workspace.yaml` file which will find all projects under `apps` or `packages` at any depth, and anything directly under `tools`, based on the existence of a `package.json` file.
 
 Make sure to place this file at the root of the repository.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,9 +115,9 @@ Make sure to place this file at the root of the repository.
 
 ```yaml
 packages:
-  - 'deeply_nested_project/**'
-  - 'users/**'
-  - 'experimental/**'
+  - 'apps/**'
+  - 'packages/**'
+  - 'tools/*'
 ```
 
 ### Link the node_modules


### PR DESCRIPTION
The previous approach does not seem stable .

It was working with initial tests but now it's not, and I'd hate for someone to encounter this sort of snag based on my contribution.

Here's the type of error I was seeing

```
RR_PNPM_WORKSPACE_PKG_NOT_FOUND  In ../../../../../../../../external/aspect_rules_js+/js/private/test/image: "@mycorp/pkg-a@workspace:*" is in the dependencies but no package named "@mycorp/pkg-a" is present in the workspace
```

This happens if you add anything like - `'./**/*'` , `- '**'` , or `- '*'`  to workspace packages. It doesn't seem to matter if you have `- !..` , it still tries to look there.

So this new approach is to manually add project dirs and their subfolders. Easy enough.

```
- 'experimental/**'
- 'users/**'
- 'some_deeply_nested_project/**'
```