### PR TITLE
Fix js_run_devserver shell script tools on Windows

### DIFF
--- a/js/private/js_run_devserver.mjs
+++ b/js/private/js_run_devserver.mjs
@@ -427,6 +427,12 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     )
 }
 
+function isWindowsScript(tool) {
+    const toolExtension = path.extname(tool)
+    const isScriptFile = toolExtension === '.bat' || toolExtension === '.cmd'
+    return isScriptFile && os.platform() === 'win32'
+}
+
 async function main(args, sandbox) {
     console.error(
         `\n\nStarting js_run_devserver ${process.env.JS_BINARY__TARGET}`
@@ -518,6 +524,10 @@ async function runIBazelProtocol(
         const proc = child_process.spawn(tool, toolArgs, {
             cwd: cwd,
             env: env,
+
+            // `.cmd` and `.bat` are always executed in a shell on windows
+            // and require the flag to be set per CVE-2024-27980
+            shell: isWindowsScript(tool),
 
             // Pipe stdin data to the child process rather than simply letting
             // the child process inherit the stream and consume the data itself.
@@ -631,6 +641,11 @@ async function runWatchProtocol(
         const proc = child_process.spawn(tool, toolArgs, {
             cwd,
             env,
+
+            // `.cmd` and `.bat` are always executed in a shell on windows
+            // and require the flag to be set per CVE-2024-27980
+            shell: isWindowsScript(tool),
+
             stdio: 'inherit',
         })
         proc.on('close', resolve)


### PR DESCRIPTION
On Windows, when js_run_devserver is run with a batch script tool (like `js_binary` targets) node returns `Error: spawn EINVAL` at [child_process.spawn](https://github.com/aspect-build/rules_js/blob/c6ff6f34a570f22920b2836ea605f94c350511b5/js/private/js_run_devserver.mjs#L518-L531). This is because these script files are always run under a shell on Windows so nodejs requires the shell flag to be set [per the CVE-2024-27980](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2).

This PR only enables the shell flag for `bat` and `cmd` files on Windows to restore the previous behaviour.

Closes #2348

---

### Changes are visible to end-users: no

This was the existing behaviour before the CVE fix broke it.

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce: Run `js_run_devserver` with a `js_binary` tool on Windows
