### PR TITLE
chore: disable e2e/js_image_oci with bazel 7+non-bzlmod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,6 +157,11 @@ jobs:
                     # TODO: un-exclude the following bzlmod tests once they work
                     - bzlmod: 1
                       folder: e2e/js_image_docker
+                    # TODO: js_image_oci with bazel 7.6.1 and non-bzlmod fails
+                    - bazel-version:
+                          major: 7
+                      bzlmod: 0
+                      folder: e2e/js_image_oci
                     - bzlmod: 1
                       folder: e2e/npm_link_package-esm
                     - bzlmod: 1


### PR DESCRIPTION
This test seems broken since [upgrade bazel from 7.5 to 7.6.1](https://github.com/aspect-build/rules_js/commit/396b2822ba26fa8f2894c9f56c38e7fd47508a4b) when bzlmod is not enabled.

Since it was not a rules_js change, and this is non-bzlmod, I think we may as well just disable the test?

See failure: https://github.com/aspect-build/rules_js/actions/runs/14412788652/job/40424230118

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
