### PR TITLE
refactor: group fp package linking alongside third-party

### DIFF
--- a/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
@@ -420,6 +420,40 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/typescript".format(name))
             link_68("{}/uvu".format(name), False, name, "uvu")
             link_targets.append(":{}/uvu".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_4(name)
+            link_targets.append(":{}/@scoped/d".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_5(name)
+            link_targets.append(":{}/alias-project-a".format(name))
+            _fp_link_6(name)
+            link_targets.append(":{}/scoped/bad".format(name))
+            _fp_link_7(name)
+            link_targets.append(":{}/test-c200-d200".format(name))
+            _fp_link_8(name)
+            link_targets.append(":{}/test-c201-d200".format(name))
+            _fp_link_9(name)
+            link_targets.append(":{}/test-peer-types".format(name))
         elif bazel_package == "projects/peers-combo-2":
             link_6("{}/@aspect-test/c".format(name), False, name, "@aspect-test/c")
             link_targets.append(":{}/@aspect-test/c".format(name))
@@ -451,6 +485,24 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/jsonify".format(name))
             link_36("{}/hello".format(name), True, name, "hello")
             link_targets.append(":{}/hello".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
         elif bazel_package == "projects/a-types":
             link_22("{}/@types/node".format(name), False, name, "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -465,6 +517,14 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@types"] = [link_targets[-1]]
             else:
                 scope_targets["@types"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_10(name)
+            link_targets.append(":{}/a-types".format(name))
         elif bazel_package == "projects/alts":
             link_48("{}/lodash-4.17.20".format(name), False, name, "lodash-4.17.20")
             link_targets.append(":{}/lodash-4.17.20".format(name))
@@ -474,222 +534,32 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/lodash".format(name))
             link_50("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
-
-    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/c".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/c/dir".format(name),
-            srcs = [":{}/@scoped/c".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/c".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/a/dir".format(name),
-            srcs = [":{}/@scoped/a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/a".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/b".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/b/dir".format(name),
-            srcs = [":{}/@scoped/b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/b".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/d".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/d/dir".format(name),
-            srcs = [":{}/@scoped/d".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/d".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/alias-project-a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/alias-project-a/dir".format(name),
-            srcs = [":{}/alias-project-a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/alias-project-a".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/scoped/bad".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/scoped/bad/dir".format(name),
-            srcs = [":{}/scoped/bad".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/scoped/bad".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c200-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c200-d200/dir".format(name),
-            srcs = [":{}/test-c200-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c200-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c201-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c201-d200/dir".format(name),
-            srcs = [":{}/test-c201-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c201-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-peer-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-peer-types/dir".format(name),
-            srcs = [":{}/test-peer-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-peer-types".format(name))
-
-    if bazel_package in ["projects/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/a-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/a-types/dir".format(name),
-            srcs = [":{}/a-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/a-types".format(name))
+        elif bazel_package == "projects/c":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+        elif bazel_package == "projects/d":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
 
     for scope, scoped_targets in scope_targets.items():
         _js_library(
@@ -800,3 +670,174 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 link_targets.append(":{}/@scoped/a".format(name))
                 link_targets.append(":{}/@scoped/b".format(name))
     return link_targets
+
+
+# Generated npm_link_package_store for linking of first-party "@scoped/c" package
+# buildifier: disable=function-docstring
+def _fp_link_0(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/c".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/c/dir".format(name),
+        srcs = [":{}/@scoped/c".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/a" package
+# buildifier: disable=function-docstring
+def _fp_link_2(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/a/dir".format(name),
+        srcs = [":{}/@scoped/a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/b" package
+# buildifier: disable=function-docstring
+def _fp_link_3(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/b".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/b/dir".format(name),
+        srcs = [":{}/@scoped/b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/d" package
+# buildifier: disable=function-docstring
+def _fp_link_4(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/d".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/d/dir".format(name),
+        srcs = [":{}/@scoped/d".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "alias-project-a" package
+# buildifier: disable=function-docstring
+def _fp_link_5(name):
+    _npm_link_package_store(
+        name = "{}/alias-project-a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/alias-project-a/dir".format(name),
+        srcs = [":{}/alias-project-a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "scoped/bad" package
+# buildifier: disable=function-docstring
+def _fp_link_6(name):
+    _npm_link_package_store(
+        name = "{}/scoped/bad".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/scoped/bad/dir".format(name),
+        srcs = [":{}/scoped/bad".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c200-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_7(name):
+    _npm_link_package_store(
+        name = "{}/test-c200-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c200-d200/dir".format(name),
+        srcs = [":{}/test-c200-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c201-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_8(name):
+    _npm_link_package_store(
+        name = "{}/test-c201-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c201-d200/dir".format(name),
+        srcs = [":{}/test-c201-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-peer-types" package
+# buildifier: disable=function-docstring
+def _fp_link_9(name):
+    _npm_link_package_store(
+        name = "{}/test-peer-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-peer-types/dir".format(name),
+        srcs = [":{}/test-peer-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "a-types" package
+# buildifier: disable=function-docstring
+def _fp_link_10(name):
+    _npm_link_package_store(
+        name = "{}/a-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/a-types/dir".format(name),
+        srcs = [":{}/a-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -411,6 +411,40 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/typescript".format(name))
             link_67("{}/uvu".format(name), False, name, "uvu")
             link_targets.append(":{}/uvu".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_4(name)
+            link_targets.append(":{}/@scoped/d".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_5(name)
+            link_targets.append(":{}/alias-project-a".format(name))
+            _fp_link_6(name)
+            link_targets.append(":{}/scoped/bad".format(name))
+            _fp_link_7(name)
+            link_targets.append(":{}/test-c200-d200".format(name))
+            _fp_link_8(name)
+            link_targets.append(":{}/test-c201-d200".format(name))
+            _fp_link_9(name)
+            link_targets.append(":{}/test-peer-types".format(name))
         elif bazel_package == "projects/peers-combo-2":
             link_6("{}/@aspect-test/c".format(name), False, name, "@aspect-test/c")
             link_targets.append(":{}/@aspect-test/c".format(name))
@@ -442,6 +476,24 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/jsonify".format(name))
             link_35("{}/hello".format(name), True, name, "hello")
             link_targets.append(":{}/hello".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
         elif bazel_package == "projects/a-types":
             link_21("{}/@types/node".format(name), False, name, "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -456,6 +508,14 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@types"] = [link_targets[-1]]
             else:
                 scope_targets["@types"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_10(name)
+            link_targets.append(":{}/a-types".format(name))
         elif bazel_package == "projects/alts":
             link_47("{}/lodash-4.17.20".format(name), False, name, "lodash-4.17.20")
             link_targets.append(":{}/lodash-4.17.20".format(name))
@@ -465,222 +525,20 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/lodash".format(name))
             link_49("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
-
-    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/c".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/c/dir".format(name),
-            srcs = [":{}/@scoped/c".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/c".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/a/dir".format(name),
-            srcs = [":{}/@scoped/a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/a".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/b".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/b/dir".format(name),
-            srcs = [":{}/@scoped/b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/b".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/d".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/d/dir".format(name),
-            srcs = [":{}/@scoped/d".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/d".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/alias-project-a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/alias-project-a/dir".format(name),
-            srcs = [":{}/alias-project-a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/alias-project-a".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/scoped/bad".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/scoped/bad/dir".format(name),
-            srcs = [":{}/scoped/bad".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/scoped/bad".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c200-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c200-d200/dir".format(name),
-            srcs = [":{}/test-c200-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c200-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c201-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c201-d200/dir".format(name),
-            srcs = [":{}/test-c201-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c201-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-peer-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-peer-types/dir".format(name),
-            srcs = [":{}/test-peer-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-peer-types".format(name))
-
-    if bazel_package in ["projects/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/a-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/a-types/dir".format(name),
-            srcs = [":{}/a-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/a-types".format(name))
+        elif bazel_package == "projects/c":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+        elif bazel_package == "projects/d":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
 
     for scope, scoped_targets in scope_targets.items():
         _js_library(
@@ -788,3 +646,174 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
         if prod:
                 link_targets.append(":{}/@scoped/a".format(name))
     return link_targets
+
+
+# Generated npm_link_package_store for linking of first-party "@scoped/c" package
+# buildifier: disable=function-docstring
+def _fp_link_0(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/c".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/c/dir".format(name),
+        srcs = [":{}/@scoped/c".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/a" package
+# buildifier: disable=function-docstring
+def _fp_link_2(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/a/dir".format(name),
+        srcs = [":{}/@scoped/a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/b" package
+# buildifier: disable=function-docstring
+def _fp_link_3(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/b".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/b/dir".format(name),
+        srcs = [":{}/@scoped/b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/d" package
+# buildifier: disable=function-docstring
+def _fp_link_4(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/d".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/d/dir".format(name),
+        srcs = [":{}/@scoped/d".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "alias-project-a" package
+# buildifier: disable=function-docstring
+def _fp_link_5(name):
+    _npm_link_package_store(
+        name = "{}/alias-project-a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/alias-project-a/dir".format(name),
+        srcs = [":{}/alias-project-a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "scoped/bad" package
+# buildifier: disable=function-docstring
+def _fp_link_6(name):
+    _npm_link_package_store(
+        name = "{}/scoped/bad".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/scoped/bad/dir".format(name),
+        srcs = [":{}/scoped/bad".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c200-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_7(name):
+    _npm_link_package_store(
+        name = "{}/test-c200-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c200-d200/dir".format(name),
+        srcs = [":{}/test-c200-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c201-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_8(name):
+    _npm_link_package_store(
+        name = "{}/test-c201-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c201-d200/dir".format(name),
+        srcs = [":{}/test-c201-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-peer-types" package
+# buildifier: disable=function-docstring
+def _fp_link_9(name):
+    _npm_link_package_store(
+        name = "{}/test-peer-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-peer-types/dir".format(name),
+        srcs = [":{}/test-peer-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "a-types" package
+# buildifier: disable=function-docstring
+def _fp_link_10(name):
+    _npm_link_package_store(
+        name = "{}/a-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/a-types/dir".format(name),
+        srcs = [":{}/a-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -420,6 +420,40 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/typescript".format(name))
             link_68("{}/uvu".format(name), False, name, "uvu")
             link_targets.append(":{}/uvu".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_4(name)
+            link_targets.append(":{}/@scoped/d".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_5(name)
+            link_targets.append(":{}/alias-project-a".format(name))
+            _fp_link_6(name)
+            link_targets.append(":{}/scoped/bad".format(name))
+            _fp_link_7(name)
+            link_targets.append(":{}/test-c200-d200".format(name))
+            _fp_link_8(name)
+            link_targets.append(":{}/test-c201-d200".format(name))
+            _fp_link_9(name)
+            link_targets.append(":{}/test-peer-types".format(name))
         elif bazel_package == "projects/peers-combo-2":
             link_6("{}/@aspect-test/c".format(name), False, name, "@aspect-test/c")
             link_targets.append(":{}/@aspect-test/c".format(name))
@@ -451,6 +485,24 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/jsonify".format(name))
             link_36("{}/hello".format(name), True, name, "hello")
             link_targets.append(":{}/hello".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
         elif bazel_package == "projects/a-types":
             link_22("{}/@types/node".format(name), False, name, "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -465,6 +517,14 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@types"] = [link_targets[-1]]
             else:
                 scope_targets["@types"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_10(name)
+            link_targets.append(":{}/a-types".format(name))
         elif bazel_package == "projects/alts":
             link_48("{}/lodash-4.17.20".format(name), False, name, "lodash-4.17.20")
             link_targets.append(":{}/lodash-4.17.20".format(name))
@@ -474,222 +534,32 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/lodash".format(name))
             link_50("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
-
-    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/c".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/c/dir".format(name),
-            srcs = [":{}/@scoped/c".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/c".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/a/dir".format(name),
-            srcs = [":{}/@scoped/a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/a".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/b".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/b/dir".format(name),
-            srcs = [":{}/@scoped/b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/b".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/d".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/d/dir".format(name),
-            srcs = [":{}/@scoped/d".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/d".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/alias-project-a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/alias-project-a/dir".format(name),
-            srcs = [":{}/alias-project-a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/alias-project-a".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/scoped/bad".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/scoped/bad/dir".format(name),
-            srcs = [":{}/scoped/bad".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/scoped/bad".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c200-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c200-d200/dir".format(name),
-            srcs = [":{}/test-c200-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c200-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c201-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c201-d200/dir".format(name),
-            srcs = [":{}/test-c201-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c201-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-peer-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-peer-types/dir".format(name),
-            srcs = [":{}/test-peer-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-peer-types".format(name))
-
-    if bazel_package in ["projects/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/a-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/a-types/dir".format(name),
-            srcs = [":{}/a-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/a-types".format(name))
+        elif bazel_package == "projects/c":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+        elif bazel_package == "projects/d":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
 
     for scope, scoped_targets in scope_targets.items():
         _js_library(
@@ -800,3 +670,174 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 link_targets.append(":{}/@scoped/a".format(name))
                 link_targets.append(":{}/@scoped/b".format(name))
     return link_targets
+
+
+# Generated npm_link_package_store for linking of first-party "@scoped/c" package
+# buildifier: disable=function-docstring
+def _fp_link_0(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/c".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/c/dir".format(name),
+        srcs = [":{}/@scoped/c".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/a" package
+# buildifier: disable=function-docstring
+def _fp_link_2(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/a/dir".format(name),
+        srcs = [":{}/@scoped/a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/b" package
+# buildifier: disable=function-docstring
+def _fp_link_3(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/b".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/b/dir".format(name),
+        srcs = [":{}/@scoped/b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/d" package
+# buildifier: disable=function-docstring
+def _fp_link_4(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/d".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/d/dir".format(name),
+        srcs = [":{}/@scoped/d".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "alias-project-a" package
+# buildifier: disable=function-docstring
+def _fp_link_5(name):
+    _npm_link_package_store(
+        name = "{}/alias-project-a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/alias-project-a/dir".format(name),
+        srcs = [":{}/alias-project-a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "scoped/bad" package
+# buildifier: disable=function-docstring
+def _fp_link_6(name):
+    _npm_link_package_store(
+        name = "{}/scoped/bad".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/scoped/bad/dir".format(name),
+        srcs = [":{}/scoped/bad".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c200-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_7(name):
+    _npm_link_package_store(
+        name = "{}/test-c200-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c200-d200/dir".format(name),
+        srcs = [":{}/test-c200-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c201-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_8(name):
+    _npm_link_package_store(
+        name = "{}/test-c201-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c201-d200/dir".format(name),
+        srcs = [":{}/test-c201-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-peer-types" package
+# buildifier: disable=function-docstring
+def _fp_link_9(name):
+    _npm_link_package_store(
+        name = "{}/test-peer-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-peer-types/dir".format(name),
+        srcs = [":{}/test-peer-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "a-types" package
+# buildifier: disable=function-docstring
+def _fp_link_10(name):
+    _npm_link_package_store(
+        name = "{}/a-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/a-types/dir".format(name),
+        srcs = [":{}/a-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -420,6 +420,40 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/typescript".format(name))
             link_68("{}/uvu".format(name), False, name, "uvu")
             link_targets.append(":{}/uvu".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_4(name)
+            link_targets.append(":{}/@scoped/d".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_5(name)
+            link_targets.append(":{}/alias-project-a".format(name))
+            _fp_link_6(name)
+            link_targets.append(":{}/scoped/bad".format(name))
+            _fp_link_7(name)
+            link_targets.append(":{}/test-c200-d200".format(name))
+            _fp_link_8(name)
+            link_targets.append(":{}/test-c201-d200".format(name))
+            _fp_link_9(name)
+            link_targets.append(":{}/test-peer-types".format(name))
         elif bazel_package == "projects/peers-combo-2":
             link_6("{}/@aspect-test/c".format(name), False, name, "@aspect-test/c")
             link_targets.append(":{}/@aspect-test/c".format(name))
@@ -451,6 +485,24 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/jsonify".format(name))
             link_36("{}/hello".format(name), True, name, "hello")
             link_targets.append(":{}/hello".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
         elif bazel_package == "projects/a-types":
             link_22("{}/@types/node".format(name), False, name, "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -465,6 +517,14 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@types"] = [link_targets[-1]]
             else:
                 scope_targets["@types"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_10(name)
+            link_targets.append(":{}/a-types".format(name))
         elif bazel_package == "projects/alts":
             link_48("{}/lodash-4.17.20".format(name), False, name, "lodash-4.17.20")
             link_targets.append(":{}/lodash-4.17.20".format(name))
@@ -474,222 +534,32 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/lodash".format(name))
             link_50("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
-
-    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/c".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/c/dir".format(name),
-            srcs = [":{}/@scoped/c".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/c".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/a/dir".format(name),
-            srcs = [":{}/@scoped/a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/a".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/b".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/b/dir".format(name),
-            srcs = [":{}/@scoped/b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/b".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/d".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/d/dir".format(name),
-            srcs = [":{}/@scoped/d".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/d".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/alias-project-a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/alias-project-a/dir".format(name),
-            srcs = [":{}/alias-project-a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/alias-project-a".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/scoped/bad".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/scoped/bad/dir".format(name),
-            srcs = [":{}/scoped/bad".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/scoped/bad".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c200-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c200-d200/dir".format(name),
-            srcs = [":{}/test-c200-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c200-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c201-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c201-d200/dir".format(name),
-            srcs = [":{}/test-c201-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c201-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-peer-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-peer-types/dir".format(name),
-            srcs = [":{}/test-peer-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-peer-types".format(name))
-
-    if bazel_package in ["projects/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/a-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/a-types/dir".format(name),
-            srcs = [":{}/a-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/a-types".format(name))
+        elif bazel_package == "projects/c":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+        elif bazel_package == "projects/d":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
 
     for scope, scoped_targets in scope_targets.items():
         _js_library(
@@ -800,3 +670,174 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 link_targets.append(":{}/@scoped/a".format(name))
                 link_targets.append(":{}/@scoped/b".format(name))
     return link_targets
+
+
+# Generated npm_link_package_store for linking of first-party "@scoped/c" package
+# buildifier: disable=function-docstring
+def _fp_link_0(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/c".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/c/dir".format(name),
+        srcs = [":{}/@scoped/c".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/a" package
+# buildifier: disable=function-docstring
+def _fp_link_2(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/a/dir".format(name),
+        srcs = [":{}/@scoped/a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/b" package
+# buildifier: disable=function-docstring
+def _fp_link_3(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/b".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/b/dir".format(name),
+        srcs = [":{}/@scoped/b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/d" package
+# buildifier: disable=function-docstring
+def _fp_link_4(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/d".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/d/dir".format(name),
+        srcs = [":{}/@scoped/d".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "alias-project-a" package
+# buildifier: disable=function-docstring
+def _fp_link_5(name):
+    _npm_link_package_store(
+        name = "{}/alias-project-a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/alias-project-a/dir".format(name),
+        srcs = [":{}/alias-project-a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "scoped/bad" package
+# buildifier: disable=function-docstring
+def _fp_link_6(name):
+    _npm_link_package_store(
+        name = "{}/scoped/bad".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/scoped/bad/dir".format(name),
+        srcs = [":{}/scoped/bad".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c200-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_7(name):
+    _npm_link_package_store(
+        name = "{}/test-c200-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c200-d200/dir".format(name),
+        srcs = [":{}/test-c200-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c201-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_8(name):
+    _npm_link_package_store(
+        name = "{}/test-c201-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c201-d200/dir".format(name),
+        srcs = [":{}/test-c201-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-peer-types" package
+# buildifier: disable=function-docstring
+def _fp_link_9(name):
+    _npm_link_package_store(
+        name = "{}/test-peer-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-peer-types/dir".format(name),
+        srcs = [":{}/test-peer-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "a-types" package
+# buildifier: disable=function-docstring
+def _fp_link_10(name):
+    _npm_link_package_store(
+        name = "{}/a-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/a-types/dir".format(name),
+        srcs = [":{}/a-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -420,6 +420,40 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/typescript".format(name))
             link_68("{}/uvu".format(name), False, name, "uvu")
             link_targets.append(":{}/uvu".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_4(name)
+            link_targets.append(":{}/@scoped/d".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_5(name)
+            link_targets.append(":{}/alias-project-a".format(name))
+            _fp_link_6(name)
+            link_targets.append(":{}/scoped/bad".format(name))
+            _fp_link_7(name)
+            link_targets.append(":{}/test-c200-d200".format(name))
+            _fp_link_8(name)
+            link_targets.append(":{}/test-c201-d200".format(name))
+            _fp_link_9(name)
+            link_targets.append(":{}/test-peer-types".format(name))
         elif bazel_package == "projects/peers-combo-2":
             link_6("{}/@aspect-test/c".format(name), False, name, "@aspect-test/c")
             link_targets.append(":{}/@aspect-test/c".format(name))
@@ -451,6 +485,24 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/jsonify".format(name))
             link_36("{}/hello".format(name), True, name, "hello")
             link_targets.append(":{}/hello".format(name))
+            _fp_link_0(name)
+            link_targets.append(":{}/@scoped/c".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
         elif bazel_package == "projects/a-types":
             link_22("{}/@types/node".format(name), False, name, "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -465,6 +517,14 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@types"] = [link_targets[-1]]
             else:
                 scope_targets["@types"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_10(name)
+            link_targets.append(":{}/a-types".format(name))
         elif bazel_package == "projects/alts":
             link_48("{}/lodash-4.17.20".format(name), False, name, "lodash-4.17.20")
             link_targets.append(":{}/lodash-4.17.20".format(name))
@@ -474,222 +534,32 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/lodash".format(name))
             link_50("{}/lodash-4.17.21-file".format(name), False, name, "lodash-4.17.21-file")
             link_targets.append(":{}/lodash-4.17.21-file".format(name))
-
-    if bazel_package in ["<LOCKVERSION>", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/c".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/c/dir".format(name),
-            srcs = [":{}/@scoped/c".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/c".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/b", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/a/dir".format(name),
-            srcs = [":{}/@scoped/a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/a".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>", "projects/c", "projects/d", "projects/peer-types"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/b".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/b/dir".format(name),
-            srcs = [":{}/@scoped/b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/b".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@scoped/d".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@scoped/d/dir".format(name),
-            srcs = [":{}/@scoped/d".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@scoped/d".format(name))
-        if "@scoped" not in scope_targets:
-            scope_targets["@scoped"] = [link_targets[-1]]
-        else:
-            scope_targets["@scoped"].append(link_targets[-1])
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/alias-project-a".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/alias-project-a/dir".format(name),
-            srcs = [":{}/alias-project-a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/alias-project-a".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/scoped/bad".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/scoped/bad/dir".format(name),
-            srcs = [":{}/scoped/bad".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/scoped/bad".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c200-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c200-d200/dir".format(name),
-            srcs = [":{}/test-c200-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c200-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-c201-d200".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-c201-d200/dir".format(name),
-            srcs = [":{}/test-c201-d200".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-c201-d200".format(name))
-
-    if bazel_package in ["<LOCKVERSION>"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-peer-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-peer-types/dir".format(name),
-            srcs = [":{}/test-peer-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-peer-types".format(name))
-
-    if bazel_package in ["projects/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/a-types".format(name),
-            src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/a-types/dir".format(name),
-            srcs = [":{}/a-types".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/a-types".format(name))
+        elif bazel_package == "projects/c":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+        elif bazel_package == "projects/d":
+            _fp_link_2(name)
+            link_targets.append(":{}/@scoped/a".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@scoped/b".format(name))
+            if "@scoped" not in scope_targets:
+                scope_targets["@scoped"] = [link_targets[-1]]
+            else:
+                scope_targets["@scoped"].append(link_targets[-1])
 
     for scope, scoped_targets in scope_targets.items():
         _js_library(
@@ -800,3 +670,174 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 link_targets.append(":{}/@scoped/a".format(name))
                 link_targets.append(":{}/@scoped/b".format(name))
     return link_targets
+
+
+# Generated npm_link_package_store for linking of first-party "@scoped/c" package
+# buildifier: disable=function-docstring
+def _fp_link_0(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/c".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/c/dir".format(name),
+        srcs = [":{}/@scoped/c".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/a" package
+# buildifier: disable=function-docstring
+def _fp_link_2(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/a/dir".format(name),
+        srcs = [":{}/@scoped/a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/b" package
+# buildifier: disable=function-docstring
+def _fp_link_3(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/b".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/b/dir".format(name),
+        srcs = [":{}/@scoped/b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@scoped/d" package
+# buildifier: disable=function-docstring
+def _fp_link_4(name):
+    _npm_link_package_store(
+        name = "{}/@scoped/d".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@scoped/d/dir".format(name),
+        srcs = [":{}/@scoped/d".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "alias-project-a" package
+# buildifier: disable=function-docstring
+def _fp_link_5(name):
+    _npm_link_package_store(
+        name = "{}/alias-project-a".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/alias-project-a/dir".format(name),
+        srcs = [":{}/alias-project-a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "scoped/bad" package
+# buildifier: disable=function-docstring
+def _fp_link_6(name):
+    _npm_link_package_store(
+        name = "{}/scoped/bad".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/scoped/bad/dir".format(name),
+        srcs = [":{}/scoped/bad".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c200-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_7(name):
+    _npm_link_package_store(
+        name = "{}/test-c200-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c200-d200/dir".format(name),
+        srcs = [":{}/test-c200-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-c201-d200" package
+# buildifier: disable=function-docstring
+def _fp_link_8(name):
+    _npm_link_package_store(
+        name = "{}/test-c201-d200".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-c201-d200/dir".format(name),
+        srcs = [":{}/test-c201-d200".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-peer-types" package
+# buildifier: disable=function-docstring
+def _fp_link_9(name):
+    _npm_link_package_store(
+        name = "{}/test-peer-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-peer-types/dir".format(name),
+        srcs = [":{}/test-peer-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "a-types" package
+# buildifier: disable=function-docstring
+def _fp_link_10(name):
+    _npm_link_package_store(
+        name = "{}/a-types".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/a-types/dir".format(name),
+        srcs = [":{}/a-types".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -189,6 +189,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+            _fp_link_2(name)
+            link_targets.append(":{}/@lib/a".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
         elif bazel_package == "app/c":
             link_0("{}/@aspect-test/a".format(name), False, name, "@aspect-test/a")
             link_targets.append(":{}/@aspect-test/a".format(name))
@@ -202,6 +208,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+            _fp_link_5(name)
+            link_targets.append(":{}/@lib/c".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
         elif bazel_package == "lib/d":
             link_3("{}/@aspect-test/d".format(name), False, name, "@aspect-test/d")
             link_targets.append(":{}/@aspect-test/d".format(name))
@@ -218,6 +230,16 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+            _fp_link_0(name)
+            link_targets.append(":{}/vendored-a".format(name))
+            _fp_link_1(name)
+            link_targets.append(":{}/vendored-b".format(name))
+            _fp_link_3(name)
+            link_targets.append(":{}/@lib/b".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
         elif bazel_package == "lib/b":
             link_5("{}/@aspect-test/f".format(name), False, name, "@aspect-test/f")
             link_targets.append(":{}/@aspect-test/f".format(name))
@@ -241,6 +263,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+            _fp_link_6(name)
+            link_targets.append(":{}/@lib/d".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
         elif bazel_package == "app/b":
             link_7("{}/@aspect-test/h".format(name), False, name, "@aspect-test/h")
             link_targets.append(":{}/@aspect-test/h".format(name))
@@ -248,166 +276,18 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
-
-    if bazel_package in ["lib/a"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/vendored-a".format(name),
-            src = "//:.aspect_rules_js/{}/vendored-a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/vendored-a/dir".format(name),
-            srcs = [":{}/vendored-a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/vendored-a".format(name))
-
-    if bazel_package in ["lib/a"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/vendored-b".format(name),
-            src = "//:.aspect_rules_js/{}/vendored-b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/vendored-b/dir".format(name),
-            srcs = [":{}/vendored-b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/vendored-b".format(name))
-
-    if bazel_package in ["app/a"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/a".format(name),
-            src = "//:.aspect_rules_js/{}/@lib+a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/a/dir".format(name),
-            srcs = [":{}/@lib/a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/a".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["app/b", "lib/a"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/b".format(name),
-            src = "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/b/dir".format(name),
-            srcs = [":{}/@lib/b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/b".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["app/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/b_alias".format(name),
-            src = "//:.aspect_rules_js/{}/@lib+b_alias@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/b_alias/dir".format(name),
-            srcs = [":{}/@lib/b_alias".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/b_alias".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["app/c"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/c".format(name),
-            src = "//:.aspect_rules_js/{}/@lib+c@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/c/dir".format(name),
-            srcs = [":{}/@lib/c".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/c".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["app/d"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/d".format(name),
-            src = "//:.aspect_rules_js/{}/@lib+d@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/d/dir".format(name),
-            srcs = [":{}/@lib/d".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/d".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@lib/b".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
+            _fp_link_4(name)
+            link_targets.append(":{}/@lib/b_alias".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
 
     for scope, scoped_targets in scope_targets.items():
         _js_library(
@@ -478,3 +358,123 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 link_targets.append(":{}/@lib/b".format(name))
                 link_targets.append(":{}/@lib/b_alias".format(name))
     return link_targets
+
+
+# Generated npm_link_package_store for linking of first-party "vendored-a" package
+# buildifier: disable=function-docstring
+def _fp_link_0(name):
+    _npm_link_package_store(
+        name = "{}/vendored-a".format(name),
+        src = "//:.aspect_rules_js/{}/vendored-a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/vendored-a/dir".format(name),
+        srcs = [":{}/vendored-a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "vendored-b" package
+# buildifier: disable=function-docstring
+def _fp_link_1(name):
+    _npm_link_package_store(
+        name = "{}/vendored-b".format(name),
+        src = "//:.aspect_rules_js/{}/vendored-b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/vendored-b/dir".format(name),
+        srcs = [":{}/vendored-b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/a" package
+# buildifier: disable=function-docstring
+def _fp_link_2(name):
+    _npm_link_package_store(
+        name = "{}/@lib/a".format(name),
+        src = "//:.aspect_rules_js/{}/@lib+a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/a/dir".format(name),
+        srcs = [":{}/@lib/a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/b" package
+# buildifier: disable=function-docstring
+def _fp_link_3(name):
+    _npm_link_package_store(
+        name = "{}/@lib/b".format(name),
+        src = "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/b/dir".format(name),
+        srcs = [":{}/@lib/b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/b_alias" package
+# buildifier: disable=function-docstring
+def _fp_link_4(name):
+    _npm_link_package_store(
+        name = "{}/@lib/b_alias".format(name),
+        src = "//:.aspect_rules_js/{}/@lib+b_alias@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/b_alias/dir".format(name),
+        srcs = [":{}/@lib/b_alias".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/c" package
+# buildifier: disable=function-docstring
+def _fp_link_5(name):
+    _npm_link_package_store(
+        name = "{}/@lib/c".format(name),
+        src = "//:.aspect_rules_js/{}/@lib+c@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/c/dir".format(name),
+        srcs = [":{}/@lib/c".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/d" package
+# buildifier: disable=function-docstring
+def _fp_link_6(name):
+    _npm_link_package_store(
+        name = "{}/@lib/d".format(name),
+        src = "//:.aspect_rules_js/{}/@lib+d@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/d/dir".format(name),
+        srcs = [":{}/@lib/d".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -189,6 +189,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/@lib/a".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
         elif bazel_package == "app/c":
             link_0("{}/@aspect-test/a".format(name), False, name, "@aspect-test/a")
             link_targets.append(":{}/@aspect-test/a".format(name))
@@ -202,6 +208,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+            _fp_link_0(name)
+            link_targets.append(":{}/@lib/c".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
         elif bazel_package == "lib/d":
             link_3("{}/@aspect-test/d".format(name), False, name, "@aspect-test/d")
             link_targets.append(":{}/@aspect-test/d".format(name))
@@ -218,6 +230,16 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+            _fp_link_1(name)
+            link_targets.append(":{}/vendored-a".format(name))
+            _fp_link_2(name)
+            link_targets.append(":{}/vendored-b".format(name))
+            _fp_link_4(name)
+            link_targets.append(":{}/@lib/b".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
         elif bazel_package == "lib/b":
             link_5("{}/@aspect-test/f".format(name), False, name, "@aspect-test/f")
             link_targets.append(":{}/@aspect-test/f".format(name))
@@ -241,6 +263,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
+            _fp_link_6(name)
+            link_targets.append(":{}/@lib/d".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
         elif bazel_package == "app/b":
             link_7("{}/@aspect-test/h".format(name), False, name, "@aspect-test/h")
             link_targets.append(":{}/@aspect-test/h".format(name))
@@ -248,166 +276,18 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@aspect-test"] = [link_targets[-1]]
             else:
                 scope_targets["@aspect-test"].append(link_targets[-1])
-
-    if bazel_package in ["app/c"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/c".format(name),
-            src = "//root:.aspect_rules_js/{}/@lib+c@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/c/dir".format(name),
-            srcs = [":{}/@lib/c".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/c".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["lib/a"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/vendored-a".format(name),
-            src = "//root:.aspect_rules_js/{}/vendored-a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/vendored-a/dir".format(name),
-            srcs = [":{}/vendored-a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/vendored-a".format(name))
-
-    if bazel_package in ["lib/a"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/vendored-b".format(name),
-            src = "//root:.aspect_rules_js/{}/vendored-b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/vendored-b/dir".format(name),
-            srcs = [":{}/vendored-b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/vendored-b".format(name))
-
-    if bazel_package in ["app/a"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/a".format(name),
-            src = "//root:.aspect_rules_js/{}/@lib+a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/a/dir".format(name),
-            srcs = [":{}/@lib/a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/a".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["app/b", "lib/a"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/b".format(name),
-            src = "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/b/dir".format(name),
-            srcs = [":{}/@lib/b".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/b".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["app/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/b_alias".format(name),
-            src = "//root:.aspect_rules_js/{}/@lib+b_alias@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/b_alias/dir".format(name),
-            srcs = [":{}/@lib/b_alias".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/b_alias".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["app/d"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/d".format(name),
-            src = "//root:.aspect_rules_js/{}/@lib+d@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/d/dir".format(name),
-            srcs = [":{}/@lib/d".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/d".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
+            _fp_link_4(name)
+            link_targets.append(":{}/@lib/b".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
+            _fp_link_5(name)
+            link_targets.append(":{}/@lib/b_alias".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
 
     for scope, scoped_targets in scope_targets.items():
         _js_library(
@@ -478,3 +358,123 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 link_targets.append(":{}/@lib/b".format(name))
                 link_targets.append(":{}/@lib/b_alias".format(name))
     return link_targets
+
+
+# Generated npm_link_package_store for linking of first-party "@lib/c" package
+# buildifier: disable=function-docstring
+def _fp_link_0(name):
+    _npm_link_package_store(
+        name = "{}/@lib/c".format(name),
+        src = "//root:.aspect_rules_js/{}/@lib+c@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/c/dir".format(name),
+        srcs = [":{}/@lib/c".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "vendored-a" package
+# buildifier: disable=function-docstring
+def _fp_link_1(name):
+    _npm_link_package_store(
+        name = "{}/vendored-a".format(name),
+        src = "//root:.aspect_rules_js/{}/vendored-a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/vendored-a/dir".format(name),
+        srcs = [":{}/vendored-a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "vendored-b" package
+# buildifier: disable=function-docstring
+def _fp_link_2(name):
+    _npm_link_package_store(
+        name = "{}/vendored-b".format(name),
+        src = "//root:.aspect_rules_js/{}/vendored-b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/vendored-b/dir".format(name),
+        srcs = [":{}/vendored-b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/a" package
+# buildifier: disable=function-docstring
+def _fp_link_3(name):
+    _npm_link_package_store(
+        name = "{}/@lib/a".format(name),
+        src = "//root:.aspect_rules_js/{}/@lib+a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/a/dir".format(name),
+        srcs = [":{}/@lib/a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/b" package
+# buildifier: disable=function-docstring
+def _fp_link_4(name):
+    _npm_link_package_store(
+        name = "{}/@lib/b".format(name),
+        src = "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/b/dir".format(name),
+        srcs = [":{}/@lib/b".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/b_alias" package
+# buildifier: disable=function-docstring
+def _fp_link_5(name):
+    _npm_link_package_store(
+        name = "{}/@lib/b_alias".format(name),
+        src = "//root:.aspect_rules_js/{}/@lib+b_alias@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/b_alias/dir".format(name),
+        srcs = [":{}/@lib/b_alias".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/d" package
+# buildifier: disable=function-docstring
+def _fp_link_6(name):
+    _npm_link_package_store(
+        name = "{}/@lib/d".format(name),
+        src = "//root:.aspect_rules_js/{}/@lib+d@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/d/dir".format(name),
+        srcs = [":{}/@lib/d".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -2525,6 +2525,18 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "js/private/test/image":
             link_6("{}/acorn".format(name), False, name, "acorn")
             link_targets.append(":{}/acorn".format(name))
+            _fp_link_2(name)
+            link_targets.append(":{}/@mycorp/pkg-a".format(name))
+            if "@mycorp" not in scope_targets:
+                scope_targets["@mycorp"] = [link_targets[-1]]
+            else:
+                scope_targets["@mycorp"].append(link_targets[-1])
+            _fp_link_8(name)
+            link_targets.append(":{}/@mycorp/pkg-d".format(name))
+            if "@mycorp" not in scope_targets:
+                scope_targets["@mycorp"] = [link_targets[-1]]
+            else:
+                scope_targets["@mycorp"].append(link_targets[-1])
         elif bazel_package == "examples/npm_deps":
             link_8("{}/acorn".format(name), True, name, "acorn")
             link_targets.append(":{}/acorn".format(name))
@@ -2568,6 +2580,24 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_targets.append(":{}/rollup".format(name))
             link_1089("{}/uvu".format(name), True, name, "uvu")
             link_targets.append(":{}/uvu".format(name))
+            _fp_link_2(name)
+            link_targets.append(":{}/@mycorp/pkg-a".format(name))
+            if "@mycorp" not in scope_targets:
+                scope_targets["@mycorp"] = [link_targets[-1]]
+            else:
+                scope_targets["@mycorp"].append(link_targets[-1])
+            _fp_link_8(name)
+            link_targets.append(":{}/@mycorp/pkg-d".format(name))
+            if "@mycorp" not in scope_targets:
+                scope_targets["@mycorp"] = [link_targets[-1]]
+            else:
+                scope_targets["@mycorp"].append(link_targets[-1])
+            _fp_link_9(name)
+            link_targets.append(":{}/@mycorp/pkg-e".format(name))
+            if "@mycorp" not in scope_targets:
+                scope_targets["@mycorp"] = [link_targets[-1]]
+            else:
+                scope_targets["@mycorp"].append(link_targets[-1])
         elif bazel_package == "examples/npm_package/packages/pkg_a":
             link_8("{}/acorn".format(name), False, name, "acorn")
             link_targets.append(":{}/acorn".format(name))
@@ -2731,6 +2761,8 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_1082("{}/unused".format(name), True, name, "unused")
             link_1099("{}/webpack-bundle-analyzer".format(name), True, name, "webpack-bundle-analyzer")
             link_targets.append(":{}/webpack-bundle-analyzer".format(name))
+            _fp_link_10(name)
+            link_targets.append(":{}/test-npm_package".format(name))
         elif bazel_package == "js/private/coverage/bundle":
             link_212("{}/@rollup/plugin-commonjs".format(name), True, name, "@rollup/plugin-commonjs")
             link_targets.append(":{}/@rollup/plugin-commonjs".format(name))
@@ -2798,6 +2830,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets["@types"] = [link_targets[-1]]
             else:
                 scope_targets["@types"].append(link_targets[-1])
+            _fp_link_3(name)
+            link_targets.append(":{}/js_lib_pkg_a".format(name))
+            _fp_link_4(name)
+            link_targets.append(":{}/js_lib_pkg_a-alias_1".format(name))
+            _fp_link_5(name)
+            link_targets.append(":{}/js_lib_pkg_a-alias_2".format(name))
         elif bazel_package == "js/private/test/js_run_devserver":
             link_277("{}/@types/node".format(name), False, name, "@types/node")
             link_targets.append(":{}/@types/node".format(name))
@@ -2848,206 +2886,33 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "examples/stack_traces":
             link_991("{}/source-map-support".format(name), True, name, "source-map-support")
             link_targets.append(":{}/source-map-support".format(name))
-
-    if bazel_package in ["js/private/test/image", "examples/js_binary", "examples/npm_deps"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@mycorp/pkg-a".format(name),
-            src = "//:.aspect_rules_js/{}/@mycorp+pkg-a@0.0.0".format(name),
-            visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@mycorp/pkg-a/dir".format(name),
-            srcs = [":{}/@mycorp/pkg-a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@mycorp/pkg-a".format(name))
-        if "@mycorp" not in scope_targets:
-            scope_targets["@mycorp"] = [link_targets[-1]]
-        else:
-            scope_targets["@mycorp"].append(link_targets[-1])
-
-    if bazel_package in ["examples/js_lib_pkg/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/js_lib_pkg_a".format(name),
-            src = "//:.aspect_rules_js/{}/js_lib_pkg_a@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/js_lib_pkg_a/dir".format(name),
-            srcs = [":{}/js_lib_pkg_a".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/js_lib_pkg_a".format(name))
-
-    if bazel_package in ["examples/js_lib_pkg/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/js_lib_pkg_a-alias_1".format(name),
-            src = "//:.aspect_rules_js/{}/js_lib_pkg_a-alias_1@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/js_lib_pkg_a-alias_1/dir".format(name),
-            srcs = [":{}/js_lib_pkg_a-alias_1".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/js_lib_pkg_a-alias_1".format(name))
-
-    if bazel_package in ["examples/js_lib_pkg/b"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/js_lib_pkg_a-alias_2".format(name),
-            src = "//:.aspect_rules_js/{}/js_lib_pkg_a-alias_2@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/js_lib_pkg_a-alias_2/dir".format(name),
-            srcs = [":{}/js_lib_pkg_a-alias_2".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/js_lib_pkg_a-alias_2".format(name))
-
-    if bazel_package in ["examples/linked_consumer"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/test".format(name),
-            src = "//:.aspect_rules_js/{}/@lib+test@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/test/dir".format(name),
-            srcs = [":{}/@lib/test".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/test".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["examples/linked_consumer"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@lib/test2".format(name),
-            src = "//:.aspect_rules_js/{}/@lib+test2@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@lib/test2/dir".format(name),
-            srcs = [":{}/@lib/test2".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@lib/test2".format(name))
-        if "@lib" not in scope_targets:
-            scope_targets["@lib"] = [link_targets[-1]]
-        else:
-            scope_targets["@lib"].append(link_targets[-1])
-
-    if bazel_package in ["examples/npm_package/packages/pkg_e", "js/private/test/image", "examples/npm_deps"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@mycorp/pkg-d".format(name),
-            src = "//:.aspect_rules_js/{}/@mycorp+pkg-d@0.0.0".format(name),
-            visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@mycorp/pkg-d/dir".format(name),
-            srcs = [":{}/@mycorp/pkg-d".format(name)],
-            output_group = "package_directory",
-            visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@mycorp/pkg-d".format(name))
-        if "@mycorp" not in scope_targets:
-            scope_targets["@mycorp"] = [link_targets[-1]]
-        else:
-            scope_targets["@mycorp"].append(link_targets[-1])
-
-    if bazel_package in ["examples/npm_deps"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/@mycorp/pkg-e".format(name),
-            src = "//:.aspect_rules_js/{}/@mycorp+pkg-e@0.0.0".format(name),
-            visibility = ["//examples:__subpackages__"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/@mycorp/pkg-e/dir".format(name),
-            srcs = [":{}/@mycorp/pkg-e".format(name)],
-            output_group = "package_directory",
-            visibility = ["//examples:__subpackages__"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/@mycorp/pkg-e".format(name))
-        if "@mycorp" not in scope_targets:
-            scope_targets["@mycorp"] = [link_targets[-1]]
-        else:
-            scope_targets["@mycorp"].append(link_targets[-1])
-
-    if bazel_package in ["npm/private/test"]:
-        # terminal target for direct dependencies
-        _npm_link_package_store(
-            name = "{}/test-npm_package".format(name),
-            src = "//:.aspect_rules_js/{}/test-npm_package@0.0.0".format(name),
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/test-npm_package/dir".format(name),
-            srcs = [":{}/test-npm_package".format(name)],
-            output_group = "package_directory",
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        link_targets.append(":{}/test-npm_package".format(name))
+        elif bazel_package == "examples/js_binary":
+            _fp_link_2(name)
+            link_targets.append(":{}/@mycorp/pkg-a".format(name))
+            if "@mycorp" not in scope_targets:
+                scope_targets["@mycorp"] = [link_targets[-1]]
+            else:
+                scope_targets["@mycorp"].append(link_targets[-1])
+        elif bazel_package == "examples/linked_consumer":
+            _fp_link_6(name)
+            link_targets.append(":{}/@lib/test".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
+            _fp_link_7(name)
+            link_targets.append(":{}/@lib/test2".format(name))
+            if "@lib" not in scope_targets:
+                scope_targets["@lib"] = [link_targets[-1]]
+            else:
+                scope_targets["@lib"].append(link_targets[-1])
+        elif bazel_package == "examples/npm_package/packages/pkg_e":
+            _fp_link_8(name)
+            link_targets.append(":{}/@mycorp/pkg-d".format(name))
+            if "@mycorp" not in scope_targets:
+                scope_targets["@mycorp"] = [link_targets[-1]]
+            else:
+                scope_targets["@mycorp"].append(link_targets[-1])
 
     for scope, scoped_targets in scope_targets.items():
         _js_library(
@@ -3247,3 +3112,157 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
         if prod:
                 link_targets.append(":{}/@mycorp/pkg-d".format(name))
     return link_targets
+
+
+# Generated npm_link_package_store for linking of first-party "@mycorp/pkg-a" package
+# buildifier: disable=function-docstring
+def _fp_link_2(name):
+    _npm_link_package_store(
+        name = "{}/@mycorp/pkg-a".format(name),
+        src = "//:.aspect_rules_js/{}/@mycorp+pkg-a@0.0.0".format(name),
+        visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@mycorp/pkg-a/dir".format(name),
+        srcs = [":{}/@mycorp/pkg-a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "js_lib_pkg_a" package
+# buildifier: disable=function-docstring
+def _fp_link_3(name):
+    _npm_link_package_store(
+        name = "{}/js_lib_pkg_a".format(name),
+        src = "//:.aspect_rules_js/{}/js_lib_pkg_a@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/js_lib_pkg_a/dir".format(name),
+        srcs = [":{}/js_lib_pkg_a".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "js_lib_pkg_a-alias_1" package
+# buildifier: disable=function-docstring
+def _fp_link_4(name):
+    _npm_link_package_store(
+        name = "{}/js_lib_pkg_a-alias_1".format(name),
+        src = "//:.aspect_rules_js/{}/js_lib_pkg_a-alias_1@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/js_lib_pkg_a-alias_1/dir".format(name),
+        srcs = [":{}/js_lib_pkg_a-alias_1".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "js_lib_pkg_a-alias_2" package
+# buildifier: disable=function-docstring
+def _fp_link_5(name):
+    _npm_link_package_store(
+        name = "{}/js_lib_pkg_a-alias_2".format(name),
+        src = "//:.aspect_rules_js/{}/js_lib_pkg_a-alias_2@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/js_lib_pkg_a-alias_2/dir".format(name),
+        srcs = [":{}/js_lib_pkg_a-alias_2".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/test" package
+# buildifier: disable=function-docstring
+def _fp_link_6(name):
+    _npm_link_package_store(
+        name = "{}/@lib/test".format(name),
+        src = "//:.aspect_rules_js/{}/@lib+test@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/test/dir".format(name),
+        srcs = [":{}/@lib/test".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@lib/test2" package
+# buildifier: disable=function-docstring
+def _fp_link_7(name):
+    _npm_link_package_store(
+        name = "{}/@lib/test2".format(name),
+        src = "//:.aspect_rules_js/{}/@lib+test2@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@lib/test2/dir".format(name),
+        srcs = [":{}/@lib/test2".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@mycorp/pkg-d" package
+# buildifier: disable=function-docstring
+def _fp_link_8(name):
+    _npm_link_package_store(
+        name = "{}/@mycorp/pkg-d".format(name),
+        src = "//:.aspect_rules_js/{}/@mycorp+pkg-d@0.0.0".format(name),
+        visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@mycorp/pkg-d/dir".format(name),
+        srcs = [":{}/@mycorp/pkg-d".format(name)],
+        output_group = "package_directory",
+        visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "@mycorp/pkg-e" package
+# buildifier: disable=function-docstring
+def _fp_link_9(name):
+    _npm_link_package_store(
+        name = "{}/@mycorp/pkg-e".format(name),
+        src = "//:.aspect_rules_js/{}/@mycorp+pkg-e@0.0.0".format(name),
+        visibility = ["//examples:__subpackages__"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/@mycorp/pkg-e/dir".format(name),
+        srcs = [":{}/@mycorp/pkg-e".format(name)],
+        output_group = "package_directory",
+        visibility = ["//examples:__subpackages__"],
+        tags = ["manual"],
+    )
+
+# Generated npm_link_package_store for linking of first-party "test-npm_package" package
+# buildifier: disable=function-docstring
+def _fp_link_10(name):
+    _npm_link_package_store(
+        name = "{}/test-npm_package".format(name),
+        src = "//:.aspect_rules_js/{}/test-npm_package@0.0.0".format(name),
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/test-npm_package/dir".format(name),
+        srcs = [":{}/test-npm_package".format(name)],
+        output_group = "package_directory",
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )


### PR DESCRIPTION
Generate factory methods instead of inline code within `npm_link_all_packages` to better align first-party package linking with third-party.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
