### PR TITLE
fix: add warnings for deprecated js_run_devserver,js_run_binary include_types,npm_sources attrs

### DIFF
--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -110,7 +110,63 @@ WARNING: js_library 'declarations' is deprecated. Use 'types' instead.""")
         **kwargs
     )
 
-js_run_devserver = _js_run_devserver
+# buildifier: disable=function-docstring
+def js_run_devserver(**kwargs):
+    include_npm_sources = kwargs.pop("include_npm_sources", True)
+    include_types = kwargs.pop("include_types", False)
+
+    # For backward compat
+    # TODO(3.0): remove backward compat handling
+    include_npm_linked_packages = kwargs.pop("include_npm_linked_packages", None)
+    if include_npm_linked_packages != None:
+        # buildifier: disable=print
+        print("""
+WARNING: js_run_devserver 'include_npm_linked_packages' is deprecated. Use 'include_npm_sources' instead.""")
+        include_npm_sources = include_npm_linked_packages
+
+    # For backward compat
+    # TODO(3.0): remove backward compat handling
+    include_declarations = kwargs.pop("include_declarations", False)
+    if include_declarations:
+        # buildifier: disable=print
+        print("""
+WARNING: js_run_devserver 'include_declarations' is deprecated. Use 'include_types' instead.""")
+        include_types = include_declarations
+
+    _js_run_devserver(
+        include_types = include_types,
+        include_npm_sources = include_npm_sources,
+        **kwargs
+    )
+
+# buildifier: disable=function-docstring
+def js_run_binary(**kwargs):
+    include_npm_sources = kwargs.pop("include_npm_sources", True)
+    include_types = kwargs.pop("include_types", False)
+
+    # For backward compat
+    # TODO(3.0): remove backward compat handling
+    include_npm_linked_packages = kwargs.pop("include_npm_linked_packages", None)
+    if include_npm_linked_packages != None:
+        # buildifier: disable=print
+        print("""
+WARNING: js_run_binary 'include_npm_linked_packages' is deprecated. Use 'include_npm_sources' instead.""")
+        include_npm_sources = include_npm_linked_packages
+
+    # For backward compat
+    # TODO(3.0): remove backward compat handling
+    include_declarations = kwargs.pop("include_declarations", False)
+    if include_declarations:
+        # buildifier: disable=print
+        print("""
+WARNING: js_run_binary 'include_declarations' is deprecated. Use 'include_types' instead.""")
+        include_types = include_declarations
+
+    _js_run_binary(
+        include_types = include_types,
+        include_npm_sources = include_npm_sources,
+        **kwargs
+    )
+
 js_info_files = _js_info_files
-js_run_binary = _js_run_binary
 js_image_layer = _js_image_layer


### PR DESCRIPTION
Fix https://github.com/aspect-build/rules_js/issues/1899

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
