### PR TITLE
fix: correct early exit from _parse_lockfile

### DIFF
--- a/npm/private/pnpm.bzl
+++ b/npm/private/pnpm.bzl
@@ -589,12 +589,12 @@ def _parse_lockfile(parsed, err):
         A tuple of (importers dict, packages dict, patched_dependencies dict, error string)
     """
     if err != None or parsed == None or parsed == {}:
-        return {}, {}, {}, err
+        return {}, {}, {}, None, err
 
     if not types.is_dict(parsed):
-        return {}, {}, {}, "lockfile should be a starlark dict"
+        return {}, {}, {}, None, "lockfile should be a starlark dict"
     if not parsed.get("lockfileVersion", False):
-        return {}, {}, {}, "expected lockfileVersion key in lockfile"
+        return {}, {}, {}, None, "expected lockfileVersion key in lockfile"
 
     # Lockfile version may be a float such as 5.4 or a string such as '6.0'
     lockfile_version = str(parsed["lockfileVersion"])

--- a/npm/private/test/parse_pnpm_lock_tests.bzl
+++ b/npm/private/test/parse_pnpm_lock_tests.bzl
@@ -8,7 +8,7 @@ def _parse_empty_lock_test_impl(ctx):
 
     parsed_json_a = pnpm.parse_pnpm_lock_json("")
     parsed_json_b = pnpm.parse_pnpm_lock_json("{}")
-    expected = ({}, {}, {}, None)
+    expected = ({}, {}, {}, None, None)
 
     asserts.equals(env, expected, parsed_json_a)
     asserts.equals(env, expected, parsed_json_b)


### PR DESCRIPTION
`_parse_lockfile` is expected to return 5 values. If pnpm lockfile is invalid user gets an error about getting 4 instead of 5 expected values and nothing about actual error. Happy path worked ofc, but error path was broken.