### PR TITLE
fix(js_run_devserver): do not output run--watch EXIT errors by default

### DIFF
--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -796,8 +796,20 @@ class AspectWatchProtocol {
 
     async disconnect() {
         if (this.connection.writable) {
-            await this._send('EXIT')
+            try {
+                await this._send('EXIT')
+            } catch (e) {
+                if (JS_BINARY__LOG_DEBUG) {
+                    console.log(
+                        'AspectWatchProtocol[disconnect]: failed to send EXIT message:',
+                        e
+                    )
+                }
+            }
+
             await new Promise((resolve) => this.connection.end(resolve))
+
+            this.connection.destroy()
         }
 
         return this


### PR DESCRIPTION
When the process is terminated with something such as cmd-c it is very common the process will not finish sending/receiving the full EXIT message from the CLI so we shouldn't spam stdout.

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: `aspect run --watch` on a `js_run_devserver` target such as webpack/rspack, cmd-c and ensure no error is outputted
