### PR TITLE
perf: determine js_run_devserver file vs directory in rule

### DIFF
--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -35,7 +35,7 @@ def _file_to_entry_json(f):
         if len(path_segments) <= package_name_segment or "@0.0.0" not in path_segments[package_name_segment]:
             return None
 
-    return json.encode(f.short_path)
+    return json.encode([f.short_path, 1 if f.is_directory else 0])
 
 def _js_run_devserver_impl(ctx):
     config_file = ctx.actions.declare_file("{}_config.json".format(ctx.label.name))

--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -176,17 +176,13 @@ async function syncSymlink(src, dst, sandbox, exists) {
     return 1
 }
 
-async function syncDirectory(src, dst, sandbox, exists, writePerm) {
+async function syncDirectory(src, dst, sandbox, writePerm) {
     if (process.env.JS_BINARY__LOG_DEBUG) {
         console.error(
             `Syncing directory ${src.slice(RUNFILES_ROOT.length + 1)}...`
         )
     }
     const contents = await fs.promises.readdir(src)
-    if (!exists) {
-        // Intentionally synchronous; see comment on mkdirpSync
-        mkdirpSync(dst)
-    }
     return (
         await Promise.all(
             contents.map(
@@ -264,7 +260,7 @@ async function syncRecursive(src, dst, sandbox, writePerm) {
         if (lstat.isSymbolicLink()) {
             return syncSymlink(src, dst, sandbox, exists)
         } else if (lstat.isDirectory()) {
-            return syncDirectory(src, dst, sandbox, exists, writePerm)
+            return syncDirectory(src, dst, sandbox, writePerm)
         } else {
             const lastChecksum = syncedChecksum.get(src)
             const checksum = await generateChecksum(src)
@@ -718,7 +714,7 @@ async function cycleSyncRecurse(cycle, src, dst, sandbox, writePerm) {
     }
 
     if (isDirectory) {
-        return syncDirectory(src, dst, sandbox, exists, writePerm)
+        return syncDirectory(src, dst, sandbox, writePerm)
     } else {
         return syncFile(src, dst, exists, lstat, writePerm)
     }


### PR DESCRIPTION
This removes a `lstat` call on almost all files being synced. Only those within directory artifacts will still be done.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; profile while using `aspect run --watch`
