### PR TITLE
perf: use native mkdirSync recursive:true in js_run_devserver

### DIFF
--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -36,11 +36,12 @@ function mkdirpSync(p) {
     if (mkdirs.has(p)) {
         return
     }
-    if (!fs.existsSync(p)) {
-        mkdirpSync(path.dirname(p))
-        fs.mkdirSync(p)
-    }
-    mkdirs.add(p)
+
+    fs.mkdirSync(p, { recursive: true })
+
+    do {
+        mkdirs.add(p)
+    } while (!mkdirs.has((p = path.dirname(p))))
 }
 
 // Determines if a file path refers to a node module.


### PR DESCRIPTION
`recursive:true` was added in node10, and surely that is faster then multiple `existsSync`+`mkdirSync` calls?

The `mkdirs` set will still prevent most calls, this reduces it to 1 instead of 2*n when that quick-exit is not hit.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce: run on large devserver, profile
