### PR TITLE
refactor: create /ref and /pkg targets for local package store entries

### DIFF
--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -72,7 +72,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
 _LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -303,8 +303,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@types"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
             src = "//projects/c:pkg",
             package = "@scoped/c",
             version = "0.0.0",
@@ -341,8 +342,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/is-number@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
             src = "//vendored/is-number:pkg",
             package = "is-number",
             version = "0.0.0",
@@ -352,8 +354,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         )
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
             src = "//projects/a:pkg",
             package = "@scoped/a",
             version = "0.0.0",
@@ -387,8 +390,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
             src = "//projects/b:pkg",
             package = "@scoped/b",
             version = "0.0.0",
@@ -424,8 +428,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
             src = "//projects/d:pkg",
             package = "@scoped/d",
             version = "0.0.0",
@@ -461,8 +466,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
             src = "//projects/a:pkg",
             package = "alias-project-a",
             version = "0.0.0",
@@ -492,8 +498,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/alias-project-a".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
             src = "//projects/b:pkg",
             package = "scoped/bad",
             version = "0.0.0",
@@ -525,8 +532,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/scoped/bad".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
             src = "//projects/peers-combo-2:pkg",
             package = "test-c200-d200",
             version = "0.0.0",
@@ -559,8 +567,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/test-c200-d200".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
             src = "//projects/peers-combo-1:pkg",
             package = "test-c201-d200",
             version = "0.0.0",
@@ -593,8 +602,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/test-c201-d200".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/a-types@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
             src = "//projects/a-types:pkg",
             package = "a-types",
             version = "0.0.0",

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -73,7 +73,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
 _LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -311,8 +311,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@types"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
             src = "//projects/c:pkg",
             package = "@scoped/c",
             version = "0.0.0",
@@ -349,8 +350,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/is-number@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
             src = "//vendored/is-number:pkg",
             package = "is-number",
             version = "0.0.0",
@@ -360,8 +362,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         )
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
             src = "//projects/a:pkg",
             package = "@scoped/a",
             version = "0.0.0",
@@ -395,8 +398,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
             src = "//projects/b:pkg",
             package = "@scoped/b",
             version = "0.0.0",
@@ -432,8 +436,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
             src = "//projects/d:pkg",
             package = "@scoped/d",
             version = "0.0.0",
@@ -470,8 +475,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
             src = "//projects/a:pkg",
             package = "alias-project-a",
             version = "0.0.0",
@@ -501,8 +507,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/alias-project-a".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
             src = "//projects/b:pkg",
             package = "scoped/bad",
             version = "0.0.0",
@@ -534,8 +541,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/scoped/bad".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
             src = "//projects/peers-combo-2:pkg",
             package = "test-c200-d200",
             version = "0.0.0",
@@ -568,8 +576,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/test-c200-d200".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
             src = "//projects/peers-combo-1:pkg",
             package = "test-c201-d200",
             version = "0.0.0",
@@ -602,8 +611,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/test-c201-d200".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/a-types@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
             src = "//projects/a-types:pkg",
             package = "a-types",
             version = "0.0.0",

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -73,7 +73,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
 _LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -311,8 +311,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@types"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
             src = "//projects/c:pkg",
             package = "@scoped/c",
             version = "0.0.0",
@@ -349,8 +350,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/is-number@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
             src = "//vendored/is-number:pkg",
             package = "is-number",
             version = "0.0.0",
@@ -360,8 +362,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         )
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
             src = "//projects/a:pkg",
             package = "@scoped/a",
             version = "0.0.0",
@@ -395,8 +398,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
             src = "//projects/b:pkg",
             package = "@scoped/b",
             version = "0.0.0",
@@ -432,8 +436,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
             src = "//projects/d:pkg",
             package = "@scoped/d",
             version = "0.0.0",
@@ -470,8 +475,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
             src = "//projects/a:pkg",
             package = "alias-project-a",
             version = "0.0.0",
@@ -501,8 +507,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/alias-project-a".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
             src = "//projects/b:pkg",
             package = "scoped/bad",
             version = "0.0.0",
@@ -534,8 +541,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/scoped/bad".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
             src = "//projects/peers-combo-2:pkg",
             package = "test-c200-d200",
             version = "0.0.0",
@@ -568,8 +576,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/test-c200-d200".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
             src = "//projects/peers-combo-1:pkg",
             package = "test-c201-d200",
             version = "0.0.0",
@@ -602,8 +611,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/test-c201-d200".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/a-types@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
             src = "//projects/a-types:pkg",
             package = "a-types",
             version = "0.0.0",

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -73,7 +73,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
 _LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -311,8 +311,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@types"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
             src = "//projects/c:pkg",
             package = "@scoped/c",
             version = "0.0.0",
@@ -349,8 +350,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/is-number@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
             src = "//vendored/is-number:pkg",
             package = "is-number",
             version = "0.0.0",
@@ -360,8 +362,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         )
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
             src = "//projects/a:pkg",
             package = "@scoped/a",
             version = "0.0.0",
@@ -395,8 +398,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
             src = "//projects/b:pkg",
             package = "@scoped/b",
             version = "0.0.0",
@@ -432,8 +436,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
             src = "//projects/d:pkg",
             package = "@scoped/d",
             version = "0.0.0",
@@ -470,8 +475,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@scoped"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
             src = "//projects/a:pkg",
             package = "alias-project-a",
             version = "0.0.0",
@@ -501,8 +507,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/alias-project-a".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
             src = "//projects/b:pkg",
             package = "scoped/bad",
             version = "0.0.0",
@@ -534,8 +541,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/scoped/bad".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
             src = "//projects/peers-combo-2:pkg",
             package = "test-c200-d200",
             version = "0.0.0",
@@ -568,8 +576,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/test-c200-d200".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
             src = "//projects/peers-combo-1:pkg",
             package = "test-c201-d200",
             version = "0.0.0",
@@ -602,8 +611,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/test-c201-d200".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/a-types@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
             src = "//projects/a-types:pkg",
             package = "a-types",
             version = "0.0.0",

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -20,7 +20,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
 _LINK_PACKAGES = ["", "app/a", "app/b", "app/c", "app/d", "lib/a", "lib/b", "lib/c", "lib/d"]
 
@@ -155,8 +155,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@aspect-test"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+c@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+c@0.0.0",
             src = "//lib/c:pkg",
             package = "@lib/c",
             version = "0.0.0",
@@ -192,8 +193,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/vendored-a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "vendored-a@0.0.0",
             src = "//vendored/a:pkg",
             package = "vendored-a",
             version = "0.0.0",
@@ -225,8 +227,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/vendored-a".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/vendored-b@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "vendored-b@0.0.0",
             src = "//vendored/b:pkg",
             package = "vendored-b",
             version = "0.0.0",
@@ -258,8 +261,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/vendored-b".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+a@0.0.0",
             src = "//lib/a:pkg",
             package = "@lib/a",
             version = "0.0.0",
@@ -298,8 +302,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+b@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+b@0.0.0",
             src = "//lib/b:pkg",
             package = "@lib/b",
             version = "0.0.0",
@@ -336,8 +341,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+b_alias@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+b_alias@0.0.0",
             src = "//lib/b:pkg",
             package = "@lib/b_alias",
             version = "0.0.0",
@@ -374,8 +380,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+d@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+d@0.0.0",
             src = "//lib/d:pkg",
             package = "@lib/d",
             version = "0.0.0",

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -20,7 +20,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
 _LINK_PACKAGES = ["", "app/a", "app/b", "app/c", "app/d", "lib/a", "lib/b", "lib/c", "lib/d"]
 
@@ -155,8 +155,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@aspect-test"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+c@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+c@0.0.0",
             src = "//lib/c:pkg",
             package = "@lib/c",
             version = "0.0.0",
@@ -192,8 +193,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/vendored-a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "vendored-a@0.0.0",
             src = "//vendored/a:pkg",
             package = "vendored-a",
             version = "0.0.0",
@@ -225,8 +227,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/vendored-a".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/vendored-b@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "vendored-b@0.0.0",
             src = "//vendored/b:pkg",
             package = "vendored-b",
             version = "0.0.0",
@@ -258,8 +261,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/vendored-b".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+a@0.0.0",
             src = "//lib/a:pkg",
             package = "@lib/a",
             version = "0.0.0",
@@ -298,8 +302,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+b@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+b@0.0.0",
             src = "//lib/b:pkg",
             package = "@lib/b",
             version = "0.0.0",
@@ -336,8 +341,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+b_alias@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+b_alias@0.0.0",
             src = "//lib/b:pkg",
             package = "@lib/b_alias",
             version = "0.0.0",
@@ -374,8 +380,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+d@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+d@0.0.0",
             src = "//lib/d:pkg",
             package = "@lib/d",
             version = "0.0.0",

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -748,14 +748,8 @@ def _npm_import_links_rule_impl(rctx):
     deps = {}
 
     for (dep_name, dep_version) in rctx.attr.deps.items():
-        dep_package_store_name = utils.package_store_name(dep_name, dep_version)
-        if dep_version.startswith("link:") or dep_version.startswith("file:"):
-            dep_store_target = '"//{root_package}:{package_store_root}/{{link_root_name}}/{package_store_name}"'
-        else:
-            dep_store_target = '":{package_store_root}/{{link_root_name}}/{package_store_name}/ref"'
-        dep_store_target = dep_store_target.format(
-            root_package = rctx.attr.root_package,
-            package_store_name = dep_package_store_name,
+        dep_store_target = '":{package_store_root}/{{link_root_name}}/{package_store_name}/ref"'.format(
+            package_store_name = utils.package_store_name(dep_name, dep_version),
             package_store_root = utils.package_store_root,
         )
         if not dep_store_target in ref_deps:
@@ -769,17 +763,13 @@ def _npm_import_links_rule_impl(rctx):
         # party npm deps; it is not used for 1st party deps
         for (dep_name, dep_versions) in rctx.attr.transitive_closure.items():
             for dep_version in dep_versions:
-                if dep_version.startswith("link:") or dep_version.startswith("file:"):
-                    dep_store_target = '"//{root_package}:{package_store_root}/{{link_root_name}}/{package_store_name}"'
-                    lc_dep_store_target = dep_store_target
-                else:
-                    dep_store_target = '":{package_store_root}/{{link_root_name}}/{package_store_name}/pkg"'
-                    lc_dep_store_target = dep_store_target
-                    if dep_name == rctx.attr.package and dep_version == rctx.attr.version:
-                        # special case for lifecycle transitive closure deps; do not depend on
-                        # the __pkg of this package as that will be the output directory
-                        # of the lifecycle action
-                        lc_dep_store_target = '":{package_store_root}/{{link_root_name}}/{package_store_name}/pkg_pre_lc_lite"'
+                dep_store_target = '":{package_store_root}/{{link_root_name}}/{package_store_name}/pkg"'
+                lc_dep_store_target = dep_store_target
+                if dep_name == rctx.attr.package and dep_version == rctx.attr.version:
+                    # special case for lifecycle transitive closure deps; do not depend on
+                    # the __pkg of this package as that will be the output directory
+                    # of the lifecycle action
+                    lc_dep_store_target = '":{package_store_root}/{{link_root_name}}/{package_store_name}/pkg_pre_lc_lite"'
 
                 dep_package_store_name = utils.package_store_name(dep_name, dep_version)
 

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -458,3 +458,32 @@ npm_package_store = rule(
     provides = npm_package_store_lib.provides,
     toolchains = npm_package_store_lib.toolchains,
 )
+
+# Invoked by generated package store targets for local packages
+# buildifier: disable=function-docstring
+# buildifier: disable=unnamed-macro
+def npm_local_package_store_internal(link_root_name, package_store_name, package, version, src, deps, visibility, tags):
+    store_target_name = "%s/%s/%s" % (utils.package_store_root, link_root_name, package_store_name)
+
+    npm_package_store(
+        name = store_target_name,
+        src = src,
+        package = package,
+        version = version,
+        deps = deps,
+        visibility = visibility,
+        tags = tags,
+    )
+
+    # Create aliases for the standard /ref and /pkg targets so local packages can be
+    # references in the same way as remote packages.
+    native.alias(
+        name = "{}/ref".format(store_target_name),
+        actual = store_target_name,
+        visibility = visibility,
+    )
+    native.alias(
+        name = "{}/pkg".format(store_target_name),
+        actual = store_target_name,
+        visibility = visibility,
+    )

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -31,8 +31,9 @@ bin_factory = _bin_factory
 _FP_STORE_TMPL = \
     """
     if is_root:
-        _npm_package_store(
-            name = "{package_store_root}/{{}}/{package_store_name}".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "{package_store_name}",
             src = "{npm_package_target}",
             package = "{package}",
             version = "0.0.0",
@@ -437,7 +438,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         defs_bzl_header.append("""load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")""")
         defs_bzl_header.append("")
         defs_bzl_header.append("# buildifier: disable=bzl-visibility")
-        defs_bzl_header.append("""load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store")""")
+        defs_bzl_header.append("""load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")""")
 
     rctx_files[rctx.attr.defs_bzl_filename] = [
         "\n".join(defs_bzl_header),

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -1102,7 +1102,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
 _LINK_PACKAGES = ["", "examples/js_binary", "examples/js_lib_pkg/a", "examples/js_lib_pkg/b", "examples/linked_consumer", "examples/linked_empty_node_modules", "examples/linked_lib", "examples/linked_pkg", "examples/macro", "examples/nextjs", "examples/npm_deps", "examples/npm_package/libs/lib_a", "examples/npm_package/packages/pkg_a", "examples/npm_package/packages/pkg_b", "examples/npm_package/packages/pkg_d", "examples/npm_package/packages/pkg_e", "examples/runfiles", "examples/stack_traces", "examples/webpack_cli", "js/private/coverage/bundle", "js/private/test/image", "js/private/test/js_run_devserver", "js/private/worker/src", "npm/private/test", "npm/private/test/npm_package", "npm/private/test/npm_package_publish"]
 
@@ -2564,8 +2564,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             link_targets.append(":{}/source-map-support".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/is-odd@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-odd@0.0.0",
             src = "//npm/private/test/vendored/is-odd:pkg",
             package = "is-odd",
             version = "0.0.0",
@@ -2577,8 +2578,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         )
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/semver-max@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "semver-max@0.0.0",
             src = "//npm/private/test/vendored/semver-max:pkg",
             package = "semver-max",
             version = "0.0.0",
@@ -2591,8 +2593,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         )
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@mycorp+pkg-a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@mycorp+pkg-a@0.0.0",
             src = "//examples/npm_package/packages/pkg_a:pkg",
             package = "@mycorp/pkg-a",
             version = "0.0.0",
@@ -2624,8 +2627,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         )
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/js_lib_pkg_a@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "js_lib_pkg_a@0.0.0",
             src = "//examples/js_lib_pkg/a:pkg",
             package = "js_lib_pkg_a",
             version = "0.0.0",
@@ -2655,8 +2659,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/js_lib_pkg_a".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/js_lib_pkg_a-alias@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "js_lib_pkg_a-alias@0.0.0",
             src = "//examples/js_lib_pkg/a:pkg",
             package = "js_lib_pkg_a-alias",
             version = "0.0.0",
@@ -2686,8 +2691,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
         link_targets.append(":{}/js_lib_pkg_a-alias".format(name))
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+test@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+test@0.0.0",
             src = "//examples/linked_pkg:pkg",
             package = "@lib/test",
             version = "0.0.0",
@@ -2723,8 +2729,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@lib+test2@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+test2@0.0.0",
             src = "//examples/linked_lib:pkg",
             package = "@lib/test2",
             version = "0.0.0",
@@ -2760,8 +2767,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@lib"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@mycorp+pkg-d@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@mycorp+pkg-d@0.0.0",
             src = "//examples/npm_package/packages/pkg_d:pkg",
             package = "@mycorp/pkg-d",
             version = "0.0.0",
@@ -2798,8 +2806,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@mycorp"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/@mycorp+pkg-e@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@mycorp+pkg-e@0.0.0",
             src = "//examples/npm_package/packages/pkg_e:pkg",
             package = "@mycorp/pkg-e",
             version = "0.0.0",
@@ -2835,8 +2844,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             scope_targets["@mycorp"].append(link_targets[-1])
 
     if is_root:
-        _npm_package_store(
-            name = ".aspect_rules_js/{}/test-npm_package@0.0.0".format(name),
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-npm_package@0.0.0",
             src = "//npm/private/test/npm_package:pkg",
             package = "test-npm_package",
             version = "0.0.0",


### PR DESCRIPTION
Reduce the inspecting of packages and simply assuming all packages (imported and local) have store implementations for the regular + `/ref` + `/pkg` targets.

Create the `npm_local_package_store_internal` wrapper macro instead of expanding the template further.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
