### PR TITLE
chore: add non_ascii directory to export-ignore

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -4,6 +4,7 @@ set -o errexit -o nounset -o pipefail
 
 # Don't include e2e or examples in the distribution artifact, to reduce size
 echo >.git/info/attributes "examples export-ignore"
+echo >>.git/info/attributes "js/private/test/image/non_ascii export-ignore"
 # But **do** include e2e/bzlmod since the BCR wants to run presubmit test
 # and it only sees our release artifact.
 # shellcheck disable=2010


### PR DESCRIPTION
If users don't have locales setup correctly, just having this is the
archive makes the download fail. If the build doesn't otherwise have
non-ascii characters the fact that their locales are incorrect doesn't
matter besides this failure:

```
ERROR: Skipping '//...': error loading package under directory '': no such package '@@aspect_rules_js+//js': java.io.IOException: Error extracting .../aspect_rules_js+/temp7219254014548800952/rules_js-v2.3.8.tar.gz to .../aspect_rules_js+/temp7219254014548800952: [unix_jni.cc:281] .../aspect_rules_js+/js/private/test/image/non_ascii/empty empty.?? (No such file or directory)
```
