### PR TITLE
chore: fix bzl_libraries

### DIFF
--- a/js/private/maybe.bzl
+++ b/js/private/maybe.bzl
@@ -1,7 +1,0 @@
-"maybe utilities"
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
-def maybe_http_archive(**kwargs):
-    maybe(_http_archive, **kwargs)

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -4,7 +4,11 @@ These are needed for local dev, and users must install them as well.
 See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 """
 
-load("//js/private:maybe.bzl", http_archive = "maybe_http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def http_archive(**kwargs):
+    maybe(_http_archive, **kwargs)
 
 # buildifier: disable=function-docstring
 def rules_js_dependencies():


### PR DESCRIPTION
Found in doc.bzl that these don't build because there was never a maybe bzl_library created.

Note, due to https://github.com/bazelbuild/bazel-skylib/issues/568 there's no validation that our bzl_library targets are correct.
