### PR TITLE
[feat] handle star pattern in exclude package contents

### DIFF
--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -550,7 +550,7 @@ def _gen_npm_import(rctx, system_tar, _import, link_workspace):
     maybe_replace_package = ("""
         replace_package = "%s",""" % _import.replace_package) if _import.replace_package else ""
     maybe_exclude_package_contents = ("""
-        exclude_package_contents = %s,""" % _import.exclude_package_contents) if len(_import.exclude_package_contents) > 0 else ""
+        exclude_package_contents = %s,""" % _import.exclude_package_contents) if _import.exclude_package_contents != None else ""
 
     return _NPM_IMPORT_TMPL.format(
         link_packages = starlark_codegen_utils.to_dict_attr(_import.link_packages, 2, quote_value = False),

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -73,9 +73,9 @@ def _gather_unique_values_from_matching_names(additive, keyed_lists, *names):
 
     # in case the key has not been met even once, we return None, instead of empty list as empty list is a valid value
     if not keys:
-        return (None, keys)
+        return None
 
-    return (result.keys(), keys)
+    return result.keys()
 
 ################################################################################
 def _gather_values_from_matching_names(additive, keyed_lists, *names):
@@ -391,7 +391,7 @@ ERROR: can not apply both `pnpm.patchedDependencies` and `npm_translate_lock(pat
         patches = [("@" if patch.startswith("//") else "") + patch for patch in patches]
 
         # gather exclude patterns
-        exclude_package_contents, _ = _gather_unique_values_from_matching_names(True, attr.exclude_package_contents, name, friendly_name, unfriendly_name)
+        exclude_package_contents = _gather_unique_values_from_matching_names(True, attr.exclude_package_contents, name, friendly_name, unfriendly_name)
 
         # gather replace packages
         replace_packages, _ = _gather_values_from_matching_names(True, attr.replace_packages, name, friendly_name, unfriendly_name)

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -48,6 +48,36 @@ Check the public_hoist_packages attribute for duplicates.
                 fail(msg)
 
 ################################################################################
+def _gather_unique_values_from_matching_names(additive, keyed_lists, *names):
+    keys = []
+    result = {}
+    for name in names:
+        if name and (name in keyed_lists or "*" in keyed_lists):
+            keys.append(name)
+            v = keyed_lists[name] if name in keyed_lists else keyed_lists["*"]
+            if additive:
+                if type(v) == "list":
+                    for item in v:
+                        result[item] = []
+                elif type(v) == "string":
+                    result[v] = []
+                else:
+                    fail("expected value to be list or string")
+            elif type(v) == "list":
+                for item in v:
+                    result[item] = []
+            elif type(v) == "string":
+                result[v] = []
+            else:
+                fail("expected value to be list or string")
+
+    # in case the key has not been met even once, we return None, instead of empty list as empty list is a valid value
+    if not keys:
+        return (None, keys)
+
+    return (result.keys(), keys)
+
+################################################################################
 def _gather_values_from_matching_names(additive, keyed_lists, *names):
     keys = []
     result = []
@@ -361,7 +391,7 @@ ERROR: can not apply both `pnpm.patchedDependencies` and `npm_translate_lock(pat
         patches = [("@" if patch.startswith("//") else "") + patch for patch in patches]
 
         # gather exclude patterns
-        exclude_package_contents, _ = _gather_values_from_matching_names(True, attr.exclude_package_contents, name, friendly_name, unfriendly_name)
+        exclude_package_contents, _ = _gather_unique_values_from_matching_names(True, attr.exclude_package_contents, name, friendly_name, unfriendly_name)
 
         # gather replace packages
         replace_packages, _ = _gather_values_from_matching_names(True, attr.replace_packages, name, friendly_name, unfriendly_name)

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -48,22 +48,14 @@ Check the public_hoist_packages attribute for duplicates.
                 fail(msg)
 
 ################################################################################
-def _gather_unique_values_from_matching_names(additive, keyed_lists, *names):
+def _gather_package_content_excludes(keyed_lists, *names):
     keys = []
     result = {}
     for name in names:
         if name and (name in keyed_lists or "*" in keyed_lists):
             keys.append(name)
             v = keyed_lists[name] if name in keyed_lists else keyed_lists["*"]
-            if additive:
-                if type(v) == "list":
-                    for item in v:
-                        result[item] = []
-                elif type(v) == "string":
-                    result[v] = []
-                else:
-                    fail("expected value to be list or string")
-            elif type(v) == "list":
+            if type(v) == "list":
                 for item in v:
                     result[item] = []
             elif type(v) == "string":
@@ -391,7 +383,7 @@ ERROR: can not apply both `pnpm.patchedDependencies` and `npm_translate_lock(pat
         patches = [("@" if patch.startswith("//") else "") + patch for patch in patches]
 
         # gather exclude patterns
-        exclude_package_contents = _gather_unique_values_from_matching_names(True, attr.exclude_package_contents, name, friendly_name, unfriendly_name)
+        exclude_package_contents = _gather_package_content_excludes(attr.exclude_package_contents, name, friendly_name, unfriendly_name)
 
         # gather replace packages
         replace_packages, _ = _gather_values_from_matching_names(True, attr.replace_packages, name, friendly_name, unfriendly_name)
@@ -679,4 +671,5 @@ helpers = struct(
 # exported for unit testing
 helpers_testonly = struct(
     find_missing_bazel_ignores = _find_missing_bazel_ignores,
+    gather_package_content_excludes = _gather_package_content_excludes,
 )

--- a/npm/private/test/translate_lock_helpers_tests.bzl
+++ b/npm/private/test/translate_lock_helpers_tests.bzl
@@ -65,5 +65,76 @@ def test_verify_ignores_in_subdir(ctx):
 t0_test = unittest.make(test_verify_ignores_in_root)
 t1_test = unittest.make(test_verify_ignores_in_subdir)
 
+# buildifier: disable=function-docstring
+def test_verify_gather_package_content_works_with_simple_name(ctx):
+    env = unittest.begin(ctx)
+    actual = helpers_testonly.gather_package_content_excludes(
+        {
+            "packageA": ["pattern1", "pattern2"],
+        },
+        "packageA",
+    )
+    expected = ["pattern1", "pattern2"]
+    asserts.equals(env, expected, actual)
+    return unittest.end(env)
+
+# buildifier: disable=function-docstring
+def test_verify_gather_package_content_works_with_star_pattern(ctx):
+    env = unittest.begin(ctx)
+    actual = helpers_testonly.gather_package_content_excludes(
+        {
+            "*": ["pattern1", "pattern2"],
+        },
+        "packageA",
+    )
+    expected = ["pattern1", "pattern2"]
+    asserts.equals(env, expected, actual)
+    return unittest.end(env)
+
+# buildifier: disable=function-docstring
+def test_verify_gather_package_content_works_with_simple_name_and_single_pattern(ctx):
+    env = unittest.begin(ctx)
+    actual = helpers_testonly.gather_package_content_excludes(
+        {
+            "packageA": "pattern1",
+        },
+        "packageA",
+    )
+    expected = ["pattern1"]
+    asserts.equals(env, expected, actual)
+    return unittest.end(env)
+
+# buildifier: disable=function-docstring
+def test_verify_gather_package_content_works_with_star_pattern_and_only_one_exclude_pattern(ctx):
+    env = unittest.begin(ctx)
+    actual = helpers_testonly.gather_package_content_excludes(
+        {
+            "*": "pattern1",
+        },
+        "packageA",
+    )
+    expected = ["pattern1"]
+    asserts.equals(env, expected, actual)
+    return unittest.end(env)
+
+# buildifier: disable=function-docstring
+def test_verify_gather_package_content_returns_none_when_no_matches(ctx):
+    env = unittest.begin(ctx)
+    actual = helpers_testonly.gather_package_content_excludes(
+        {
+            "packageB": "pattern1",
+        },
+        "packageA",
+    )
+    expected = None
+    asserts.equals(env, expected, actual)
+    return unittest.end(env)
+
+t2_test = unittest.make(test_verify_gather_package_content_works_with_simple_name)
+t3_test = unittest.make(test_verify_gather_package_content_works_with_star_pattern)
+t4_test = unittest.make(test_verify_gather_package_content_works_with_simple_name_and_single_pattern)
+t5_test = unittest.make(test_verify_gather_package_content_works_with_star_pattern_and_only_one_exclude_pattern)
+t6_test = unittest.make(test_verify_gather_package_content_returns_none_when_no_matches)
+
 def translate_lock_helpers_tests(name):
-    unittest.suite(name, t0_test, t1_test)
+    unittest.suite(name, t0_test, t1_test, t2_test, t3_test, t4_test, t5_test, t6_test)


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

feat: exclude package contents now accepts also star pattern for selecting all npm packages in the package-lock.json

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Tested with manually adding * as a pattern to the e2e test for exclude patterns and checking the result.

TODO: Discuss if we want to merge the * pattern excludes with the specific modules excludes and make a test for the decided approach.