### PR TITLE
refactor: group fp package store targets alongside third-party

### DIFF
--- a/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
@@ -178,6 +178,134 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_68(name)
         store_69(name)
         store_70(name)
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
+            src = "//projects/c:pkg",
+            package = "@scoped/c",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
+            src = "//vendored/is-number:pkg",
+            package = "is-number",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "@scoped/a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
+            src = "//projects/b:pkg",
+            package = "@scoped/b",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
+            src = "//projects/d:pkg",
+            package = "@scoped/d",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "alias-project-a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
+            src = "//projects/b:pkg",
+            package = "scoped/bad",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
+            src = "//projects/peers-combo-2:pkg",
+            package = "test-c200-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
+            src = "//projects/peers-combo-1:pkg",
+            package = "test-c201-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
+            src = "//projects/a-types:pkg",
+            package = "a-types",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_4("{}/@aspect-test-a-bad-scope".format(name), False, name, "@aspect-test-a-bad-scope")
@@ -347,21 +475,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_50("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
-            src = "//projects/c:pkg",
-            package = "@scoped/c",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -385,30 +498,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "is-number@0.0.0",
-            src = "//vendored/is-number:pkg",
-            package = "is-number",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "@scoped/a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
@@ -434,20 +523,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+b@0.0.0",
-            src = "//projects/b:pkg",
-            package = "@scoped/b",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -471,21 +546,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+d@0.0.0",
-            src = "//projects/d:pkg",
-            package = "@scoped/d",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -511,18 +571,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "alias-project-a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "alias-project-a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -542,20 +590,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/alias-project-a".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "scoped+bad@0.0.0",
-            src = "//projects/b:pkg",
-            package = "scoped/bad",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -577,21 +611,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/scoped/bad".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c200-d200@0.0.0",
-            src = "//projects/peers-combo-2:pkg",
-            package = "test-c200-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -611,21 +630,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-c200-d200".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c201-d200@0.0.0",
-            src = "//projects/peers-combo-1:pkg",
-            package = "test-c201-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -647,18 +651,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/test-c201-d200".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-peer-types@0.0.0",
-            src = "//projects/peer-types:pkg",
-            package = "test-peer-types",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -678,20 +670,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-peer-types".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "a-types@0.0.0",
-            src = "//projects/a-types:pkg",
-            package = "a-types",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["projects/b"]:
         # terminal target for direct dependencies

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -176,6 +176,133 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_67(name)
         store_68(name)
         store_69(name)
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
+            src = "//projects/c:pkg",
+            package = "@scoped/c",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
+            src = "//vendored/is-number:pkg",
+            package = "is-number",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "@scoped/a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
+            src = "//projects/b:pkg",
+            package = "@scoped/b",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
+            src = "//projects/d:pkg",
+            package = "@scoped/d",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "alias-project-a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
+            src = "//projects/b:pkg",
+            package = "scoped/bad",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
+            src = "//projects/peers-combo-2:pkg",
+            package = "test-c200-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
+            src = "//projects/peers-combo-1:pkg",
+            package = "test-c201-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
+            src = "//projects/a-types:pkg",
+            package = "a-types",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_4("{}/@aspect-test-a-bad-scope".format(name), False, name, "@aspect-test-a-bad-scope")
@@ -339,21 +466,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_49("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
-            src = "//projects/c:pkg",
-            package = "@scoped/c",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -377,30 +489,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "is-number@0.0.0",
-            src = "//vendored/is-number:pkg",
-            package = "is-number",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "@scoped/a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
@@ -426,20 +514,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+b@0.0.0",
-            src = "//projects/b:pkg",
-            package = "@scoped/b",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -463,20 +537,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+d@0.0.0",
-            src = "//projects/d:pkg",
-            package = "@scoped/d",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -502,18 +562,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "alias-project-a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "alias-project-a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -533,20 +581,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/alias-project-a".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "scoped+bad@0.0.0",
-            src = "//projects/b:pkg",
-            package = "scoped/bad",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -568,21 +602,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/scoped/bad".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c200-d200@0.0.0",
-            src = "//projects/peers-combo-2:pkg",
-            package = "test-c200-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -602,21 +621,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-c200-d200".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c201-d200@0.0.0",
-            src = "//projects/peers-combo-1:pkg",
-            package = "test-c201-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -638,18 +642,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/test-c201-d200".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-peer-types@0.0.0",
-            src = "//projects/peer-types:pkg",
-            package = "test-peer-types",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -669,20 +661,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-peer-types".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "a-types@0.0.0",
-            src = "//projects/a-types:pkg",
-            package = "a-types",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["projects/b"]:
         # terminal target for direct dependencies

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -178,6 +178,134 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_68(name)
         store_69(name)
         store_70(name)
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
+            src = "//projects/c:pkg",
+            package = "@scoped/c",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
+            src = "//vendored/is-number:pkg",
+            package = "is-number",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "@scoped/a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
+            src = "//projects/b:pkg",
+            package = "@scoped/b",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
+            src = "//projects/d:pkg",
+            package = "@scoped/d",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "alias-project-a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
+            src = "//projects/b:pkg",
+            package = "scoped/bad",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
+            src = "//projects/peers-combo-2:pkg",
+            package = "test-c200-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
+            src = "//projects/peers-combo-1:pkg",
+            package = "test-c201-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
+            src = "//projects/a-types:pkg",
+            package = "a-types",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_4("{}/@aspect-test-a-bad-scope".format(name), False, name, "@aspect-test-a-bad-scope")
@@ -347,21 +475,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_50("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
-            src = "//projects/c:pkg",
-            package = "@scoped/c",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -385,30 +498,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "is-number@0.0.0",
-            src = "//vendored/is-number:pkg",
-            package = "is-number",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "@scoped/a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
@@ -434,20 +523,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+b@0.0.0",
-            src = "//projects/b:pkg",
-            package = "@scoped/b",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -471,21 +546,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+d@0.0.0",
-            src = "//projects/d:pkg",
-            package = "@scoped/d",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -511,18 +571,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "alias-project-a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "alias-project-a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -542,20 +590,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/alias-project-a".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "scoped+bad@0.0.0",
-            src = "//projects/b:pkg",
-            package = "scoped/bad",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -577,21 +611,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/scoped/bad".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c200-d200@0.0.0",
-            src = "//projects/peers-combo-2:pkg",
-            package = "test-c200-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -611,21 +630,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-c200-d200".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c201-d200@0.0.0",
-            src = "//projects/peers-combo-1:pkg",
-            package = "test-c201-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -647,18 +651,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/test-c201-d200".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-peer-types@0.0.0",
-            src = "//projects/peer-types:pkg",
-            package = "test-peer-types",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -678,20 +670,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-peer-types".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "a-types@0.0.0",
-            src = "//projects/a-types:pkg",
-            package = "a-types",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["projects/b"]:
         # terminal target for direct dependencies

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -178,6 +178,134 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_68(name)
         store_69(name)
         store_70(name)
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
+            src = "//projects/c:pkg",
+            package = "@scoped/c",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
+            src = "//vendored/is-number:pkg",
+            package = "is-number",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "@scoped/a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
+            src = "//projects/b:pkg",
+            package = "@scoped/b",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
+            src = "//projects/d:pkg",
+            package = "@scoped/d",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "alias-project-a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
+            src = "//projects/b:pkg",
+            package = "scoped/bad",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
+            src = "//projects/peers-combo-2:pkg",
+            package = "test-c200-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
+            src = "//projects/peers-combo-1:pkg",
+            package = "test-c201-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
+            src = "//projects/a-types:pkg",
+            package = "a-types",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_4("{}/@aspect-test-a-bad-scope".format(name), False, name, "@aspect-test-a-bad-scope")
@@ -347,21 +475,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_50("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
-            src = "//projects/c:pkg",
-            package = "@scoped/c",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -385,30 +498,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "is-number@0.0.0",
-            src = "//vendored/is-number:pkg",
-            package = "is-number",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "@scoped/a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
@@ -434,20 +523,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+b@0.0.0",
-            src = "//projects/b:pkg",
-            package = "@scoped/b",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -471,21 +546,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+d@0.0.0",
-            src = "//projects/d:pkg",
-            package = "@scoped/d",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -511,18 +571,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "alias-project-a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "alias-project-a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -542,20 +590,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/alias-project-a".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "scoped+bad@0.0.0",
-            src = "//projects/b:pkg",
-            package = "scoped/bad",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -577,21 +611,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/scoped/bad".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c200-d200@0.0.0",
-            src = "//projects/peers-combo-2:pkg",
-            package = "test-c200-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -611,21 +630,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-c200-d200".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c201-d200@0.0.0",
-            src = "//projects/peers-combo-1:pkg",
-            package = "test-c201-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -647,18 +651,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/test-c201-d200".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-peer-types@0.0.0",
-            src = "//projects/peer-types:pkg",
-            package = "test-peer-types",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -678,20 +670,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-peer-types".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "a-types@0.0.0",
-            src = "//projects/a-types:pkg",
-            package = "a-types",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["projects/b"]:
         # terminal target for direct dependencies

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -178,6 +178,134 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_68(name)
         store_69(name)
         store_70(name)
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+c@0.0.0",
+            src = "//projects/c:pkg",
+            package = "@scoped/c",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-number@0.0.0",
+            src = "//vendored/is-number:pkg",
+            package = "is-number",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "@scoped/a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+b@0.0.0",
+            src = "//projects/b:pkg",
+            package = "@scoped/b",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@scoped+d@0.0.0",
+            src = "//projects/d:pkg",
+            package = "@scoped/d",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "alias-project-a@0.0.0",
+            src = "//projects/a:pkg",
+            package = "alias-project-a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "scoped+bad@0.0.0",
+            src = "//projects/b:pkg",
+            package = "scoped/bad",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c200-d200@0.0.0",
+            src = "//projects/peers-combo-2:pkg",
+            package = "test-c200-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-c201-d200@0.0.0",
+            src = "//projects/peers-combo-1:pkg",
+            package = "test-c201-d200",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-peer-types@0.0.0",
+            src = "//projects/peer-types:pkg",
+            package = "test-peer-types",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "a-types@0.0.0",
+            src = "//projects/a-types:pkg",
+            package = "a-types",
+            version = "0.0.0",
+            deps = {
+                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
     if link:
         if bazel_package == "<LOCKVERSION>":
             link_4("{}/@aspect-test-a-bad-scope".format(name), False, name, "@aspect-test-a-bad-scope")
@@ -347,21 +475,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_50("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
-            src = "//projects/c:pkg",
-            package = "@scoped/c",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -385,30 +498,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "is-number@0.0.0",
-            src = "//vendored/is-number:pkg",
-            package = "is-number",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "@scoped/a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
@@ -434,20 +523,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+b@0.0.0",
-            src = "//projects/b:pkg",
-            package = "@scoped/b",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -471,21 +546,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@scoped"] = [link_targets[-1]]
         else:
             scope_targets["@scoped"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@scoped+d@0.0.0",
-            src = "//projects/d:pkg",
-            package = "@scoped/d",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -511,18 +571,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@scoped"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "alias-project-a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "alias-project-a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -542,20 +590,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/alias-project-a".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "scoped+bad@0.0.0",
-            src = "//projects/b:pkg",
-            package = "scoped/bad",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -577,21 +611,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/scoped/bad".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c200-d200@0.0.0",
-            src = "//projects/peers-combo-2:pkg",
-            package = "test-c200-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.0".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.0".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -611,21 +630,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-c200-d200".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-c201-d200@0.0.0",
-            src = "//projects/peers-combo-1:pkg",
-            package = "test-c201-d200",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+c@2.0.1".format(name): "@aspect-test/c",
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.1".format(name): "@aspect-test/d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
@@ -647,18 +651,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/test-c201-d200".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-peer-types@0.0.0",
-            src = "//projects/peer-types:pkg",
-            package = "test-peer-types",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["<LOCKVERSION>"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -678,20 +670,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/test-peer-types".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "a-types@0.0.0",
-            src = "//projects/a-types:pkg",
-            package = "a-types",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "@types/node",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["projects/b"]:
         # terminal target for direct dependencies

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -62,6 +62,96 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_10(name)
         store_11(name)
         store_12(name)
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "vendored-a@0.0.0",
+            src = "//vendored/a:pkg",
+            package = "vendored-a",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "vendored-b@0.0.0",
+            src = "//vendored/b:pkg",
+            package = "vendored-b",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+a@0.0.0",
+            src = "//lib/a:pkg",
+            package = "@lib/a",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e",
+                "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
+                "//:.aspect_rules_js/{}/vendored-a@0.0.0".format(name): "vendored-a",
+                "//:.aspect_rules_js/{}/vendored-b@0.0.0".format(name): "vendored-b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+b@0.0.0",
+            src = "//lib/b:pkg",
+            package = "@lib/b",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
+                "//:.aspect_rules_js/{}/@types+sizzle@2.3.8".format(name): "alias-1",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+b_alias@0.0.0",
+            src = "//lib/b:pkg",
+            package = "@lib/b_alias",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
+                "//:.aspect_rules_js/{}/@types+sizzle@2.3.8".format(name): "alias-1",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+c@0.0.0",
+            src = "//lib/c:pkg",
+            package = "@lib/c",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+d@0.0.0",
+            src = "//lib/d:pkg",
+            package = "@lib/d",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.2".format(name): "@aspect-test/d",
+                "//:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "alias-2",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
     if link:
         if bazel_package == "":
             link_0("{}/@aspect-test/a".format(name), False, name, "@aspect-test/a")
@@ -159,20 +249,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "vendored-a@0.0.0",
-            src = "//vendored/a:pkg",
-            package = "vendored-a",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["lib/a"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -193,20 +269,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/vendored-a".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "vendored-b@0.0.0",
-            src = "//vendored/b:pkg",
-            package = "vendored-b",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["lib/a"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -226,23 +288,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/vendored-b".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+a@0.0.0",
-            src = "//lib/a:pkg",
-            package = "@lib/a",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e",
-                "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
-                "//:.aspect_rules_js/{}/vendored-a@0.0.0".format(name): "vendored-a",
-                "//:.aspect_rules_js/{}/vendored-b@0.0.0".format(name): "vendored-b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["app/a"]:
         # terminal target for direct dependencies
@@ -268,21 +313,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@lib"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+b@0.0.0",
-            src = "//lib/b:pkg",
-            package = "@lib/b",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
-                "//:.aspect_rules_js/{}/@types+sizzle@2.3.8".format(name): "alias-1",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["app/b", "lib/a"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -306,21 +336,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@lib"] = [link_targets[-1]]
         else:
             scope_targets["@lib"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+b_alias@0.0.0",
-            src = "//lib/b:pkg",
-            package = "@lib/b_alias",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
-                "//:.aspect_rules_js/{}/@types+sizzle@2.3.8".format(name): "alias-1",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["app/b"]:
         # terminal target for direct dependencies
@@ -346,20 +361,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@lib"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+c@0.0.0",
-            src = "//lib/c:pkg",
-            package = "@lib/c",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["app/c"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -383,21 +384,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@lib"] = [link_targets[-1]]
         else:
             scope_targets["@lib"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+d@0.0.0",
-            src = "//lib/d:pkg",
-            package = "@lib/d",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.2".format(name): "@aspect-test/d",
-                "//:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "alias-2",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["app/d"]:
         # terminal target for direct dependencies

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -62,6 +62,96 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_10(name)
         store_11(name)
         store_12(name)
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+c@0.0.0",
+            src = "//lib/c:pkg",
+            package = "@lib/c",
+            version = "0.0.0",
+            deps = {
+                "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "vendored-a@0.0.0",
+            src = "//vendored/a:pkg",
+            package = "vendored-a",
+            version = "0.0.0",
+            deps = {
+                "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "vendored-b@0.0.0",
+            src = "//vendored/b:pkg",
+            package = "vendored-b",
+            version = "0.0.0",
+            deps = {
+                "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+a@0.0.0",
+            src = "//lib/a:pkg",
+            package = "@lib/a",
+            version = "0.0.0",
+            deps = {
+                "//root:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e",
+                "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
+                "//root:.aspect_rules_js/{}/vendored-a@0.0.0".format(name): "vendored-a",
+                "//root:.aspect_rules_js/{}/vendored-b@0.0.0".format(name): "vendored-b",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+b@0.0.0",
+            src = "//lib/b:pkg",
+            package = "@lib/b",
+            version = "0.0.0",
+            deps = {
+                "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
+                "//root:.aspect_rules_js/{}/@types+sizzle@2.3.8".format(name): "alias-1",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+b_alias@0.0.0",
+            src = "//lib/b:pkg",
+            package = "@lib/b_alias",
+            version = "0.0.0",
+            deps = {
+                "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
+                "//root:.aspect_rules_js/{}/@types+sizzle@2.3.8".format(name): "alias-1",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+d@0.0.0",
+            src = "//lib/d:pkg",
+            package = "@lib/d",
+            version = "0.0.0",
+            deps = {
+                "//root:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.2".format(name): "@aspect-test/d",
+                "//root:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "alias-2",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
     if link:
         if bazel_package == "":
             link_0("{}/@aspect-test/a".format(name), False, name, "@aspect-test/a")
@@ -159,20 +249,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+c@0.0.0",
-            src = "//lib/c:pkg",
-            package = "@lib/c",
-            version = "0.0.0",
-            deps = {
-                "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["app/c"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -197,20 +273,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@lib"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "vendored-a@0.0.0",
-            src = "//vendored/a:pkg",
-            package = "vendored-a",
-            version = "0.0.0",
-            deps = {
-                "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["lib/a"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -231,20 +293,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/vendored-a".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "vendored-b@0.0.0",
-            src = "//vendored/b:pkg",
-            package = "vendored-b",
-            version = "0.0.0",
-            deps = {
-                "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["lib/a"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -264,23 +312,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/vendored-b".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+a@0.0.0",
-            src = "//lib/a:pkg",
-            package = "@lib/a",
-            version = "0.0.0",
-            deps = {
-                "//root:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e",
-                "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
-                "//root:.aspect_rules_js/{}/vendored-a@0.0.0".format(name): "vendored-a",
-                "//root:.aspect_rules_js/{}/vendored-b@0.0.0".format(name): "vendored-b",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["app/a"]:
         # terminal target for direct dependencies
@@ -306,21 +337,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@lib"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+b@0.0.0",
-            src = "//lib/b:pkg",
-            package = "@lib/b",
-            version = "0.0.0",
-            deps = {
-                "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
-                "//root:.aspect_rules_js/{}/@types+sizzle@2.3.8".format(name): "alias-1",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["app/b", "lib/a"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -345,21 +361,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@lib"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+b_alias@0.0.0",
-            src = "//lib/b:pkg",
-            package = "@lib/b_alias",
-            version = "0.0.0",
-            deps = {
-                "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
-                "//root:.aspect_rules_js/{}/@types+sizzle@2.3.8".format(name): "alias-1",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["app/b"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -383,21 +384,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@lib"] = [link_targets[-1]]
         else:
             scope_targets["@lib"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+d@0.0.0",
-            src = "//lib/d:pkg",
-            package = "@lib/d",
-            version = "0.0.0",
-            deps = {
-                "//root:.aspect_rules_js/{}/@aspect-test+d@2.0.0_at_aspect-test_c_2.0.2".format(name): "@aspect-test/d",
-                "//root:.aspect_rules_js/{}/@types+node@18.19.54".format(name): "alias-2",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["app/d"]:
         # terminal target for direct dependencies

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -2344,6 +2344,136 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_1131(name)
         store_1132(name)
         store_1133(name)
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "is-odd@0.0.0",
+            src = "//npm/private/test/vendored/is-odd:pkg",
+            package = "is-odd",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/is-number@6.0.0".format(name): "is-number",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "semver-max@0.0.0",
+            src = "//npm/private/test/vendored/semver-max:pkg",
+            package = "semver-max",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/is-odd@0.0.0".format(name): "is-odd",
+                "//:.aspect_rules_js/{}/semver@5.7.2".format(name): "semver",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@mycorp+pkg-a@0.0.0",
+            src = "//examples/npm_package/packages/pkg_a:pkg",
+            package = "@mycorp/pkg-a",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/acorn@8.7.1".format(name): "acorn",
+                "//:.aspect_rules_js/{}/uuid@8.3.2".format(name): "uuid",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "js_lib_pkg_a@0.0.0",
+            src = "//examples/js_lib_pkg/a:pkg",
+            package = "js_lib_pkg_a",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "js_lib_pkg_a-alias_1@0.0.0",
+            src = "//examples/js_lib_pkg/a:pkg",
+            package = "js_lib_pkg_a-alias_1",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "js_lib_pkg_a-alias_2@0.0.0",
+            src = "//examples/js_lib_pkg/a:pkg",
+            package = "js_lib_pkg_a-alias_2",
+            version = "0.0.0",
+            deps = {},
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+test@0.0.0",
+            src = "//examples/linked_pkg:pkg",
+            package = "@lib/test",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e,alias-e",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@lib+test2@0.0.0",
+            src = "//examples/linked_lib:pkg",
+            package = "@lib/test2",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e,alias-e",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@mycorp+pkg-d@0.0.0",
+            src = "//examples/npm_package/packages/pkg_d:pkg",
+            package = "@mycorp/pkg-d",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/acorn@8.7.1".format(name): "acorn",
+                "//:.aspect_rules_js/{}/uuid@8.3.2".format(name): "uuid",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "@mycorp+pkg-e@0.0.0",
+            src = "//examples/npm_package/packages/pkg_e:pkg",
+            package = "@mycorp/pkg-e",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/@mycorp+pkg-d@0.0.0".format(name): "@mycorp/pkg-d",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
+        _npm_local_package_store(
+            link_root_name = name,
+            package_store_name = "test-npm_package@0.0.0",
+            src = "//npm/private/test/npm_package:pkg",
+            package = "test-npm_package",
+            version = "0.0.0",
+            deps = {
+                "//:.aspect_rules_js/{}/chalk@5.0.1".format(name): "chalk",
+                "//:.aspect_rules_js/{}/chalk@5.1.1".format(name): "chalk-alt",
+            },
+            visibility = ["//visibility:public"],
+            tags = ["manual"],
+        )
     if link:
         if bazel_package == "js/private/worker/src":
             link_1("{}/abortcontroller-polyfill".format(name), True, name, "abortcontroller-polyfill")
@@ -2719,50 +2849,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_991("{}/source-map-support".format(name), True, name, "source-map-support")
             link_targets.append(":{}/source-map-support".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "is-odd@0.0.0",
-            src = "//npm/private/test/vendored/is-odd:pkg",
-            package = "is-odd",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/is-number@6.0.0".format(name): "is-number",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "semver-max@0.0.0",
-            src = "//npm/private/test/vendored/semver-max:pkg",
-            package = "semver-max",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/is-odd@0.0.0".format(name): "is-odd",
-                "//:.aspect_rules_js/{}/semver@5.7.2".format(name): "semver",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@mycorp+pkg-a@0.0.0",
-            src = "//examples/npm_package/packages/pkg_a:pkg",
-            package = "@mycorp/pkg-a",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/acorn@8.7.1".format(name): "acorn",
-                "//:.aspect_rules_js/{}/uuid@8.3.2".format(name): "uuid",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["js/private/test/image", "examples/js_binary", "examples/npm_deps"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -2787,18 +2873,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@mycorp"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "js_lib_pkg_a@0.0.0",
-            src = "//examples/js_lib_pkg/a:pkg",
-            package = "js_lib_pkg_a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["examples/js_lib_pkg/b"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -2818,18 +2892,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/js_lib_pkg_a".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "js_lib_pkg_a-alias_1@0.0.0",
-            src = "//examples/js_lib_pkg/a:pkg",
-            package = "js_lib_pkg_a-alias_1",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["examples/js_lib_pkg/b"]:
         # terminal target for direct dependencies
@@ -2851,18 +2913,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         link_targets.append(":{}/js_lib_pkg_a-alias_1".format(name))
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "js_lib_pkg_a-alias_2@0.0.0",
-            src = "//examples/js_lib_pkg/a:pkg",
-            package = "js_lib_pkg_a-alias_2",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["examples/js_lib_pkg/b"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -2882,20 +2932,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         link_targets.append(":{}/js_lib_pkg_a-alias_2".format(name))
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+test@0.0.0",
-            src = "//examples/linked_pkg:pkg",
-            package = "@lib/test",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e,alias-e",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["examples/linked_consumer"]:
         # terminal target for direct dependencies
@@ -2921,20 +2957,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@lib"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@lib+test2@0.0.0",
-            src = "//examples/linked_lib:pkg",
-            package = "@lib/test2",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e,alias-e",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["examples/linked_consumer"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -2958,21 +2980,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@lib"] = [link_targets[-1]]
         else:
             scope_targets["@lib"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@mycorp+pkg-d@0.0.0",
-            src = "//examples/npm_package/packages/pkg_d:pkg",
-            package = "@mycorp/pkg-d",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/acorn@8.7.1".format(name): "acorn",
-                "//:.aspect_rules_js/{}/uuid@8.3.2".format(name): "uuid",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["examples/npm_package/packages/pkg_e", "js/private/test/image", "examples/npm_deps"]:
         # terminal target for direct dependencies
@@ -2998,20 +3005,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         else:
             scope_targets["@mycorp"].append(link_targets[-1])
 
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "@mycorp+pkg-e@0.0.0",
-            src = "//examples/npm_package/packages/pkg_e:pkg",
-            package = "@mycorp/pkg-e",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/@mycorp+pkg-d@0.0.0".format(name): "@mycorp/pkg-d",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
     if bazel_package in ["examples/npm_deps"]:
         # terminal target for direct dependencies
         _npm_link_package_store(
@@ -3035,21 +3028,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets["@mycorp"] = [link_targets[-1]]
         else:
             scope_targets["@mycorp"].append(link_targets[-1])
-
-    if is_root:
-        _npm_local_package_store(
-            link_root_name = name,
-            package_store_name = "test-npm_package@0.0.0",
-            src = "//npm/private/test/npm_package:pkg",
-            package = "test-npm_package",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/{}/chalk@5.0.1".format(name): "chalk",
-                "//:.aspect_rules_js/{}/chalk@5.1.1".format(name): "chalk-alt",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
 
     if bazel_package in ["npm/private/test"]:
         # terminal target for direct dependencies


### PR DESCRIPTION
To align the first-party and third-party code more, in prep for more cleanup+refactoring.

There should be no functional changes other then the `_npm_local_package_store` invocations now all being done before the `_npm_link_package_store` and `link_targets.append(...)` which should have no side-effects.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
