### PR TITLE
refactor: reduce generated code for linking of first-party packages

### DIFF
--- a/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
@@ -76,7 +76,7 @@ load("@@aspect_rules_js~~npm~lock-<LOCKVERSION>__wrap-ansi__8.1.0__links//:defs.
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
+load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
@@ -675,169 +675,79 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring
 def _fp_link_0(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/c/dir".format(name),
-        srcs = [":{}/@scoped/c".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package
 # buildifier: disable=function-docstring
 def _fp_link_2(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/a/dir".format(name),
-        srcs = [":{}/@scoped/a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/b" package
 # buildifier: disable=function-docstring
 def _fp_link_3(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/b".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/b/dir".format(name),
-        srcs = [":{}/@scoped/b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/d" package
 # buildifier: disable=function-docstring
 def _fp_link_4(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/d".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/d/dir".format(name),
-        srcs = [":{}/@scoped/d".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "alias-project-a" package
 # buildifier: disable=function-docstring
 def _fp_link_5(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/alias-project-a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/alias-project-a/dir".format(name),
-        srcs = [":{}/alias-project-a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "scoped/bad" package
 # buildifier: disable=function-docstring
 def _fp_link_6(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/scoped/bad".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/scoped/bad/dir".format(name),
-        srcs = [":{}/scoped/bad".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c200-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_7(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c200-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c200-d200/dir".format(name),
-        srcs = [":{}/test-c200-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c201-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_8(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c201-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c201-d200/dir".format(name),
-        srcs = [":{}/test-c201-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-peer-types" package
 # buildifier: disable=function-docstring
 def _fp_link_9(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-peer-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-peer-types/dir".format(name),
-        srcs = [":{}/test-peer-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring
 def _fp_link_10(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/a-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/a-types/dir".format(name),
-        srcs = [":{}/a-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -75,7 +75,7 @@ load("@@aspect_rules_js~~npm~lock-<LOCKVERSION>__wrap-ansi__8.1.0__links//:defs.
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
+load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
@@ -651,169 +651,79 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring
 def _fp_link_0(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/c/dir".format(name),
-        srcs = [":{}/@scoped/c".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package
 # buildifier: disable=function-docstring
 def _fp_link_2(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/a/dir".format(name),
-        srcs = [":{}/@scoped/a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/b" package
 # buildifier: disable=function-docstring
 def _fp_link_3(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/b".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/b/dir".format(name),
-        srcs = [":{}/@scoped/b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/d" package
 # buildifier: disable=function-docstring
 def _fp_link_4(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/d".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/d/dir".format(name),
-        srcs = [":{}/@scoped/d".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "alias-project-a" package
 # buildifier: disable=function-docstring
 def _fp_link_5(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/alias-project-a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/alias-project-a/dir".format(name),
-        srcs = [":{}/alias-project-a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "scoped/bad" package
 # buildifier: disable=function-docstring
 def _fp_link_6(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/scoped/bad".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/scoped/bad/dir".format(name),
-        srcs = [":{}/scoped/bad".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c200-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_7(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c200-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c200-d200/dir".format(name),
-        srcs = [":{}/test-c200-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c201-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_8(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c201-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c201-d200/dir".format(name),
-        srcs = [":{}/test-c201-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-peer-types" package
 # buildifier: disable=function-docstring
 def _fp_link_9(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-peer-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-peer-types/dir".format(name),
-        srcs = [":{}/test-peer-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring
 def _fp_link_10(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/a-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/a-types/dir".format(name),
-        srcs = [":{}/a-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -76,7 +76,7 @@ load("@@aspect_rules_js~~npm~lock-<LOCKVERSION>__wrap-ansi__8.1.0__links//:defs.
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
+load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
@@ -675,169 +675,79 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring
 def _fp_link_0(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/c/dir".format(name),
-        srcs = [":{}/@scoped/c".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package
 # buildifier: disable=function-docstring
 def _fp_link_2(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/a/dir".format(name),
-        srcs = [":{}/@scoped/a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/b" package
 # buildifier: disable=function-docstring
 def _fp_link_3(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/b".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/b/dir".format(name),
-        srcs = [":{}/@scoped/b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/d" package
 # buildifier: disable=function-docstring
 def _fp_link_4(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/d".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/d/dir".format(name),
-        srcs = [":{}/@scoped/d".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "alias-project-a" package
 # buildifier: disable=function-docstring
 def _fp_link_5(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/alias-project-a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/alias-project-a/dir".format(name),
-        srcs = [":{}/alias-project-a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "scoped/bad" package
 # buildifier: disable=function-docstring
 def _fp_link_6(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/scoped/bad".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/scoped/bad/dir".format(name),
-        srcs = [":{}/scoped/bad".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c200-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_7(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c200-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c200-d200/dir".format(name),
-        srcs = [":{}/test-c200-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c201-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_8(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c201-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c201-d200/dir".format(name),
-        srcs = [":{}/test-c201-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-peer-types" package
 # buildifier: disable=function-docstring
 def _fp_link_9(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-peer-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-peer-types/dir".format(name),
-        srcs = [":{}/test-peer-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring
 def _fp_link_10(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/a-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/a-types/dir".format(name),
-        srcs = [":{}/a-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -76,7 +76,7 @@ load("@@aspect_rules_js~~npm~lock-<LOCKVERSION>__wrap-ansi__8.1.0__links//:defs.
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
+load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
@@ -675,169 +675,79 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring
 def _fp_link_0(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/c/dir".format(name),
-        srcs = [":{}/@scoped/c".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package
 # buildifier: disable=function-docstring
 def _fp_link_2(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/a/dir".format(name),
-        srcs = [":{}/@scoped/a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/b" package
 # buildifier: disable=function-docstring
 def _fp_link_3(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/b".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/b/dir".format(name),
-        srcs = [":{}/@scoped/b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/d" package
 # buildifier: disable=function-docstring
 def _fp_link_4(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/d".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/d/dir".format(name),
-        srcs = [":{}/@scoped/d".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "alias-project-a" package
 # buildifier: disable=function-docstring
 def _fp_link_5(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/alias-project-a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/alias-project-a/dir".format(name),
-        srcs = [":{}/alias-project-a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "scoped/bad" package
 # buildifier: disable=function-docstring
 def _fp_link_6(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/scoped/bad".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/scoped/bad/dir".format(name),
-        srcs = [":{}/scoped/bad".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c200-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_7(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c200-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c200-d200/dir".format(name),
-        srcs = [":{}/test-c200-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c201-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_8(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c201-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c201-d200/dir".format(name),
-        srcs = [":{}/test-c201-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-peer-types" package
 # buildifier: disable=function-docstring
 def _fp_link_9(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-peer-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-peer-types/dir".format(name),
-        srcs = [":{}/test-peer-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring
 def _fp_link_10(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/a-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/a-types/dir".format(name),
-        srcs = [":{}/a-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -76,7 +76,7 @@ load("@@aspect_rules_js~~npm~lock-<LOCKVERSION>__wrap-ansi__8.1.0__links//:defs.
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
+load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
@@ -675,169 +675,79 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring
 def _fp_link_0(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/c/dir".format(name),
-        srcs = [":{}/@scoped/c".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package
 # buildifier: disable=function-docstring
 def _fp_link_2(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/a/dir".format(name),
-        srcs = [":{}/@scoped/a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/b" package
 # buildifier: disable=function-docstring
 def _fp_link_3(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/b".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/b/dir".format(name),
-        srcs = [":{}/@scoped/b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/d" package
 # buildifier: disable=function-docstring
 def _fp_link_4(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@scoped/d".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+d@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@scoped/d/dir".format(name),
-        srcs = [":{}/@scoped/d".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "alias-project-a" package
 # buildifier: disable=function-docstring
 def _fp_link_5(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/alias-project-a".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/alias-project-a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/alias-project-a/dir".format(name),
-        srcs = [":{}/alias-project-a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "scoped/bad" package
 # buildifier: disable=function-docstring
 def _fp_link_6(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/scoped/bad".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/scoped+bad@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/scoped/bad/dir".format(name),
-        srcs = [":{}/scoped/bad".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c200-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_7(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c200-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c200-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c200-d200/dir".format(name),
-        srcs = [":{}/test-c200-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c201-d200" package
 # buildifier: disable=function-docstring
 def _fp_link_8(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-c201-d200".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-c201-d200@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-c201-d200/dir".format(name),
-        srcs = [":{}/test-c201-d200".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-peer-types" package
 # buildifier: disable=function-docstring
 def _fp_link_9(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-peer-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/test-peer-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-peer-types/dir".format(name),
-        srcs = [":{}/test-peer-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring
 def _fp_link_10(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/a-types".format(name),
         src = "//<LOCKVERSION>:.aspect_rules_js/{}/a-types@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/a-types/dir".format(name),
-        srcs = [":{}/a-types".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -18,7 +18,7 @@ load("@@aspect_rules_js~~npm~npm__undici-types__5.26.5__links//:defs.bzl", store
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
+load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
@@ -363,118 +363,55 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
 # buildifier: disable=function-docstring
 def _fp_link_0(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/vendored-a".format(name),
         src = "//:.aspect_rules_js/{}/vendored-a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/vendored-a/dir".format(name),
-        srcs = [":{}/vendored-a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "vendored-b" package
 # buildifier: disable=function-docstring
 def _fp_link_1(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/vendored-b".format(name),
         src = "//:.aspect_rules_js/{}/vendored-b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/vendored-b/dir".format(name),
-        srcs = [":{}/vendored-b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/a" package
 # buildifier: disable=function-docstring
 def _fp_link_2(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/a".format(name),
         src = "//:.aspect_rules_js/{}/@lib+a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/a/dir".format(name),
-        srcs = [":{}/@lib/a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/b" package
 # buildifier: disable=function-docstring
 def _fp_link_3(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/b".format(name),
         src = "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/b/dir".format(name),
-        srcs = [":{}/@lib/b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/b_alias" package
 # buildifier: disable=function-docstring
 def _fp_link_4(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/b_alias".format(name),
         src = "//:.aspect_rules_js/{}/@lib+b_alias@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/b_alias/dir".format(name),
-        srcs = [":{}/@lib/b_alias".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/c" package
 # buildifier: disable=function-docstring
 def _fp_link_5(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/c".format(name),
         src = "//:.aspect_rules_js/{}/@lib+c@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/c/dir".format(name),
-        srcs = [":{}/@lib/c".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/d" package
 # buildifier: disable=function-docstring
 def _fp_link_6(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/d".format(name),
         src = "//:.aspect_rules_js/{}/@lib+d@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/d/dir".format(name),
-        srcs = [":{}/@lib/d".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -18,7 +18,7 @@ load("@@aspect_rules_js~~npm~npm__undici-types__5.26.5__links//:defs.bzl", store
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
+load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
@@ -363,118 +363,55 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 # Generated npm_link_package_store for linking of first-party "@lib/c" package
 # buildifier: disable=function-docstring
 def _fp_link_0(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/c".format(name),
         src = "//root:.aspect_rules_js/{}/@lib+c@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/c/dir".format(name),
-        srcs = [":{}/@lib/c".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
 # buildifier: disable=function-docstring
 def _fp_link_1(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/vendored-a".format(name),
         src = "//root:.aspect_rules_js/{}/vendored-a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/vendored-a/dir".format(name),
-        srcs = [":{}/vendored-a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "vendored-b" package
 # buildifier: disable=function-docstring
 def _fp_link_2(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/vendored-b".format(name),
         src = "//root:.aspect_rules_js/{}/vendored-b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/vendored-b/dir".format(name),
-        srcs = [":{}/vendored-b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/a" package
 # buildifier: disable=function-docstring
 def _fp_link_3(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/a".format(name),
         src = "//root:.aspect_rules_js/{}/@lib+a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/a/dir".format(name),
-        srcs = [":{}/@lib/a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/b" package
 # buildifier: disable=function-docstring
 def _fp_link_4(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/b".format(name),
         src = "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/b/dir".format(name),
-        srcs = [":{}/@lib/b".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/b_alias" package
 # buildifier: disable=function-docstring
 def _fp_link_5(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/b_alias".format(name),
         src = "//root:.aspect_rules_js/{}/@lib+b_alias@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/b_alias/dir".format(name),
-        srcs = [":{}/@lib/b_alias".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/d" package
 # buildifier: disable=function-docstring
 def _fp_link_6(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/d".format(name),
         src = "//root:.aspect_rules_js/{}/@lib+d@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/d/dir".format(name),
-        srcs = [":{}/@lib/d".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -152,3 +152,20 @@ npm_link_package_store = rule(
     attrs = _ATTRS,
     provides = [DefaultInfo, JsInfo],
 )
+
+# A private util method to minimize the generated code for local package store links.
+# May be changed/deleted at any time to minimize code from the generated npm_link_all_packages().
+def npm_local_link_package_store_internal(name, src, link_visibility = ["//visibility:public"]):
+    npm_link_package_store(
+        name = name,
+        src = src,
+        visibility = link_visibility,
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "{}/dir".format(name),
+        srcs = [":" + name],
+        output_group = utils.package_directory_output_group,
+        visibility = link_visibility,
+        tags = ["manual"],
+    )

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -1142,7 +1142,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_package_visibility.bzl", _npm_validate_package_visibility = "validate_npm_package_visibility")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_link_package_store = "npm_link_package_store")
+load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
@@ -3118,152 +3118,74 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-a" package
 # buildifier: disable=function-docstring
 def _fp_link_2(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@mycorp/pkg-a".format(name),
         src = "//:.aspect_rules_js/{}/@mycorp+pkg-a@0.0.0".format(name),
-        visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@mycorp/pkg-a/dir".format(name),
-        srcs = [":{}/@mycorp/pkg-a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
-        tags = ["manual"],
+        link_visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
     )
 
 # Generated npm_link_package_store for linking of first-party "js_lib_pkg_a" package
 # buildifier: disable=function-docstring
 def _fp_link_3(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/js_lib_pkg_a".format(name),
         src = "//:.aspect_rules_js/{}/js_lib_pkg_a@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/js_lib_pkg_a/dir".format(name),
-        srcs = [":{}/js_lib_pkg_a".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "js_lib_pkg_a-alias_1" package
 # buildifier: disable=function-docstring
 def _fp_link_4(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/js_lib_pkg_a-alias_1".format(name),
         src = "//:.aspect_rules_js/{}/js_lib_pkg_a-alias_1@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/js_lib_pkg_a-alias_1/dir".format(name),
-        srcs = [":{}/js_lib_pkg_a-alias_1".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "js_lib_pkg_a-alias_2" package
 # buildifier: disable=function-docstring
 def _fp_link_5(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/js_lib_pkg_a-alias_2".format(name),
         src = "//:.aspect_rules_js/{}/js_lib_pkg_a-alias_2@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/js_lib_pkg_a-alias_2/dir".format(name),
-        srcs = [":{}/js_lib_pkg_a-alias_2".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/test" package
 # buildifier: disable=function-docstring
 def _fp_link_6(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/test".format(name),
         src = "//:.aspect_rules_js/{}/@lib+test@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/test/dir".format(name),
-        srcs = [":{}/@lib/test".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/test2" package
 # buildifier: disable=function-docstring
 def _fp_link_7(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@lib/test2".format(name),
         src = "//:.aspect_rules_js/{}/@lib+test2@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@lib/test2/dir".format(name),
-        srcs = [":{}/@lib/test2".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-d" package
 # buildifier: disable=function-docstring
 def _fp_link_8(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@mycorp/pkg-d".format(name),
         src = "//:.aspect_rules_js/{}/@mycorp+pkg-d@0.0.0".format(name),
-        visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@mycorp/pkg-d/dir".format(name),
-        srcs = [":{}/@mycorp/pkg-d".format(name)],
-        output_group = "package_directory",
-        visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
-        tags = ["manual"],
+        link_visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-e" package
 # buildifier: disable=function-docstring
 def _fp_link_9(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/@mycorp/pkg-e".format(name),
         src = "//:.aspect_rules_js/{}/@mycorp+pkg-e@0.0.0".format(name),
-        visibility = ["//examples:__subpackages__"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/@mycorp/pkg-e/dir".format(name),
-        srcs = [":{}/@mycorp/pkg-e".format(name)],
-        output_group = "package_directory",
-        visibility = ["//examples:__subpackages__"],
-        tags = ["manual"],
+        link_visibility = ["//examples:__subpackages__"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-npm_package" package
 # buildifier: disable=function-docstring
 def _fp_link_10(name):
-    _npm_link_package_store(
+    _npm_local_link_package_store(
         name = "{}/test-npm_package".format(name),
         src = "//:.aspect_rules_js/{}/test-npm_package@0.0.0".format(name),
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
-    )
-    native.filegroup(
-        name = "{}/test-npm_package/dir".format(name),
-        srcs = [":{}/test-npm_package".format(name)],
-        output_group = "package_directory",
-        visibility = ["//visibility:public"],
-        tags = ["manual"],
     )


### PR DESCRIPTION
Just to reduce the size and complexity of generated code.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
