### PR TITLE
feat(npm): make repo rules reproducible

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -174,6 +174,9 @@ See https://github.com/aspect-build/rules_js/issues/1445
         state.link_workspace(),
     )
 
+    if hasattr(rctx, "repo_metadata"):
+        return rctx.repo_metadata(reproducible = True)
+
 npm_translate_lock_rule = repository_rule(
     implementation = _npm_translate_lock_impl,
     attrs = _ATTRS,


### PR DESCRIPTION
In order to use the `--repo_contents_cache`, we need to mark the repository rule as reproducible.

See https://github.com/bazel-contrib/bazel-gazelle/pull/2119 as an example

### Changes are visible to end-users: yes/no

The contents of their `repo_contents_cache` might be different.