### PR TITLE
feat: RUNFILES_DIR compatibility

### DIFF
--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -150,6 +150,12 @@ trap _exit EXIT
 export RUNFILES
 JS_BINARY__RUNFILES="$RUNFILES"
 export JS_BINARY__RUNFILES
+# Set RUNFILES_DIR for compatibility with languages obeying the design laid out in
+# https://github.com/bazelbuild/bazel/issues/4460
+if [ -z "${RUNFILES_DIR:-}" ]; then
+    RUNFILES_DIR="$RUNFILES"
+fi
+export RUNFILES_DIR
 
 # ==============================================================================
 # Prepare to run main program


### PR DESCRIPTION
Add this environment variable in line with https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub

For compatibility with existing users and workarounds, the variable is conditionally exported.

Resolves #1180 

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes/no

### Test plan

 - Manual testing; successful invocation on Mac and Linux. `js_binary` invokes a `go_binary` that relies on transitive runfiles from a `sh_binary`