### PR TITLE
Add new idea bazel plugin folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ node_modules/
 # [MODULE.bazel.lock file "reads through" already-locked package manager](https://github.com/bazelbuild/bazel/issues/20272)
 # [moduleFileHash in MODULE.bazel.lock causes frequent Git merge conflicts](https://github.com/bazelbuild/bazel/issues/20369)
 MODULE.bazel.lock
+
+.bazelbsp

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 
 .idea/
 .ijwb/
+.bazelbsp/
 .vscode
 .DS_Store
 
@@ -16,5 +17,3 @@ node_modules/
 # [MODULE.bazel.lock file "reads through" already-locked package manager](https://github.com/bazelbuild/bazel/issues/20272)
 # [moduleFileHash in MODULE.bazel.lock causes frequent Git merge conflicts](https://github.com/bazelbuild/bazel/issues/20369)
 MODULE.bazel.lock
-
-.bazelbsp


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan
- Covered by existing test cases

Just a developer improvement if the rules_js dev is using the new idea Bazel plugin: https://plugins.jetbrains.com/plugin/22977-bazel-eap-

This plugin creates this folder for keeping the project view. I think it should be ignored as it is specific to the used IDE of the rules_js dev.