### PR TITLE
refactor: reduce use of pnpm <9 lockfile properties

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -667,12 +667,7 @@ def _npm_import_links_rule_impl(rctx):
                 deps[dep_store_target].append(dep_name)
     else:
         for (dep_name, dep_version) in rctx.attr.deps.items():
-            if dep_version.startswith("link:") or dep_version.startswith("file:"):
-                dep_store_target = """"//{root_package}:{package_store_root}/{{}}/{package_store_name}".format(link_root_name)"""
-            else:
-                dep_store_target = """":{package_store_root}/{{}}/{package_store_name}".format(link_root_name)"""
-            dep_store_target = dep_store_target.format(
-                root_package = rctx.attr.root_package,
+            dep_store_target = """":{package_store_root}/{{}}/{package_store_name}".format(link_root_name)""".format(
                 package_store_name = utils.package_store_name(dep_name, dep_version),
                 package_store_root = utils.package_store_root,
             )

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -122,15 +122,13 @@ sh_binary(
     }
 
     # Look for first-party file: links in packages
-    for package_key, package_info in packages.items():
+    for package_info in packages.values():
         name = package_info.get("name")
         version = package_info.get("version")
         deps = package_info.get("dependencies")
-        if package_key.startswith("file:"):
-            if version in packages and packages[version]["id"] and packages[version]["id"].startswith("file:"):
-                dep_path = helpers.link_package(root_package, packages[version]["id"][len("file:"):])
-            else:
-                dep_path = helpers.link_package(root_package, version[len("file:"):])
+        resolution = package_info.get("resolution")
+        if resolution.get("type", None) == "directory":
+            dep_path = helpers.link_package(root_package, resolution.get("directory"))
             dep_key = "{}+{}".format(name, version)
             transitive_deps = {}
             for raw_package, raw_version in deps.items():

--- a/npm/private/pnpm.bzl
+++ b/npm/private/pnpm.bzl
@@ -35,14 +35,6 @@ def _new_import_info(dependencies, dev_dependencies, optional_dependencies):
 # have data normalized across lockfiles.
 #
 # Args:
-#   id: a "universal identifier of the package" only present when the id is not the same as the key
-#       Normally present when the package is an odd version (such as file: or link: package) while
-#       also having peer dependencies in the key.
-#
-#       Removed in lockfile v9+ where snapshots/packages are separate.
-#
-#       See https://github.com/pnpm/spec/blob/master/lockfile/6.0.md#packagesdependencypathid
-#
 #   name:
 #   version:
 #   dependencies:
@@ -65,9 +57,8 @@ def _new_import_info(dependencies, dev_dependencies, optional_dependencies):
 #       See https://github.com/pnpm/spec/blob/master/lockfile/6.0.md#packagesdependencypathrequiresbuild
 #
 #   resolution: the lockfile resolution field
-def _new_package_info(id, name, dependencies, optional_dependencies, dev_only, has_bin, optional, requires_build, version, friendly_version, resolution):
+def _new_package_info(name, dependencies, optional_dependencies, dev_only, has_bin, optional, requires_build, version, friendly_version, resolution):
     return {
-        "id": id,
         "name": name,
         "dependencies": dependencies,
         "optional_dependencies": optional_dependencies,
@@ -241,7 +232,6 @@ def _convert_v5_packages(packages):
         package_key = _to_package_key(name, version)
 
         package_info = _new_package_info(
-            id = package_snapshot.get("id", None),
             name = name,
             version = version,
             friendly_version = friendly_version,
@@ -412,7 +402,6 @@ def _convert_v6_packages(packages):
         package_key = _to_package_key(name, version)
 
         package_info = _new_package_info(
-            id = package_snapshot.get("id", None),
             name = name,
             version = version,
             friendly_version = friendly_version,
@@ -543,16 +532,7 @@ def _convert_v9_packages(packages, snapshots):
 
         package_key = _convert_pnpm_v6_v9_version_peer_dep(package_key)
 
-        # pnpm v9+ no longer contains an id field
-        # but we will use it to support some edge cases
-        id = None
-
         if version.startswith("file:"):
-            # Keep the file: path as the 'id' for later use when linking to the path
-            peer_index = version.find("(")
-            if peer_index != -1:
-                id = version[:peer_index]
-
             version, friendly_version = _convert_v9_file_package_version(version, package_data)
             version = _convert_pnpm_v6_v9_version_peer_dep(version)
 
@@ -565,7 +545,6 @@ def _convert_v9_packages(packages, snapshots):
             friendly_version = package_data["version"] if "version" in package_data else static_key[version_index + 1:]
 
         package_info = _new_package_info(
-            id = id,
             name = name,
             version = version,
             friendly_version = friendly_version,

--- a/npm/private/test/parse_pnpm_lock_tests.bzl
+++ b/npm/private/test/parse_pnpm_lock_tests.bzl
@@ -27,7 +27,6 @@ expected_importers = {
 }
 expected_packages = {
     "@aspect-test/a@5.0.0": {
-        "id": None,
         "name": "@aspect-test/a",
         "dependencies": {
             "@aspect-test/b": "5.0.0",
@@ -46,7 +45,6 @@ expected_packages = {
         },
     },
     "lodash@4.17.21": {
-        "id": None,
         "name": "lodash",
         "dependencies": {},
         "optional_dependencies": {},


### PR DESCRIPTION
The lockfile `id` property is removed with v9. Our only use of it is to resolve `file:` paths in some scenarios however the `resolution.directory` always has the same information available across all lockfile versions.

The `resolution.directory` property also already has the `file:` prefix removed and `resolution.type == "directory"` is a more reliable way of checking for references to directories.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
