### PR TITLE
test: stabilize pnpm_lockfiles versions

### DIFF
--- a/e2e/pnpm_lockfiles/base/package.json
+++ b/e2e/pnpm_lockfiles/base/package.json
@@ -64,7 +64,8 @@
             "is-number": "file:../vendored/is-number",
             "diff": "https://github.com/kpdecker/jsdiff/archive/refs/tags/v5.2.0.tar.gz",
             "fsevents": "^2.3",
-            "typescript": "5.5.2"
+            "typescript": "5.5.2",
+            "@types/glob": "^8.1.0"
         }
     }
 }

--- a/e2e/pnpm_lockfiles/update-snapshots.sh
+++ b/e2e/pnpm_lockfiles/update-snapshots.sh
@@ -4,10 +4,10 @@ bazel run @@//v54:repos
 bazel run @@//v60:repos
 bazel run @@//v61:repos
 bazel run @@//v90:repos
-bazel run @@//v10:repos
+bazel run @@//v101:repos
 
 bazel run --enable_bzlmod=false @@//v54:wksp-repos
 bazel run --enable_bzlmod=false @@//v60:wksp-repos
 bazel run --enable_bzlmod=false @@//v61:wksp-repos
 bazel run --enable_bzlmod=false @@//v90:wksp-repos
-bazel run --enable_bzlmod=false @@//v10:wksp-repos
+bazel run --enable_bzlmod=false @@//v101:wksp-repos

--- a/e2e/pnpm_lockfiles/v101/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v101/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   diff: https://github.com/kpdecker/jsdiff/archive/refs/tags/v5.2.0.tar.gz
   fsevents: ^2.3
   typescript: 5.5.2
+  '@types/glob': ^8.1.0
 
 patchedDependencies:
   meaning-of-life@1.0.0:

--- a/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v54/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   diff: https://github.com/kpdecker/jsdiff/archive/refs/tags/v5.2.0.tar.gz
   fsevents: ^2.3
   typescript: 5.5.2
+  '@types/glob': ^8.1.0
 
 patchedDependencies:
   meaning-of-life@1.0.0:

--- a/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v60/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   diff: https://github.com/kpdecker/jsdiff/archive/refs/tags/v5.2.0.tar.gz
   fsevents: ^2.3
   typescript: 5.5.2
+  '@types/glob': ^8.1.0
 
 patchedDependencies:
   meaning-of-life@1.0.0:

--- a/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v61/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   diff: https://github.com/kpdecker/jsdiff/archive/refs/tags/v5.2.0.tar.gz
   fsevents: ^2.3
   typescript: 5.5.2
+  '@types/glob': ^8.1.0
 
 patchedDependencies:
   meaning-of-life@1.0.0:

--- a/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/v90/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   diff: https://github.com/kpdecker/jsdiff/archive/refs/tags/v5.2.0.tar.gz
   fsevents: ^2.3
   typescript: 5.5.2
+  '@types/glob': ^8.1.0
 
 patchedDependencies:
   meaning-of-life@1.0.0:


### PR DESCRIPTION
Override the version `@types/glob` to keep it at v8, because v9 adds a dependency on the real `glob` package and brings in a lot.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
