### PR TITLE
fix: Prefix the publishable package path with `./`

### DIFF
--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -452,7 +452,7 @@ def npm_package(
             name = "{}.publish".format(name),
             entry_point = Label("@aspect_rules_js//npm/private:npm_publish_mjs"),
             fixed_args = [
-                "$(rootpath :{})".format(name),
+                "./$(rootpath :{})".format(name),
             ],
             data = [name],
             # required to make npm to be available in PATH


### PR DESCRIPTION
When trying to call the `.publish` rule on a publishable `npm_package` in a non-root BUILD file, currently the call to `npm` does not find the given package and interprets the argument as a git repository `github.com/path/to.git` .  Specifically if you have a package rule in a first-level drectory, e.g. `ts/BUILD.bazel` contains a `npm_package(name = 'foo'...` then calling `npm publish ts/foo` will attempt to `git ls-remote https://github.com/ts/foo.git`.

https://github.com/npm/cli/issues/2796 implies that this is a behaviour change and we need to prefix a `./` to force it to find this argument as a filesystem path.  This does indeed work in my local testing.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fix publishing npm packages in a subdirectory.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Run `bazel run `//target/to.publish` with an `npm_package()` in a subdirectory.
