### PR TITLE
fix: pnpm v9 url version specifiers without resolved semver

### DIFF
--- a/e2e/pnpm_lockfiles/.bazelignore
+++ b/e2e/pnpm_lockfiles/.bazelignore
@@ -10,6 +10,7 @@ projects/a-types/node_modules
 projects/b/node_modules
 projects/c/node_modules
 projects/d/node_modules
+projects/peer-types/node_modules
 projects/peers-combo-1/node_modules
 projects/peers-combo-2/node_modules
 v54/node_modules/

--- a/e2e/pnpm_lockfiles/base/package.json
+++ b/e2e/pnpm_lockfiles/base/package.json
@@ -33,6 +33,7 @@
         "@scoped/c": "file:../projects/c",
         "@scoped/d": "../projects/d",
         "alias-project-a": "link:../projects/a",
+        "test-peer-types": "../projects/peer-types",
         "test-c200-d200": "workspace:*",
         "test-c201-d200": "workspace:*"
     },

--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -128,6 +128,7 @@ def lockfile_test(npm_link_all_packages, name = None):
             ":node_modules/@scoped/d",
             ":node_modules/test-c200-d200",
             ":node_modules/test-c201-d200",
+            ":node_modules/test-peer-types",
             ":node_modules/scoped/bad",
             ":node_modules/lodash",
 

--- a/e2e/pnpm_lockfiles/projects/peer-types/BUILD.bazel
+++ b/e2e/pnpm_lockfiles/projects/peer-types/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+
+js_library(
+    name = "pkg",
+    srcs = ["package.json"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/pnpm_lockfiles/projects/peer-types/package.json
+++ b/e2e/pnpm_lockfiles/projects/peer-types/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "test-peer-types",
+    "private": true,
+    "description": "A package with peer dependencies including: workspace, link, also-in-dev, odd version specifiers",
+    "peerDependencies": {
+        "@scoped/a": "workspace:*",
+        "@scoped/b": "link:../b",
+        "@scoped/c": "file:../c",
+        "hello": "https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello",
+        "jsonify": "https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz"
+    }
+}

--- a/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
@@ -54,6 +54,7 @@ importers:
       scoped/bad: link:../projects/b
       test-c200-d200: workspace:*
       test-c201-d200: workspace:*
+      test-peer-types: ../projects/peer-types
       tslib: ^2.6.3
       typescript: 5.5.2
       uvu: 0.5.6
@@ -88,6 +89,7 @@ importers:
       scoped/bad: link:../projects/b
       test-c200-d200: link:../projects/peers-combo-2
       test-c201-d200: link:../projects/peers-combo-1
+      test-peer-types: link:../projects/peer-types
       tslib: 2.8.1
       typescript: 5.5.2
       uvu: 0.5.6
@@ -131,6 +133,9 @@ importers:
       '@scoped/a': workspace:*
     dependencies:
       '@scoped/a': link:../a
+
+  ../projects/peer-types:
+    specifiers: {}
 
   ../projects/peers-combo-1:
     specifiers:

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -74,7 +74,7 @@ load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_packa
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
-_LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
+_LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = []):
@@ -604,6 +604,38 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
     if is_root:
         _npm_local_package_store(
             link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    if bazel_package in ["<LOCKVERSION>"]:
+        # terminal target for direct dependencies
+        _npm_link_package_store(
+            name = "{}/test-peer-types".format(name),
+            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+        # filegroup target that provides a single file which is
+        # package directory for use in $(execpath) and $(rootpath)
+        native.filegroup(
+            name = "{}/test-peer-types/dir".format(name),
+            srcs = [":{}/test-peer-types".format(name)],
+            output_group = "package_directory",
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        link_targets.append(":{}/test-peer-types".format(name))
+
+    if is_root:
+        _npm_local_package_store(
+            link_root_name = name,
             package_store_name = "a-types@0.0.0",
             src = "//projects/a-types:pkg",
             package = "a-types",
@@ -724,6 +756,9 @@ def npm_link_targets(name = "node_modules", package = None):
 
     if bazel_package in ["<LOCKVERSION>"]:
         link_targets.append(":{}/test-c201-d200".format(name))
+
+    if bazel_package in ["<LOCKVERSION>"]:
+        link_targets.append(":{}/test-peer-types".format(name))
 
     if bazel_package in ["projects/b"]:
         link_targets.append(":{}/a-types".format(name))

--- a/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       test-c201-d200:
         specifier: workspace:*
         version: link:../projects/peers-combo-1
+      test-peer-types:
+        specifier: ../projects/peer-types
+        version: link:../projects/peer-types
       tslib:
         specifier: ^2.6.3
         version: 2.6.3
@@ -179,6 +182,24 @@ importers:
       '@scoped/b':
         specifier: link:../b
         version: link:../b
+
+  ../projects/peer-types:
+    dependencies:
+      '@scoped/a':
+        specifier: workspace:*
+        version: link:../a
+      '@scoped/b':
+        specifier: link:../b
+        version: link:../b
+      '@scoped/c':
+        specifier: file:../c
+        version: file:../projects/c(@scoped/b@projects+b)
+      hello:
+        specifier: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
+        version: '@gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello'
+      jsonify:
+        specifier: https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz
+        version: '@github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz'
 
   ../projects/peers-combo-1:
     dependencies:

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -75,7 +75,7 @@ load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_packa
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
-_LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
+_LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = []):
@@ -295,6 +295,11 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+        elif bazel_package == "projects/peer-types":
+            link_13("{}/jsonify".format(name), link_root_name = name, link_alias = "jsonify")
+            link_targets.append(":{}/jsonify".format(name))
+            link_35("{}/hello".format(name), link_root_name = name, link_alias = "hello")
+            link_targets.append(":{}/hello".format(name))
         elif bazel_package == "projects/a-types":
             link_21("{}/@types/node".format(name), link_root_name = name, link_alias = "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -325,7 +330,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/c".format(name),
@@ -373,7 +378,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/a".format(name),
@@ -411,7 +416,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/b".format(name),
@@ -613,6 +618,44 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
     if is_root:
         _npm_local_package_store(
             link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name): "@scoped/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@gitpkg.vercel.app+EqualMa+gitpkg-hello+packages+hello".format(name): "hello",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@github.com+aspect-build+test-packages+releases+download+0.0.0+@foo-jsonify-0.0.0.tgz".format(name): "jsonify",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    if bazel_package in ["<LOCKVERSION>"]:
+        # terminal target for direct dependencies
+        _npm_link_package_store(
+            name = "{}/test-peer-types".format(name),
+            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+        # filegroup target that provides a single file which is
+        # package directory for use in $(execpath) and $(rootpath)
+        native.filegroup(
+            name = "{}/test-peer-types/dir".format(name),
+            srcs = [":{}/test-peer-types".format(name)],
+            output_group = "package_directory",
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        link_targets.append(":{}/test-peer-types".format(name))
+
+    if is_root:
+        _npm_local_package_store(
+            link_root_name = name,
             package_store_name = "a-types@0.0.0",
             src = "//projects/a-types:pkg",
             package = "a-types",
@@ -706,18 +749,21 @@ def npm_link_targets(name = "node_modules", package = None):
         elif bazel_package == "projects/peers-combo-1":
             link_targets.append(":{}/@aspect-test/c".format(name))
             link_targets.append(":{}/@aspect-test/d".format(name))
+        elif bazel_package == "projects/peer-types":
+            link_targets.append(":{}/jsonify".format(name))
+            link_targets.append(":{}/hello".format(name))
         elif bazel_package == "projects/a-types":
             link_targets.append(":{}/@types/node".format(name))
         elif bazel_package == "projects/b":
             link_targets.append(":{}/@types/node".format(name))
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/c".format(name))
 
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/a".format(name))
 
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/b".format(name))
 
     if bazel_package in ["<LOCKVERSION>"]:
@@ -734,6 +780,9 @@ def npm_link_targets(name = "node_modules", package = None):
 
     if bazel_package in ["<LOCKVERSION>"]:
         link_targets.append(":{}/test-c201-d200".format(name))
+
+    if bazel_package in ["<LOCKVERSION>"]:
+        link_targets.append(":{}/test-peer-types".format(name))
 
     if bazel_package in ["projects/b"]:
         link_targets.append(":{}/a-types".format(name))

--- a/e2e/pnpm_lockfiles/v60/snapshots/repositories.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/repositories.bzl
@@ -273,6 +273,7 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "<LOCKVERSION>": ["jsonify"],
+            "projects/peer-types": ["jsonify"],
         },
         package = "@foo/jsonify",
         version = "@github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz",
@@ -716,6 +717,7 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "<LOCKVERSION>": ["hello"],
+            "projects/peer-types": ["hello"],
         },
         package = "hello",
         version = "@gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello",

--- a/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       test-c201-d200:
         specifier: workspace:*
         version: link:../projects/peers-combo-1
+      test-peer-types:
+        specifier: ../projects/peer-types
+        version: link:../projects/peer-types
       tslib:
         specifier: ^2.6.3
         version: 2.6.3
@@ -183,6 +186,24 @@ importers:
       '@scoped/b':
         specifier: link:../b
         version: link:../b
+
+  ../projects/peer-types:
+    dependencies:
+      '@scoped/a':
+        specifier: workspace:*
+        version: link:../a
+      '@scoped/b':
+        specifier: link:../b
+        version: link:../b
+      '@scoped/c':
+        specifier: file:../c
+        version: file:../projects/c(@scoped/b@projects+b)
+      hello:
+        specifier: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
+        version: '@gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello'
+      jsonify:
+        specifier: https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz
+        version: '@github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz'
 
   ../projects/peers-combo-1:
     dependencies:

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -75,7 +75,7 @@ load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_packa
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
-_LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
+_LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = []):
@@ -295,6 +295,11 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+        elif bazel_package == "projects/peer-types":
+            link_13("{}/jsonify".format(name), link_root_name = name, link_alias = "jsonify")
+            link_targets.append(":{}/jsonify".format(name))
+            link_35("{}/hello".format(name), link_root_name = name, link_alias = "hello")
+            link_targets.append(":{}/hello".format(name))
         elif bazel_package == "projects/a-types":
             link_21("{}/@types/node".format(name), link_root_name = name, link_alias = "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -325,7 +330,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/c".format(name),
@@ -373,7 +378,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/a".format(name),
@@ -411,7 +416,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/b".format(name),
@@ -613,6 +618,44 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
     if is_root:
         _npm_local_package_store(
             link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name): "@scoped/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@gitpkg.vercel.app+EqualMa+gitpkg-hello+packages+hello".format(name): "hello",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@github.com+aspect-build+test-packages+releases+download+0.0.0+@foo-jsonify-0.0.0.tgz".format(name): "jsonify",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    if bazel_package in ["<LOCKVERSION>"]:
+        # terminal target for direct dependencies
+        _npm_link_package_store(
+            name = "{}/test-peer-types".format(name),
+            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+        # filegroup target that provides a single file which is
+        # package directory for use in $(execpath) and $(rootpath)
+        native.filegroup(
+            name = "{}/test-peer-types/dir".format(name),
+            srcs = [":{}/test-peer-types".format(name)],
+            output_group = "package_directory",
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        link_targets.append(":{}/test-peer-types".format(name))
+
+    if is_root:
+        _npm_local_package_store(
+            link_root_name = name,
             package_store_name = "a-types@0.0.0",
             src = "//projects/a-types:pkg",
             package = "a-types",
@@ -706,18 +749,21 @@ def npm_link_targets(name = "node_modules", package = None):
         elif bazel_package == "projects/peers-combo-1":
             link_targets.append(":{}/@aspect-test/c".format(name))
             link_targets.append(":{}/@aspect-test/d".format(name))
+        elif bazel_package == "projects/peer-types":
+            link_targets.append(":{}/jsonify".format(name))
+            link_targets.append(":{}/hello".format(name))
         elif bazel_package == "projects/a-types":
             link_targets.append(":{}/@types/node".format(name))
         elif bazel_package == "projects/b":
             link_targets.append(":{}/@types/node".format(name))
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/c".format(name))
 
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/a".format(name))
 
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/b".format(name))
 
     if bazel_package in ["<LOCKVERSION>"]:
@@ -734,6 +780,9 @@ def npm_link_targets(name = "node_modules", package = None):
 
     if bazel_package in ["<LOCKVERSION>"]:
         link_targets.append(":{}/test-c201-d200".format(name))
+
+    if bazel_package in ["<LOCKVERSION>"]:
+        link_targets.append(":{}/test-peer-types".format(name))
 
     if bazel_package in ["projects/b"]:
         link_targets.append(":{}/a-types".format(name))

--- a/e2e/pnpm_lockfiles/v61/snapshots/repositories.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/repositories.bzl
@@ -273,6 +273,7 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "<LOCKVERSION>": ["jsonify"],
+            "projects/peer-types": ["jsonify"],
         },
         package = "@foo/jsonify",
         version = "@github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz",
@@ -716,6 +717,7 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "<LOCKVERSION>": ["hello"],
+            "projects/peer-types": ["hello"],
         },
         package = "hello",
         version = "@gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello",

--- a/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       test-c201-d200:
         specifier: workspace:*
         version: link:../projects/peers-combo-1
+      test-peer-types:
+        specifier: ../projects/peer-types
+        version: link:../projects/peer-types
       tslib:
         specifier: ^2.6.3
         version: 2.8.1
@@ -180,6 +183,24 @@ importers:
       '@scoped/b':
         specifier: link:../b
         version: link:../b
+
+  ../projects/peer-types:
+    dependencies:
+      '@scoped/a':
+        specifier: workspace:*
+        version: link:../a
+      '@scoped/b':
+        specifier: link:../b
+        version: link:../b
+      '@scoped/c':
+        specifier: file:../c
+        version: file:../projects/c(@scoped/b@projects+b)
+      hello:
+        specifier: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
+        version: https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello
+      jsonify:
+        specifier: https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz
+        version: '@foo/jsonify@https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz'
 
   ../projects/peers-combo-1:
     dependencies:

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -75,7 +75,7 @@ load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_packa
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
 
-_LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
+_LINK_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = []):
@@ -295,6 +295,11 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+        elif bazel_package == "projects/peer-types":
+            link_13("{}/jsonify".format(name), link_root_name = name, link_alias = "jsonify")
+            link_targets.append(":{}/jsonify".format(name))
+            link_35("{}/hello".format(name), link_root_name = name, link_alias = "hello")
+            link_targets.append(":{}/hello".format(name))
         elif bazel_package == "projects/a-types":
             link_21("{}/@types/node".format(name), link_root_name = name, link_alias = "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -325,7 +330,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/c".format(name),
@@ -373,7 +378,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/a".format(name),
@@ -411,7 +416,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
             tags = ["manual"],
         )
 
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
             name = "{}/@scoped/b".format(name),
@@ -613,6 +618,44 @@ def npm_link_all_packages(name = "node_modules", imported_links = []):
     if is_root:
         _npm_local_package_store(
             link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name): "@scoped/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/hello@https+gitpkg.vercel.app+EqualMa+gitpkg-hello+packages+hello".format(name): "hello",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@foo+jsonify@https+github.com+aspect-build+test-packages+releases+download+0.0.0+@foo-jsonify-0.0.0.tgz".format(name): "jsonify",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+    if bazel_package in ["<LOCKVERSION>"]:
+        # terminal target for direct dependencies
+        _npm_link_package_store(
+            name = "{}/test-peer-types".format(name),
+            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+
+        # filegroup target that provides a single file which is
+        # package directory for use in $(execpath) and $(rootpath)
+        native.filegroup(
+            name = "{}/test-peer-types/dir".format(name),
+            srcs = [":{}/test-peer-types".format(name)],
+            output_group = "package_directory",
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        link_targets.append(":{}/test-peer-types".format(name))
+
+    if is_root:
+        _npm_local_package_store(
+            link_root_name = name,
             package_store_name = "a-types@0.0.0",
             src = "//projects/a-types:pkg",
             package = "a-types",
@@ -706,18 +749,21 @@ def npm_link_targets(name = "node_modules", package = None):
         elif bazel_package == "projects/peers-combo-1":
             link_targets.append(":{}/@aspect-test/c".format(name))
             link_targets.append(":{}/@aspect-test/d".format(name))
+        elif bazel_package == "projects/peer-types":
+            link_targets.append(":{}/jsonify".format(name))
+            link_targets.append(":{}/hello".format(name))
         elif bazel_package == "projects/a-types":
             link_targets.append(":{}/@types/node".format(name))
         elif bazel_package == "projects/b":
             link_targets.append(":{}/@types/node".format(name))
 
-    if bazel_package in ["<LOCKVERSION>"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/c".format(name))
 
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/a".format(name))
 
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d"]:
+    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         link_targets.append(":{}/@scoped/b".format(name))
 
     if bazel_package in ["<LOCKVERSION>"]:
@@ -734,6 +780,9 @@ def npm_link_targets(name = "node_modules", package = None):
 
     if bazel_package in ["<LOCKVERSION>"]:
         link_targets.append(":{}/test-c201-d200".format(name))
+
+    if bazel_package in ["<LOCKVERSION>"]:
+        link_targets.append(":{}/test-peer-types".format(name))
 
     if bazel_package in ["projects/b"]:
         link_targets.append(":{}/a-types".format(name))

--- a/e2e/pnpm_lockfiles/v90/snapshots/repositories.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/repositories.bzl
@@ -273,6 +273,7 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "<LOCKVERSION>": ["jsonify"],
+            "projects/peer-types": ["jsonify"],
         },
         package = "@foo/jsonify",
         version = "https://github.com/aspect-build/test-packages/releases/download/0.0.0/@foo-jsonify-0.0.0.tgz",
@@ -712,6 +713,7 @@ def npm_repositories():
         link_workspace = "",
         link_packages = {
             "<LOCKVERSION>": ["hello"],
+            "projects/peer-types": ["hello"],
         },
         package = "hello",
         version = "https://gitpkg.vercel.app/EqualMa/gitpkg-hello/packages/hello",

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -60,7 +60,7 @@ def _package_store_name(pnpm_name, pnpm_version):
     if version.startswith("@"):
         # Special case where the package name should _not_ be included in the package store name.
         # See https://github.com/aspect-build/rules_js/issues/423 for more context.
-        return version.replace("/", "+")
+        return version.replace("://", "/").replace("/", "+")
     else:
         escaped_name = name.replace("/", "+")
         escaped_version = version.replace("://", "/").replace("/", "+")


### PR DESCRIPTION
A similar test found an issue involving `file:` deps + peers, but I'd like to merge this first.

### Changes are visible to end-users: no

### Test plan

- New test cases added
