### PR TITLE
[chore] fix CI test, disable performance optimization for js_run_devserver e2e test

### DIFF
--- a/e2e/js_run_devserver/.bazelrc
+++ b/e2e/js_run_devserver/.bazelrc
@@ -13,3 +13,7 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 # should be last statement in this config so the user configuration is able to overwrite flags from
 # this file. See https://bazel.build/configure/best-practices#bazelrc-file.
 try-import %workspace%/../../.aspect/bazelrc/user.bazelrc
+
+# An override of the performance.bazelrc setting
+# This is needed as Bazel fails to detect a new file when added during an iBazel execution
+build --build_runfile_links


### PR DESCRIPTION
Related to: https://github.com/bazelbuild/bazel/issues/6627
Test was broken by a performance optimization: https://github.com/aspect-build/rules_js/commit/5522ff8c4bd970598497dcfc98363899e91b36e0#diff-7e21af0f988e602e8c7f2058dbed8d5e92b044c8d833e3795bb7a8c84a13425aR15

Proposed fix is to stop the optimization for this test.

---

### Changes are visible to end-users: no

### Test plan
- Covered by existing test cases
