### PR TITLE
chore: update tools_telemetry to 0.2.8

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 # Lower-bounds (minimum) versions for direct runtime dependencies.
 # Do not bump these unless rules_js requires a newer version to function.
 bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
-bazel_dep(name = "aspect_tools_telemetry", version = "0.2.6")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.2.8")
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -18,6 +18,7 @@ bzl_library(
         "//js/private:js_library",
         "//js/private:js_run_binary",
         "//js/private:js_run_devserver",
+        "@aspect_tools_telemetry_report//:defs.bzl",
     ],
 )
 

--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -1,5 +1,6 @@
 """Rules for running JavaScript programs"""
 
+load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load(
     "//js/private:js_binary.bzl",
     _js_binary = "js_binary",

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -31,3 +31,10 @@ def rules_js_dependencies():
         strip_prefix = "bazel-lib-2.16.0",
         url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.16.0/bazel-lib-v2.16.0.tar.gz",
     )
+
+    http_archive(
+        name = "aspect_tools_telemetry_report",
+        sha256 = "fea3bc2f9b7896ab222756c27147b1f1b8f489df8114e03d252ffff475f8bce6",
+        strip_prefix = "tools_telemetry-0.2.8",
+        url = "https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.8/tools_telemetry-v0.2.8.tar.gz",
+    )

--- a/npm/defs.bzl
+++ b/npm/defs.bzl
@@ -1,6 +1,7 @@
 """Rules for fetching and linking npm dependencies and packaging and linking first-party deps
 """
 
+load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load(
     "//npm/private:npm_link_package.bzl",
     _npm_link_package = "npm_link_package",

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -4,7 +4,6 @@ See https://bazel.build/docs/bzlmod#extension-definition
 
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
 load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
-load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load("@bazel_features//:features.bzl", "bazel_features")
 load("//npm:repositories.bzl", "npm_import", "pnpm_repository", _DEFAULT_PNPM_VERSION = "DEFAULT_PNPM_VERSION", _LATEST_PNPM_VERSION = "LATEST_PNPM_VERSION")
 load("//npm/private:exclude_package_contents_default.bzl", "exclude_package_contents_default")


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
