### PR TITLE
fix(js_run_devserver): delete full sandbox directory on exit

### DIFF
--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -565,15 +565,14 @@ async function main(args, sandbox) {
     onProcessEnd(() => sandbox && removeSandbox(sandbox) && (sandbox = null))
 
     try {
-        sandbox = path.join(
-            await fs.promises.mkdtemp(
-                path.join(os.tmpdir(), 'js_run_devserver-')
-            ),
-            process.env.JS_BINARY__WORKSPACE
+        sandbox = await fs.promises.mkdtemp(
+            path.join(os.tmpdir(), 'js_run_devserver-')
         )
+        const sandboxMain = path.join(sandbox, process.env.JS_BINARY__WORKSPACE)
+
         // Intentionally synchronous; see comment on mkdirpSync
-        mkdirpSync(path.join(sandbox, process.env.JS_BINARY__CHDIR || ''))
-        await main(process.argv.slice(2), sandbox)
+        mkdirpSync(path.join(sandboxMain, process.env.JS_BINARY__CHDIR || ''))
+        await main(process.argv.slice(2), sandboxMain)
     } catch (e) {
         console.error(e)
         process.exit(1)


### PR DESCRIPTION
Today the `{sandbox}/_main` subdirectory is removed but leaves behind the (normally empty) `{sandbox}` directory.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fix `js_run_devserver` temp directory not being fully deleted on exit.

### Test plan

- Manual testing; run a `js_run_devserver` target and kill it via cmd-c
