### PR TITLE
fix: avoid sh_binary

### DIFF
--- a/npm/private/BUILD.bazel
+++ b/npm/private/BUILD.bazel
@@ -14,8 +14,6 @@ js_library(
 
 exports_files(glob(["*.bzl"]))
 
-exports_files(["noop.sh"])
-
 # We manually keep the generated rules documentation synced.
 # Check that the signatures stay matched.
 [

--- a/npm/private/noop.sh
+++ b/npm/private/noop.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-exit 0

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -75,16 +75,16 @@ def generate_repository_files(rctx, importers, packages, patched_dependencies, o
 
     rctx_files = {
         "BUILD.bazel": [
+            """load("@aspect_rules_js//js:defs.bzl", "js_binary")""",
             """load("@bazel_skylib//:bzl_library.bzl", "bzl_library")""",
-            "",
+            """load("@bazel_skylib//rules:write_file.bzl", "write_file")""",
             """
 # A no-op run target that can be run to invalidate the repository
 # to update the pnpm lockfile. Useful under bzlmod where
 # `bazel sync --only=repo` is a no-op.
-sh_binary(
-    name = "sync",
-    srcs = ["@aspect_rules_js//npm/private:noop.sh"],
-)""",
+write_file(name="noop", out="noop.js", content=["#!/usr/bin/env node"])
+js_binary(name = "sync", entry_point = "noop.js")
+""",
             "",
             "exports_files({})".format(starlark_codegen_utils.to_list_attr([
                 rctx.attr.defs_bzl_filename,


### PR DESCRIPTION
Bazel 9 requires this be loaded from rules_shell, and we don't want to add another module dependency from the generated @npm repo
