### PR TITLE
Update helper message when ASPECT_RULES_JS_FROZEN_PNPM_LOCK=true

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -844,15 +844,20 @@ INFO: {} file has changed""".format(pnpm_lock_relative_path))
 
 ################################################################################
 def _fail_if_frozen_pnpm_lock(rctx, state):
+    repo_reference_symbol = "@"
+    if rctx.attr.bzlmod:
+        repo_reference_symbol = "@@"
+
     if RULES_JS_FROZEN_PNPM_LOCK_ENV in rctx.os.environ.keys() and rctx.os.environ[RULES_JS_FROZEN_PNPM_LOCK_ENV]:
         fail("""
 
 ERROR: `{action_cache}` is out of date. `{pnpm_lock}` may require an update. To update run,
 
-           bazel run @{rctx_name}//:sync
+           bazel run {repo_reference_symbol}{rctx_name}//:sync
 
 """.format(
             action_cache = state.label_store.relative_path("action_cache"),
             pnpm_lock = state.label_store.relative_path("pnpm_lock"),
+            repo_reference_symbol = repo_reference_symbol,
             rctx_name = rctx.name,
         ))


### PR DESCRIPTION
This PR updates the helper message to the user when `ASPECT_RULES_JS_FROZEN_PNPM_LOCK=true` is set. Under `bzlmod` the output label to run is the canonical label, however, only includes one `@` symbol, so if the user copy/pastes the command it fails to run. This PR tries to rectify it by adding the correct number of `@@` symbols prior to the canonical label, eg:
```
           bazel run @@aspect_rules_js~~npm~npm//:sync
```

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

<!-- Delete any which do not apply -->

- Manual testing; please provide instructions so we can reproduce:
1. Add `update_pnpm_lock = True` to `e2e/bzlmod/MODULE.bazel`
```
diff --git a/e2e/bzlmod/MODULE.bazel b/e2e/bzlmod/MODULE.bazel
index 9f04be97..bf9a2b8f 100644
--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -39,9 +39,11 @@ npm.npm_translate_lock(
         "less": "npm --version",
         "jasmine": "tsc --version",
     },
+    data = ["//:package.json"],
     npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
+    update_pnpm_lock = True,
 )
 use_repo(npm, "npm")
```
2. Modify a dependency in `e2e/bzlmod/package.json`, eg:
```
diff --git a/e2e/bzlmod/package.json b/e2e/bzlmod/package.json
index 3a825429..8e783bfc 100644
--- a/e2e/bzlmod/package.json
+++ b/e2e/bzlmod/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "chalk": "5.3.0",
         "less": "4.1.3",
-        "jasmine": "5.0.2"
+        "jasmine": "5.0.0"
     },
     "pnpm": {
         "packageExtensions": {
```
3. Attempt to build in e2e/bzlmod, eg:
```
$ e2e/bzlmod
$ bazel build --action_env=ASPECT_RULES_JS_FROZEN_PNPM_LOCK=true ...
```

before the change:
```
ERROR: `.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=` is out of date. `pnpm-lock.yaml` may require an update. To update run,

           bazel run @aspect_rules_js~~npm~npm//:sync

```
after the change:
```
ERROR: `.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=` is out of date. `pnpm-lock.yaml` may require an update. To update run,

           bazel run @@aspect_rules_js~~npm~npm//:sync
```