### PR TITLE
refactor: add bazel_ibp_support tag to js_run_devserver

### DIFF
--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -278,10 +278,11 @@ def js_run_devserver(
             "//conditions:default": False,
         }),
         entry_point = Label("@aspect_rules_js//js/private:js_devserver_entrypoint"),
-        # This rule speaks the ibazel protocol
+        # This rule speaks the ibazel protocol, supports live reload, supports incremental-build-protocol
         tags = kwargs.pop("tags", []) + [
             "ibazel_live_reload",
             "ibazel_notify_changes",
+            "supports_incremental_build_protocol",
         ],
         tool_exec_cfg = tool,
         tool_target_cfg = tool,


### PR DESCRIPTION
Add a tag so tools can detect ibazel vs incremental-build-protocol support before running the target.

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
