### PR TITLE
Adopt new NodeJS runtime toolchain

### DIFF
--- a/e2e/pnpm_workspace/BUILD.bazel
+++ b/e2e/pnpm_workspace/BUILD.bazel
@@ -18,7 +18,7 @@ sh_test(
         "@nodejs_linux_amd64//:node_files",
         "@nodejs_linux_arm64//:node_files",
     ],
-    toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
+    toolchains = ["@rules_nodejs//nodejs:current_node_runtime"],
 )
 
 build_test(

--- a/e2e/pnpm_workspace_rerooted/BUILD.bazel
+++ b/e2e/pnpm_workspace_rerooted/BUILD.bazel
@@ -18,7 +18,7 @@ sh_test(
         "@nodejs_linux_amd64//:node_files",
         "@nodejs_linux_arm64//:node_files",
     ],
-    toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
+    toolchains = ["@rules_nodejs//nodejs:current_node_runtime"],
 )
 
 build_test(

--- a/examples/genrule/BUILD.bazel
+++ b/examples/genrule/BUILD.bazel
@@ -43,8 +43,8 @@ genrule(
         # $@ is bazel shorthand for the path of the output file
         ">$@",
     ]),
-    toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
-    tools = ["@nodejs_toolchains//:resolved_toolchain"],
+    toolchains = ["@rules_nodejs//nodejs:current_node_toolchain"],
+    tools = ["@rules_nodejs//nodejs:current_node_toolchain"],
 )
 
 diff_test(
@@ -74,8 +74,8 @@ genrule(
         $(NODE_PATH) \\
         ./$(execpath :require_acorn_js) \\
         $@""",
-    toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
-    tools = ["@nodejs_toolchains//:resolved_toolchain"],
+    toolchains = ["@rules_nodejs//nodejs:current_node_toolchain"],
+    tools = ["@rules_nodejs//nodejs:current_node_toolchain"],
 )
 
 diff_test(

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -287,7 +287,7 @@ _ATTRS = {
         """,
     ),
     "node_toolchain": attr.label(
-        doc = """The Node.js toolchain to use for this target.
+        doc = """The Node.js runtime toolchain to use for this target.
 
         See https://bazel-contrib.github.io/rules_nodejs/Toolchains.html
 
@@ -505,7 +505,7 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
     if ctx.attr.node_toolchain:
         nodeinfo = ctx.attr.node_toolchain[platform_common.ToolchainInfo].nodeinfo
     else:
-        nodeinfo = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo
+        nodeinfo = ctx.toolchains["@rules_nodejs//nodejs:runtime_toolchain_type"].nodeinfo
 
     if DirectoryPathInfo in ctx.attr.entry_point:
         entry_point = ctx.attr.entry_point[DirectoryPathInfo].directory
@@ -636,7 +636,7 @@ js_binary_lib = struct(
     toolchains = [
         # TODO: on Windows this toolchain is never referenced
         "@bazel_tools//tools/sh:toolchain_type",
-        "@rules_nodejs//nodejs:toolchain_type",
+        "@rules_nodejs//nodejs:runtime_toolchain_type",
     ] + COPY_FILE_TO_BIN_TOOLCHAINS,
 )
 

--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -408,7 +408,7 @@ else {
         transitive = [files],
     )
 
-    nodeinfo = ctx.attr._current_node[platform_common.ToolchainInfo].nodeinfo
+    nodeinfo = ctx.attr._node_tool[platform_common.ToolchainInfo].nodeinfo
     if hasattr(nodeinfo, "node"):
         node_exec = nodeinfo.node
     else:
@@ -627,8 +627,8 @@ js_image_layer_lib = struct(
             default = "//js/private:js_image_layer.mjs",
             allow_single_file = True,
         ),
-        "_current_node": attr.label(
-            default = "@nodejs_toolchains//:resolved_toolchain",
+        "_node_tool": attr.label(
+            default = "@rules_nodejs//nodejs:current_node_toolchain",
             cfg = "exec",
         ),
         "binary": attr.label(
@@ -687,6 +687,7 @@ js_image_layer = rule(
     doc = _DOC,
     toolchains = [
         tar_lib.toolchain_type,
-        "@rules_nodejs//nodejs:toolchain_type",
+        "@rules_nodejs//nodejs:toolchain_type",  # for executing Node in our actions
+        "@rules_nodejs//nodejs:runtime_toolchain_type",  # for bundling Node for target platform (rely on js_binary)
     ],
 )

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -75,5 +75,5 @@ sh_test(
         "@nodejs_linux_amd64//:node_files",
         "@nodejs_linux_arm64//:node_files",
     ],
-    toolchains = ["@nodejs_toolchains//:resolved_toolchain"],
+    toolchains = ["@rules_nodejs//nodejs:current_node_runtime"],
 )


### PR DESCRIPTION
`js_binary` should use the new runtime toolchain to avoid execution toolchain being leaked into target environments (eg.,  `js_image_oci`)

See https://github.com/bazel-contrib/rules_nodejs/issues/3854

Depends on: 

- https://github.com/bazel-contrib/rules_nodejs/pull/3859

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

> Switched `js_binary` (and `js_test`) to start using the new runtime toolchain type introduced by `rules_nodejs` to better support cross-platform builds (eg., building `arm64` container from `amd64`). 

### Test plan

- Covered by existing test cases
