### PR TITLE
fix: pnpm v9 peer deps with workspace/link: deps

### DIFF
--- a/e2e/pnpm_lockfiles/projects/c/package.json
+++ b/e2e/pnpm_lockfiles/projects/c/package.json
@@ -3,5 +3,8 @@
     "private": true,
     "dependencies": {
         "@scoped/a": "link:../a"
+    },
+    "peerDependencies": {
+        "@scoped/b": "workspace:*"
     }
 }

--- a/e2e/pnpm_lockfiles/projects/d/package.json
+++ b/e2e/pnpm_lockfiles/projects/d/package.json
@@ -3,5 +3,8 @@
     "private": true,
     "dependencies": {
         "@scoped/a": "workspace:*"
+    },
+    "peerDependencies": {
+        "@scoped/b": "link:../b"
     }
 }

--- a/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
       '@isaacs/cliui': 8.0.2
       '@scoped/a': link:../projects/a
       '@scoped/b': link:../projects/b
-      '@scoped/c': file:../projects/c
+      '@scoped/c': file:../projects/c_@scoped+b@projects+b
       '@scoped/d': link:../projects/d
       aspect-test-a-no-scope: /@aspect-test/a/5.0.2
       aspect-test-a/no-at: /@aspect-test/a/5.0.2
@@ -524,11 +524,15 @@ packages:
     version: 1.0.0
     dev: false
 
-  file:../projects/c:
+  file:../projects/c_@scoped+b@projects+b:
     resolution: {directory: ../projects/c, type: directory}
+    id: file:../projects/c
     name: '@scoped/c'
+    peerDependencies:
+      '@scoped/b': workspace:*
     dependencies:
       '@scoped/a': link:../a
+      '@scoped/b': link:../projects/b
     dev: false
 
   file:../vendored/is-number:

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -310,6 +310,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             version = "0.0.0",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],

--- a/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: link:../projects/b
       '@scoped/c':
         specifier: file:../projects/c
-        version: file:../projects/c
+        version: file:../projects/c(@scoped/b@projects+b)
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
@@ -164,12 +164,18 @@ importers:
       '@scoped/a':
         specifier: link:../a
         version: link:../a
+      '@scoped/b':
+        specifier: workspace:*
+        version: link:../b
 
   ../projects/d:
     dependencies:
       '@scoped/a':
         specifier: workspace:*
         version: link:../a
+      '@scoped/b':
+        specifier: link:../b
+        version: link:../b
 
   ../projects/peers-combo-1:
     dependencies:
@@ -571,11 +577,15 @@ packages:
     version: 1.0.0
     dev: false
 
-  file:../projects/c:
+  file:../projects/c(@scoped/b@projects+b):
     resolution: {directory: ../projects/c, type: directory}
+    id: file:../projects/c
     name: '@scoped/c'
+    peerDependencies:
+      '@scoped/b': workspace:*
     dependencies:
       '@scoped/a': link:../a
+      '@scoped/b': link:../projects/b
     dev: false
 
   file:../vendored/is-number:

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -318,6 +318,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             version = "0.0.0",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -406,7 +407,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/b".format(name),
@@ -438,6 +439,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             version = "0.0.0",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -674,7 +676,7 @@ def npm_link_targets(name = "node_modules", package = None):
     if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
         link_targets.append(":{}/@scoped/a".format(name))
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
         link_targets.append(":{}/@scoped/b".format(name))
 
     if bazel_package in ["<LOCKVERSION>"]:

--- a/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         version: link:../projects/b
       '@scoped/c':
         specifier: file:../projects/c
-        version: file:../projects/c
+        version: file:../projects/c(@scoped/b@projects+b)
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
@@ -168,12 +168,18 @@ importers:
       '@scoped/a':
         specifier: link:../a
         version: link:../a
+      '@scoped/b':
+        specifier: workspace:*
+        version: link:../b
 
   ../projects/d:
     dependencies:
       '@scoped/a':
         specifier: workspace:*
         version: link:../a
+      '@scoped/b':
+        specifier: link:../b
+        version: link:../b
 
   ../projects/peers-combo-1:
     dependencies:
@@ -575,11 +581,15 @@ packages:
     version: 1.0.0
     dev: false
 
-  file:../projects/c:
+  file:../projects/c(@scoped/b@projects+b):
     resolution: {directory: ../projects/c, type: directory}
+    id: file:../projects/c
     name: '@scoped/c'
+    peerDependencies:
+      '@scoped/b': workspace:*
     dependencies:
       '@scoped/a': link:../a
+      '@scoped/b': link:../projects/b
     dev: false
 
   file:../vendored/is-number:

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -318,6 +318,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             version = "0.0.0",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -406,7 +407,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/b".format(name),
@@ -438,6 +439,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             version = "0.0.0",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -674,7 +676,7 @@ def npm_link_targets(name = "node_modules", package = None):
     if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
         link_targets.append(":{}/@scoped/a".format(name))
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
         link_targets.append(":{}/@scoped/b".format(name))
 
     if bazel_package in ["<LOCKVERSION>"]:

--- a/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: link:../projects/b
       '@scoped/c':
         specifier: file:../projects/c
-        version: file:../projects/c
+        version: file:../projects/c(@scoped/b@projects+b)
       '@scoped/d':
         specifier: ../projects/d
         version: link:../projects/d
@@ -165,12 +165,18 @@ importers:
       '@scoped/a':
         specifier: link:../a
         version: link:../a
+      '@scoped/b':
+        specifier: workspace:*
+        version: link:../b
 
   ../projects/d:
     dependencies:
       '@scoped/a':
         specifier: workspace:*
         version: link:../a
+      '@scoped/b':
+        specifier: link:../b
+        version: link:../b
 
   ../projects/peers-combo-1:
     dependencies:
@@ -248,6 +254,8 @@ packages:
 
   '@scoped/c@file:../projects/c':
     resolution: {directory: ../projects/c, type: directory}
+    peerDependencies:
+      '@scoped/b': workspace:*
 
   '@types/archiver@5.3.1':
     resolution: {integrity: sha512-wKYZaSXaDvTZuInAWjCeGG7BEAgTWG2zZW0/f7IYFcoHB2X2d9lkVFnrOlXl3W6NrvO6Ml3FLLu8Uksyymcpnw==, tarball: https://registry.npmjs.org/@types/archiver/-/archiver-5.3.1.tgz}
@@ -516,9 +524,10 @@ snapshots:
       picomatch: 2.3.1
       rollup: 2.14.0
 
-  '@scoped/c@file:../projects/c':
+  '@scoped/c@file:../projects/c(@scoped/b@projects+b)':
     dependencies:
       '@scoped/a': link:../a
+      '@scoped/b': link:../projects/b
 
   '@types/archiver@5.3.1':
     dependencies:

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -318,6 +318,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             version = "0.0.0",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -406,7 +407,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/b".format(name),
@@ -438,6 +439,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             version = "0.0.0",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -674,7 +676,7 @@ def npm_link_targets(name = "node_modules", package = None):
     if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
         link_targets.append(":{}/@scoped/a".format(name))
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
         link_targets.append(":{}/@scoped/b".format(name))
 
     if bazel_package in ["<LOCKVERSION>"]:

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -127,7 +127,7 @@ sh_binary(
         version = package_info.get("version")
         deps = package_info.get("dependencies")
         if version.startswith("file:"):
-            if version in packages and packages[version]["id"]:
+            if version in packages and packages[version]["id"] and packages[version]["id"].startswith("file:"):
                 dep_path = helpers.link_package(root_package, packages[version]["id"][len("file:"):])
             else:
                 dep_path = helpers.link_package(root_package, version[len("file:"):])
@@ -166,7 +166,7 @@ sh_binary(
             if dep_version.startswith("file:"):
                 dep_key = "{}+{}".format(dep_package, dep_version)
                 if not dep_key in fp_links.keys():
-                    msg = "Expected to file: referenced package {} in first-party links".format(dep_key)
+                    msg = "Expected to file: referenced package {} in first-party links {}".format(dep_key, fp_links.keys())
                     fail(msg)
                 fp_links[dep_key]["link_packages"][link_package] = True
             elif dep_version.startswith("link:"):


### PR DESCRIPTION
Add tests for the scenario fixed in https://github.com/aspect-build/rules_js/commit/a8c192eed0e553acb7000beee00c60d60a32ed82
Fix the issue when reproduced in pnpm v9+

FWIW I was trying to understand when this pnpm <v9 `id` field is used and no tests failed when removing it. It seems it is declared in pnpm <v9 when `file:` or `link:` dependencies have peer dependencies, the `id` will be the `file:` path without the peer dependency information.

The ugly v9 workaround can be removed in https://github.com/aspect-build/rules_js/pull/2177 but I wanted to add tests before that PR

### Changes are visible to end-users: no

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:
