### PR TITLE
fix: add console log when removing js_run_devserver sandbox

### DIFF
--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -734,6 +734,8 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
 function removeSandbox(sandbox) {
     try {
         if (sandbox) {
+            console.error(`Deleting js_run_devserver sandbox at ${sandbox}...`)
+
             // Must be synchronous when invoked from process exit handler
             fs.rmSync(sandbox, { force: true, recursive: true })
         }


### PR DESCRIPTION
To discourage users from hitting ctrl-c again while a slow delete operation is running.

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: 