### PR TITLE
fix: don't use version 0.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,6 @@
 
 module(
     name = "aspect_rules_js",
-    version = "0.0.0",
     bazel_compatibility = [">=6.0.0"],
     compatibility_level = 1,
 )


### PR DESCRIPTION
See bazel-contrib/rules-template#148
