### PR TITLE
fix(pnpm): don't print dumb warning

### DIFF
--- a/npm/private/pnpm_extension.bzl
+++ b/npm/private/pnpm_extension.bzl
@@ -50,6 +50,7 @@ def resolve_pnpm_repositories(modules):
     for name, version_list in registrations.items():
         # Disregard repeated version numbers
         versions = unique(version_list)
+
         # Use "Minimal Version Selection" like bzlmod does for resolving module conflicts
         # Note, the 'sorted(list)' function in starlark doesn't allow us to provide a custom comparator
         if len(versions) > 1:

--- a/npm/private/pnpm_extension.bzl
+++ b/npm/private/pnpm_extension.bzl
@@ -1,5 +1,6 @@
 """pnpm extension logic (the extension itself is in npm/extensions.bzl)."""
 
+load("@aspect_bazel_lib//lib:lists.bzl", "unique")
 load(":pnpm_repository.bzl", "LATEST_PNPM_VERSION")
 
 DEFAULT_PNPM_REPO_NAME = "pnpm"
@@ -46,7 +47,9 @@ def resolve_pnpm_repositories(modules):
             registrations[attr.name].append(v)
             if attr.pnpm_version_integrity:
                 integrity[attr.pnpm_version] = attr.pnpm_version_integrity
-    for name, versions in registrations.items():
+    for name, version_list in registrations.items():
+        # Disregard repeated version numbers
+        versions = unique(version_list)
         # Use "Minimal Version Selection" like bzlmod does for resolving module conflicts
         # Note, the 'sorted(list)' function in starlark doesn't allow us to provide a custom comparator
         if len(versions) > 1:

--- a/npm/private/test/pnpm_test.bzl
+++ b/npm/private/test/pnpm_test.bzl
@@ -106,17 +106,12 @@ def _custom_name(ctx):
 
 def _integrity_conflict(ctx):
     # What happens if two modules define the same version with conflicting integrity parameters.
-    # @gzm0, 2024-10-04: The behavior here is probably not intended and merely an implementation artifact.
-    # I've added a test anyways to capture the existing behavior.
-
+    # Currently we print nothing to indicate this, we trust whichever integrity wins.
     return _resolve_test(
         ctx,
         repositories = {
             "pnpm": ("8.6.7", "dep-integrity"),
         },
-        notes = [
-            """NOTE: repo 'pnpm' has multiple versions ["8.6.7", "8.6.7"]; selected 8.6.7""",
-        ],
         # Modules are *BFS* from root:
         # https://bazel.build/rules/lib/builtins/module_ctx#modules
         modules = [


### PR DESCRIPTION
I keep seeing

`DEBUG: /private/var/tmp/_bazel_alexeagle/9a577879aedc63bdf5030f4fbc898758/external/aspect_rules_js+/npm/extensions.bzl:272:18: NOTE: repo 'pnpm' has multiple versions ["8.6.7", "8.6.7"]; selected 8.6.7`

which is not useful.
