### PR TITLE
feat: add pnpm_version_from

### DIFF
--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -63,9 +63,13 @@ pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 # not some transitive dependency.
 pnpm.pnpm(
     name = "pnpm",
-    pnpm_version = "8.15.2",
+    pnpm_version_from = "//:package.json",
+)
+pnpm.pnpm(
+    name = "other_pnpm",
+    pnpm_version = "9.15.9",
 )
 
 # Allows developers to run the identical version of pnpm for local workflows like
 # bazel run -- @pnpm --dir $PWD install
-use_repo(pnpm, "pnpm")
+use_repo(pnpm, "other_pnpm", "pnpm")

--- a/e2e/bzlmod/package.json
+++ b/e2e/bzlmod/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "type": "module",
+    "packageManager": "pnpm@10.13.1",
     "dependencies": {
         "chalk": "5.3.0",
         "less": "4.1.3",

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -292,7 +292,7 @@ npm = module_extension(
 )
 
 def _pnpm_extension_impl(module_ctx):
-    resolved = resolve_pnpm_repositories(module_ctx.modules)
+    resolved = resolve_pnpm_repositories(module_ctx)
 
     for note in resolved.notes:
         # buildifier: disable=print
@@ -317,6 +317,10 @@ pnpm = module_extension(
                 "pnpm_version": attr.string(
                     doc = "pnpm version to use. The string `latest` will be resolved to LATEST_PNPM_VERSION.",
                     default = DEFAULT_PNPM_VERSION,
+                ),
+                "pnpm_version_from": attr.label(
+                    doc = "Label to a package.json file to read the pnpm version from. It should be in the packageManager attribute.",
+                    default = None,
                 ),
                 "pnpm_version_integrity": attr.string(),
             },

--- a/npm/private/pnpm_extension.bzl
+++ b/npm/private/pnpm_extension.bzl
@@ -40,8 +40,8 @@ def resolve_pnpm_repositories(mctx):
             if not registrations.get(attr.name, False):
                 registrations[attr.name] = []
 
-            if attr.pnpm_version_from and attr.pnpm_version != DEFAULT_PNPM_VERSION:
-                fail("Cannot specify both pnpm_version and pnpm_version_from")
+            if attr.pnpm_version_from and attr.pnpm_version and attr.pnpm_version != DEFAULT_PNPM_VERSION:
+                fail("Cannot specify both pnpm_version = {} and pnpm_version_from = {}".format(attr.pnpm_version, attr.pnpm_version_from))
 
             # Handle pnpm_version_from by reading package.json
             if attr.pnpm_version_from != None:

--- a/npm/private/test/pnpm_test.bzl
+++ b/npm/private/test/pnpm_test.bzl
@@ -8,6 +8,7 @@ def _fake_pnpm_tag(version, name = DEFAULT_PNPM_REPO_NAME, integrity = None):
     return struct(
         name = name,
         pnpm_version = version,
+        pnpm_version_from = None,
         pnpm_version_integrity = integrity,
     )
 
@@ -25,7 +26,7 @@ def _resolve_test(ctx, repositories = [], notes = [], modules = []):
         notes = notes,
     )
 
-    result = resolve_pnpm_repositories(modules)
+    result = resolve_pnpm_repositories(struct(modules = modules))
 
     asserts.equals(env, expected, result)
     return unittest.end(env)
@@ -51,9 +52,7 @@ def _override(ctx):
     return _resolve_test(
         ctx,
         repositories = {"pnpm": "9.1.0"},
-        notes = [
-            """NOTE: repo 'pnpm' has multiple versions ["9.1.0", "8.6.7"]; selected 9.1.0""",
-        ],
+        notes = [],
         modules = [
             _fake_mod(
                 True,

--- a/npm/private/test/pnpm_test.bzl
+++ b/npm/private/test/pnpm_test.bzl
@@ -4,11 +4,11 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//npm/private:pnpm_extension.bzl", "DEFAULT_PNPM_REPO_NAME", "resolve_pnpm_repositories")
 load("//npm/private:pnpm_repository.bzl", "LATEST_PNPM_VERSION")
 
-def _fake_pnpm_tag(version, name = DEFAULT_PNPM_REPO_NAME, integrity = None):
+def _fake_pnpm_tag(version = None, name = DEFAULT_PNPM_REPO_NAME, integrity = None, pnpm_version_from = None):
     return struct(
         name = name,
         pnpm_version = version,
-        pnpm_version_from = None,
+        pnpm_version_from = pnpm_version_from,
         pnpm_version_integrity = integrity,
     )
 
@@ -18,7 +18,7 @@ def _fake_mod(is_root, *pnpm_tags):
         tags = struct(pnpm = pnpm_tags),
     )
 
-def _resolve_test(ctx, repositories = [], notes = [], modules = []):
+def _resolve_test(ctx, repositories = [], notes = [], modules = [], package_json_content = None):
     env = unittest.begin(ctx)
 
     expected = struct(
@@ -26,7 +26,7 @@ def _resolve_test(ctx, repositories = [], notes = [], modules = []):
         notes = notes,
     )
 
-    result = resolve_pnpm_repositories(struct(modules = modules))
+    result = resolve_pnpm_repositories(struct(modules = modules, read = lambda f: package_json_content))
 
     asserts.equals(env, expected, result)
     return unittest.end(env)
@@ -45,6 +45,16 @@ def _basic(ctx):
                 _fake_pnpm_tag(version = "8.6.7", integrity = "8.6.7-integrity"),
             ),
         ],
+    )
+
+def _from_package_json(ctx):
+    return _resolve_test(
+        ctx,
+        repositories = {"pnpm": "1.2.3"},
+        modules = [
+            _fake_mod(True, _fake_pnpm_tag(pnpm_version_from = "//:package.json")),
+        ],
+        package_json_content = json.encode({"packageManager": "pnpm@1.2.3"}),
     )
 
 def _override(ctx):
@@ -130,6 +140,7 @@ override_test = unittest.make(_override)
 latest_test = unittest.make(_latest)
 custom_name_test = unittest.make(_custom_name)
 integrity_conflict_test = unittest.make(_integrity_conflict)
+from_package_json_test = unittest.make(_from_package_json)
 
 def pnpm_tests(name):
     unittest.suite(
@@ -139,4 +150,5 @@ def pnpm_tests(name):
         latest_test,
         custom_name_test,
         integrity_conflict_test,
+        from_package_json_test,
     )


### PR DESCRIPTION
Ideally pnpm version should be kept in-sync with non-Bazel codepaths, and the easiest way to do this is the packageManager field in package.json

See https://github.com/nodejs/corepack#when-authoring-packages
