### PR TITLE
fix: update `pnpm_version_from` to support `packageManager` fields with `+sha512.<hash>`

### DIFF
--- a/npm/private/pnpm_extension.bzl
+++ b/npm/private/pnpm_extension.bzl
@@ -58,6 +58,8 @@ def resolve_pnpm_repositories(mctx):
 
                 # Extract version from "pnpm@8.15.9" format
                 v = package_manager[5:]  # Remove "pnpm@" prefix
+                v = v.rsplit("+sha512.")[0]  # Remove optional "+sha512.<hash>" suffix
+
             elif attr.pnpm_version == "latest":
                 v = LATEST_PNPM_VERSION
             else:

--- a/npm/private/test/pnpm_test.bzl
+++ b/npm/private/test/pnpm_test.bzl
@@ -47,7 +47,7 @@ def _basic(ctx):
         ],
     )
 
-def _from_package_json(ctx):
+def _from_package_json_simple(ctx):
     return _resolve_test(
         ctx,
         repositories = {"pnpm": "1.2.3"},
@@ -55,6 +55,16 @@ def _from_package_json(ctx):
             _fake_mod(True, _fake_pnpm_tag(pnpm_version_from = "//:package.json")),
         ],
         package_json_content = json.encode({"packageManager": "pnpm@1.2.3"}),
+    )
+
+def _from_package_json_with_hash(ctx):
+    return _resolve_test(
+        ctx,
+        repositories = {"pnpm": "1.2.3"},
+        modules = [
+            _fake_mod(True, _fake_pnpm_tag(pnpm_version_from = "//:package.json")),
+        ],
+        package_json_content = json.encode({"packageManager": "pnpm@1.2.3+sha512.97462997561378b6f52ac5c614f3a3b923a652ad5ac987100286e4aa2d84a6a0642e9e45f3d01d30c46b12b20beb0f86aeb790bf9a82bc59db42b67fe69d1a25"}),
     )
 
 def _override(ctx):
@@ -140,7 +150,8 @@ override_test = unittest.make(_override)
 latest_test = unittest.make(_latest)
 custom_name_test = unittest.make(_custom_name)
 integrity_conflict_test = unittest.make(_integrity_conflict)
-from_package_json_test = unittest.make(_from_package_json)
+from_package_json_simple_test = unittest.make(_from_package_json_simple)
+from_package_json_with_hash_test = unittest.make(_from_package_json_with_hash)
 
 def pnpm_tests(name):
     unittest.suite(
@@ -150,5 +161,6 @@ def pnpm_tests(name):
         latest_test,
         custom_name_test,
         integrity_conflict_test,
-        from_package_json_test,
+        from_package_json_simple_test,
+        from_package_json_with_hash_test,
     )


### PR DESCRIPTION
Update `pnpm_version_from` to support `package.json` `packageManager` fields with a `+sha512.<hash>` suffix.

For example: 

```json
"packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef",
```
---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`pnpm_version_from` now supports `packageManager` fields with a `+sha512.<hash>` suffix.

### Test plan

- Covered by existing test cases
- New test cases added

