### PR TITLE
chore: use local buildifier target for pre-commit

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -92,6 +92,7 @@ buildifier(
     lint_warnings = ["-out-of-order-load"],  # TODO: enable out-of-order-load
     mode = "fix",
     tags = ["manual"],  # tag as manual so windows ci does not build it by default
+    visibility = ["//visibility:public"],
 )
 
 buildifier(
@@ -104,6 +105,7 @@ buildifier(
     lint_warnings = ["-out-of-order-load"],  # TODO: enable out-of-order-load
     mode = "diff",
     tags = ["manual"],  # tag as manual so windows ci does not build it by default
+    visibility = ["//visibility:public"],
 )
 
 alias(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -12,7 +12,7 @@ package(default_visibility = ["//:__subpackages__"])
 format_multirun(
     name = "format",
     shell = "@aspect_rules_lint//format:shfmt",
-    starlark = "@buildifier_prebuilt//:buildifier",
+    starlark = "//:buildifier",
 )
 
 bazelrc_preset(


### PR DESCRIPTION
We need to use the local target which has some config specified such as `exclude_patterns`.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
