### PR TITLE
fix: Fix typo with the include_external_repositories example

### DIFF
--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -283,7 +283,7 @@ def npm_package(
             `path/to/file` within the output directory.
 
             ```
-            npp_package(
+            npm_package(
                 name = "dir",
                 include_external_repositories = ["external_*"],
                 srcs = ["@external_repo//path/to:file"],


### PR DESCRIPTION
This PR correct a minor typo related to the `include_external_repositories` in `npm_package` rule.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
