### PR TITLE
fix: bzlmod invalid lockfile entry error

### DIFF
--- a/npm/private/repository_label_store.bzl
+++ b/npm/private/repository_label_store.bzl
@@ -60,7 +60,7 @@ def _add_root(priv, repo_root, key, path):
     root_path = priv["root"]["path"]
 
     # we have no idea what package this path is in so just assume the root package which works for repository rules
-    label = Label("@{}//:{}".format(root_workspace, path))
+    label = Label("@@{}//:{}".format(root_workspace, path))
     priv["labels"][key] = label
     priv["paths"][key] = paths.join(root_path, path)
     priv["repository_paths"][key] = paths.join(repo_root, path)


### PR DESCRIPTION
There have been discussions about ["invalid lockfile entry error"](https://bazelbuild.slack.com/archives/C014RARENH0/p1742987773306169) that this may resolve.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
