### PR TITLE
devserver: skip unlink when possible

### DIFF
--- a/e2e/js_run_devserver/src/BUILD.bazel
+++ b/e2e/js_run_devserver/src/BUILD.bazel
@@ -121,6 +121,7 @@ js_run_devserver(
         ":web_files",
     ],
     log_level = "debug",
+    grant_sandbox_write_permissions = True,
 )
 
 # Now the js_binary variant
@@ -141,6 +142,7 @@ js_run_devserver(
     ],
     log_level = "debug",
     tool = ":simple_bin",
+    grant_sandbox_write_permissions = True,
 )
 
 # Intentionally a js_library and not a js_binary to test that transitive npm are

--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -219,9 +219,14 @@ async function syncRecursive(src, dst, sandbox, writePerm) {
                     )} (${friendlyFileSize(lstat.size)})`
                 )
             }
-            if (exists) {
+            // unlink file if it exists, unless `writePerm` is true or we are not on Linux
+            // on macOS, and possibly other operating systems, you get errors if you copy
+            // over a file without the necessary permissions
+            let unlinkIsNecessary = writePerm || process.platform !== "linux";
+            if (exists && unlinkIsNecessary) {
                 await fs.promises.unlink(dst)
-            } else {
+            }
+            if (!exists) {
                 // Intentionally synchronous; see comment on mkdirpSync
                 mkdirpSync(path.dirname(dst))
             }

--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -214,17 +214,9 @@ async function syncRecursive(src, dst, sandbox, writePerm) {
 
             if (process.env.JS_BINARY__LOG_DEBUG) {
                 console.error(
-                    `Syncing file ${src.slice(
-                        RUNFILES_ROOT.length + 1
-                    )} (${friendlyFileSize(lstat.size)})`
+                    `Syncing file ${src} (${friendlyFileSize(lstat.size)}) to ${dst}`
                 )
-            }
-            // unlink file if it exists, unless `writePerm` is true or we are not on Linux
-            // on macOS, and possibly other operating systems, you get errors if you copy
-            // over a file without the necessary permissions
-            let unlinkIsNecessary = writePerm || process.platform !== "linux";
-            if (exists && unlinkIsNecessary) {
-                await fs.promises.unlink(dst)
+                console.error(`Dst exists: ${exists}`)
             }
             if (!exists) {
                 // Intentionally synchronous; see comment on mkdirpSync


### PR DESCRIPTION
Without this change we incur the cost of an extra unnecessary syscall on every file we need to sync. In my testing this didn't make a perceivable difference with small sets of changed files, however it could make a difference on large ones.

This change works just fine on Linux. However, on macOS you get a permission error if you try to copy over an existing file without `grant_sandbox_write_permissions = True`. So on macOS we only enable this optimization if `grant_sandbox_write_permissions == True`, otherwise we `unlink` the file like we did before.

---

### Changes are visible to end-users: no

### Test plan
Existing tests

If it is possible to write a test that only runs on macOS, we could test that code path. However, I'm not sure how feasible that is.
