### PR TITLE
chore: turn on tools_telemetry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,10 +10,14 @@ module(
 # Lower-bounds (minimum) versions for direct runtime dependencies.
 # Do not bump these unless rules_js requires a newer version to function.
 bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.2.2")
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "rules_nodejs", version = "6.3.0")
+
+tel = use_extension("@aspect_tools_telemetry//:extension.bzl", "telemetry")
+use_repo(tel, "aspect_tools_telemetry_report")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 use_repo(node, "nodejs_toolchains")

--- a/README.md
+++ b/README.md
@@ -167,3 +167,7 @@ This third approach has trade-offs.
     and must ensure that sources are copied there first.
     This forces users to pass a `BAZEL_BINDIR` in the environment of every node action.
     https://github.com/bazelbuild/bazel/issues/15470 suggests a way to improve that, avoiding that imposition on users.
+
+# Telemetry & privacy policy
+
+This ruleset collects limited usage data via [`tools_telemetry`](https://github.com/aspect-build/tools_telemetry), which is reported to Aspect Build Inc and governed by our [privacy policy](https://www.aspect.build/privacy-policy).

--- a/e2e/worker/BUILD.bazel
+++ b/e2e/worker/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load(":defs.bzl", "pi_rule")
 
 copy_file(

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -5,7 +5,6 @@ local_path_override(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
-bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "rules_nodejs", version = "6.3.0", dev_dependency = True)
 
 node = use_extension(

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -4,6 +4,7 @@ See https://bazel.build/docs/bzlmod#extension-definition
 
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
 load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
+load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load("@bazel_features//:features.bzl", "bazel_features")
 load("//npm:repositories.bzl", "npm_import", "pnpm_repository", _DEFAULT_PNPM_VERSION = "DEFAULT_PNPM_VERSION", _LATEST_PNPM_VERSION = "LATEST_PNPM_VERSION")
 load("//npm/private:exclude_package_contents_default.bzl", "exclude_package_contents_default")


### PR DESCRIPTION
See also https://github.com/aspect-build/rules_py/pull/612

### Changes are visible to end-users: yes

- Suggested release notes appear below: yes/no

`aspect_tools_telemetry` is now used for coarse grained usage tracking.

### Test plan

- Manual testing (`build ...`) produced a telemetry report.