### PR TITLE
fix: treat file: references in package store the same as pnpm

### DIFF
--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -143,21 +143,21 @@ def lockfile_test(npm_link_all_packages, name = None):
             ":node_modules/scoped/bad",
             ":.aspect_rules_js/node_modules/@scoped+a@0.0.0",
             ":.aspect_rules_js/node_modules/@scoped+b@0.0.0",
-            ":.aspect_rules_js/node_modules/@scoped+c@0.0.0",
+            ":.aspect_rules_js/node_modules/@scoped+c@file+..+projects+c_at_scoped_b_projects%sb" % ("_" if lock_version == "v54" else "+"),  # is declared as a file: instead of link:
             ":.aspect_rules_js/node_modules/@scoped+d@0.0.0",
             ":.aspect_rules_js/node_modules/scoped+bad@0.0.0",
 
             # file: 4.17.21.tgz tarbal
             ":node_modules/lodash",
-            ":.aspect_rules_js/node_modules/lodash@0.0.0",
-            ":.aspect_rules_js/node_modules/lodash@0.0.0/dir",
+            ":.aspect_rules_js/node_modules/lodash@file+..+vendored+lodash-4.17.21.tgz",
+            ":.aspect_rules_js/node_modules/lodash@file+..+vendored+lodash-4.17.21.tgz/dir",
             "@%s__lodash__file_.._vendored_lodash-4.17.21.tgz//:pkg" % lock_repo,
             "@%s__lodash__file_.._vendored_lodash-4.17.21.tgz__links//:defs.bzl" % lock_repo,
 
             # Packages involving overrides
             ":node_modules/is-odd",
             ":.aspect_rules_js/node_modules/is-odd@3.0.1",
-            ":.aspect_rules_js/node_modules/is-number@0.0.0",
+            ":.aspect_rules_js/node_modules/is-number@file+..+vendored+is-number",
 
             # Odd git/http versions
             ":node_modules/debug",

--- a/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
@@ -171,10 +171,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_70(name)
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
+            package_store_name = "@scoped+c@file+..+projects+c_at_scoped_b_projects+b",
             src = "//projects/c:pkg",
             package = "@scoped/c",
-            version = "0.0.0",
+            version = "file:../projects/c_at_scoped_b_projects+b",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
@@ -184,10 +184,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "is-number@0.0.0",
+            package_store_name = "is-number@file+..+vendored+is-number",
             src = "//vendored/is-number:pkg",
             package = "is-number",
-            version = "0.0.0",
+            version = "file:../vendored/is-number",
             deps = {},
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -665,7 +665,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 def _fp_link_0(name):
     _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
-        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@file+..+projects+c_at_scoped_b_projects+b".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package

--- a/e2e/pnpm_lockfiles/v101/snapshots/lodash-4.17.21_tgz_defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/lodash-4.17.21_tgz_defs.bzl
@@ -12,7 +12,7 @@ load("@aspect_rules_js//npm/private:npm_import.bzl",
 PACKAGE = "lodash"
 VERSION = "file:../vendored/lodash-4.17.21.tgz"
 _ROOT_PACKAGE = "<LOCKVERSION>"
-_PACKAGE_STORE_NAME = "lodash@0.0.0"
+_PACKAGE_STORE_NAME = "lodash@file+..+vendored+lodash-4.17.21.tgz"
 
 # Generated npm_package_store targets for npm package lodash@file:../vendored/lodash-4.17.21.tgz
 # buildifier: disable=function-docstring
@@ -23,11 +23,11 @@ def npm_imported_package_store(link_root_name):
         version = VERSION,
         root_package = _ROOT_PACKAGE,
         deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg": "lodash",
         },
         ref_deps = {},
         lc_deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg_pre_lc_lite": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg_pre_lc_lite": "lodash",
         },
         dev_only = False,
         has_lifecycle_build_target = False,

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -169,10 +169,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_69(name)
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
+            package_store_name = "@scoped+c@file+..+projects+c_at_scoped_b_projects_b",
             src = "//projects/c:pkg",
             package = "@scoped/c",
-            version = "0.0.0",
+            version = "file:../projects/c_at_scoped_b_projects_b",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
@@ -182,10 +182,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "is-number@0.0.0",
+            package_store_name = "is-number@file+..+vendored+is-number",
             src = "//vendored/is-number:pkg",
             package = "is-number",
-            version = "0.0.0",
+            version = "file:../vendored/is-number",
             deps = {},
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -638,7 +638,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 def _fp_link_0(name):
     _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
-        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@file+..+projects+c_at_scoped_b_projects_b".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package

--- a/e2e/pnpm_lockfiles/v54/snapshots/lodash-4.17.21_tgz_defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/lodash-4.17.21_tgz_defs.bzl
@@ -12,7 +12,7 @@ load("@aspect_rules_js//npm/private:npm_import.bzl",
 PACKAGE = "lodash"
 VERSION = "file:../vendored/lodash-4.17.21.tgz"
 _ROOT_PACKAGE = "<LOCKVERSION>"
-_PACKAGE_STORE_NAME = "lodash@0.0.0"
+_PACKAGE_STORE_NAME = "lodash@file+..+vendored+lodash-4.17.21.tgz"
 
 # Generated npm_package_store targets for npm package lodash@file:../vendored/lodash-4.17.21.tgz
 # buildifier: disable=function-docstring
@@ -23,11 +23,11 @@ def npm_imported_package_store(link_root_name):
         version = VERSION,
         root_package = _ROOT_PACKAGE,
         deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg": "lodash",
         },
         ref_deps = {},
         lc_deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg_pre_lc_lite": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg_pre_lc_lite": "lodash",
         },
         dev_only = False,
         has_lifecycle_build_target = False,

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -171,10 +171,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_70(name)
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
+            package_store_name = "@scoped+c@file+..+projects+c_at_scoped_b_projects+b",
             src = "//projects/c:pkg",
             package = "@scoped/c",
-            version = "0.0.0",
+            version = "file:../projects/c_at_scoped_b_projects+b",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
@@ -184,10 +184,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "is-number@0.0.0",
+            package_store_name = "is-number@file+..+vendored+is-number",
             src = "//vendored/is-number:pkg",
             package = "is-number",
-            version = "0.0.0",
+            version = "file:../vendored/is-number",
             deps = {},
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -665,7 +665,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 def _fp_link_0(name):
     _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
-        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@file+..+projects+c_at_scoped_b_projects+b".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package

--- a/e2e/pnpm_lockfiles/v60/snapshots/lodash-4.17.21_tgz_defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/lodash-4.17.21_tgz_defs.bzl
@@ -12,7 +12,7 @@ load("@aspect_rules_js//npm/private:npm_import.bzl",
 PACKAGE = "lodash"
 VERSION = "file:../vendored/lodash-4.17.21.tgz"
 _ROOT_PACKAGE = "<LOCKVERSION>"
-_PACKAGE_STORE_NAME = "lodash@0.0.0"
+_PACKAGE_STORE_NAME = "lodash@file+..+vendored+lodash-4.17.21.tgz"
 
 # Generated npm_package_store targets for npm package lodash@file:../vendored/lodash-4.17.21.tgz
 # buildifier: disable=function-docstring
@@ -23,11 +23,11 @@ def npm_imported_package_store(link_root_name):
         version = VERSION,
         root_package = _ROOT_PACKAGE,
         deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg": "lodash",
         },
         ref_deps = {},
         lc_deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg_pre_lc_lite": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg_pre_lc_lite": "lodash",
         },
         dev_only = False,
         has_lifecycle_build_target = False,

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -171,10 +171,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_70(name)
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
+            package_store_name = "@scoped+c@file+..+projects+c_at_scoped_b_projects+b",
             src = "//projects/c:pkg",
             package = "@scoped/c",
-            version = "0.0.0",
+            version = "file:../projects/c_at_scoped_b_projects+b",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
@@ -184,10 +184,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "is-number@0.0.0",
+            package_store_name = "is-number@file+..+vendored+is-number",
             src = "//vendored/is-number:pkg",
             package = "is-number",
-            version = "0.0.0",
+            version = "file:../vendored/is-number",
             deps = {},
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -665,7 +665,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 def _fp_link_0(name):
     _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
-        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@file+..+projects+c_at_scoped_b_projects+b".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package

--- a/e2e/pnpm_lockfiles/v61/snapshots/lodash-4.17.21_tgz_defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/lodash-4.17.21_tgz_defs.bzl
@@ -12,7 +12,7 @@ load("@aspect_rules_js//npm/private:npm_import.bzl",
 PACKAGE = "lodash"
 VERSION = "file:../vendored/lodash-4.17.21.tgz"
 _ROOT_PACKAGE = "<LOCKVERSION>"
-_PACKAGE_STORE_NAME = "lodash@0.0.0"
+_PACKAGE_STORE_NAME = "lodash@file+..+vendored+lodash-4.17.21.tgz"
 
 # Generated npm_package_store targets for npm package lodash@file:../vendored/lodash-4.17.21.tgz
 # buildifier: disable=function-docstring
@@ -23,11 +23,11 @@ def npm_imported_package_store(link_root_name):
         version = VERSION,
         root_package = _ROOT_PACKAGE,
         deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg": "lodash",
         },
         ref_deps = {},
         lc_deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg_pre_lc_lite": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg_pre_lc_lite": "lodash",
         },
         dev_only = False,
         has_lifecycle_build_target = False,

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -171,10 +171,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_70(name)
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "@scoped+c@0.0.0",
+            package_store_name = "@scoped+c@file+..+projects+c_at_scoped_b_projects+b",
             src = "//projects/c:pkg",
             package = "@scoped/c",
-            version = "0.0.0",
+            version = "file:../projects/c_at_scoped_b_projects+b",
             deps = {
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+a@0.0.0".format(name): "@scoped/a",
                 "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+b@0.0.0".format(name): "@scoped/b",
@@ -184,10 +184,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "is-number@0.0.0",
+            package_store_name = "is-number@file+..+vendored+is-number",
             src = "//vendored/is-number:pkg",
             package = "is-number",
-            version = "0.0.0",
+            version = "file:../vendored/is-number",
             deps = {},
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -665,7 +665,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 def _fp_link_0(name):
     _npm_local_link_package_store(
         name = "{}/@scoped/c".format(name),
-        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@0.0.0".format(name),
+        src = "//<LOCKVERSION>:.aspect_rules_js/{}/@scoped+c@file+..+projects+c_at_scoped_b_projects+b".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package

--- a/e2e/pnpm_lockfiles/v90/snapshots/lodash-4.17.21_tgz_defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/lodash-4.17.21_tgz_defs.bzl
@@ -12,7 +12,7 @@ load("@aspect_rules_js//npm/private:npm_import.bzl",
 PACKAGE = "lodash"
 VERSION = "file:../vendored/lodash-4.17.21.tgz"
 _ROOT_PACKAGE = "<LOCKVERSION>"
-_PACKAGE_STORE_NAME = "lodash@0.0.0"
+_PACKAGE_STORE_NAME = "lodash@file+..+vendored+lodash-4.17.21.tgz"
 
 # Generated npm_package_store targets for npm package lodash@file:../vendored/lodash-4.17.21.tgz
 # buildifier: disable=function-docstring
@@ -23,11 +23,11 @@ def npm_imported_package_store(link_root_name):
         version = VERSION,
         root_package = _ROOT_PACKAGE,
         deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg": "lodash",
         },
         ref_deps = {},
         lc_deps = {
-            ":.aspect_rules_js/{link_root_name}/lodash@0.0.0/pkg_pre_lc_lite": "lodash",
+            ":.aspect_rules_js/{link_root_name}/lodash@file+..+vendored+lodash-4.17.21.tgz/pkg_pre_lc_lite": "lodash",
         },
         dev_only = False,
         has_lifecycle_build_target = False,

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -55,10 +55,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_12(name)
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "vendored-a@0.0.0",
+            package_store_name = "vendored-a@file+vendored+a",
             src = "//vendored/a:pkg",
             package = "vendored-a",
-            version = "0.0.0",
+            version = "file:vendored/a",
             deps = {
                 "//:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
             },
@@ -67,10 +67,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "vendored-b@0.0.0",
+            package_store_name = "vendored-b@file+vendored+b_at_lib_b_lib+b",
             src = "//vendored/b:pkg",
             package = "vendored-b",
-            version = "0.0.0",
+            version = "file:vendored/b_at_lib_b_lib+b",
             deps = {
                 "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
             },
@@ -86,8 +86,8 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             deps = {
                 "//:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e",
                 "//:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
-                "//:.aspect_rules_js/{}/vendored-a@0.0.0".format(name): "vendored-a",
-                "//:.aspect_rules_js/{}/vendored-b@0.0.0".format(name): "vendored-b",
+                "//:.aspect_rules_js/{}/vendored-a@file+vendored+a".format(name): "vendored-a",
+                "//:.aspect_rules_js/{}/vendored-b@file+vendored+b_at_lib_b_lib+b".format(name): "vendored-b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -375,7 +375,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 def _fp_link_0(name):
     _npm_local_link_package_store(
         name = "{}/vendored-a".format(name),
-        src = "//:.aspect_rules_js/{}/vendored-a@0.0.0".format(name),
+        src = "//:.aspect_rules_js/{}/vendored-a@file+vendored+a".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "vendored-b" package
@@ -383,7 +383,7 @@ def _fp_link_0(name):
 def _fp_link_1(name):
     _npm_local_link_package_store(
         name = "{}/vendored-b".format(name),
-        src = "//:.aspect_rules_js/{}/vendored-b@0.0.0".format(name),
+        src = "//:.aspect_rules_js/{}/vendored-b@file+vendored+b_at_lib_b_lib+b".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/a" package

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -55,10 +55,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_12(name)
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "@lib+c@0.0.0",
+            package_store_name = "@lib+c@file+..+lib+c",
             src = "//lib/c:pkg",
             package = "@lib/c",
-            version = "0.0.0",
+            version = "file:../lib/c",
             deps = {
                 "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
             },
@@ -67,10 +67,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "vendored-a@0.0.0",
+            package_store_name = "vendored-a@file+..+vendored+a",
             src = "//vendored/a:pkg",
             package = "vendored-a",
-            version = "0.0.0",
+            version = "file:../vendored/a",
             deps = {
                 "//root:.aspect_rules_js/{}/@aspect-test+f@1.0.0".format(name): "@aspect-test/f",
             },
@@ -79,10 +79,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "vendored-b@0.0.0",
+            package_store_name = "vendored-b@file+..+vendored+b_at_lib_b_lib+b",
             src = "//vendored/b:pkg",
             package = "vendored-b",
-            version = "0.0.0",
+            version = "file:../vendored/b_at_lib_b_lib+b",
             deps = {
                 "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
             },
@@ -98,8 +98,8 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             deps = {
                 "//root:.aspect_rules_js/{}/@aspect-test+e@1.0.0".format(name): "@aspect-test/e",
                 "//root:.aspect_rules_js/{}/@lib+b@0.0.0".format(name): "@lib/b",
-                "//root:.aspect_rules_js/{}/vendored-a@0.0.0".format(name): "vendored-a",
-                "//root:.aspect_rules_js/{}/vendored-b@0.0.0".format(name): "vendored-b",
+                "//root:.aspect_rules_js/{}/vendored-a@file+..+vendored+a".format(name): "vendored-a",
+                "//root:.aspect_rules_js/{}/vendored-b@file+..+vendored+b_at_lib_b_lib+b".format(name): "vendored-b",
             },
             visibility = ["//visibility:public"],
             tags = ["manual"],
@@ -375,7 +375,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 def _fp_link_0(name):
     _npm_local_link_package_store(
         name = "{}/@lib/c".format(name),
-        src = "//root:.aspect_rules_js/{}/@lib+c@0.0.0".format(name),
+        src = "//root:.aspect_rules_js/{}/@lib+c@file+..+lib+c".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
@@ -383,7 +383,7 @@ def _fp_link_0(name):
 def _fp_link_1(name):
     _npm_local_link_package_store(
         name = "{}/vendored-a".format(name),
-        src = "//root:.aspect_rules_js/{}/vendored-a@0.0.0".format(name),
+        src = "//root:.aspect_rules_js/{}/vendored-a@file+..+vendored+a".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "vendored-b" package
@@ -391,7 +391,7 @@ def _fp_link_1(name):
 def _fp_link_2(name):
     _npm_local_link_package_store(
         name = "{}/vendored-b".format(name),
-        src = "//root:.aspect_rules_js/{}/vendored-b@0.0.0".format(name),
+        src = "//root:.aspect_rules_js/{}/vendored-b@file+..+vendored+b_at_lib_b_lib+b".format(name),
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/a" package

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -121,6 +121,7 @@ js_binary(name = "sync", entry_point = "noop.js")
                 transitive_deps[dep_store_target] = ",".join(transitive_deps[dep_store_target])
             fp_links[dep_key] = {
                 "package": name,
+                "version": version,
                 "path": dep_path,
                 "link_packages": {},
                 "deps": transitive_deps,

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -2338,10 +2338,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         store_1133(name)
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "is-odd@0.0.0",
+            package_store_name = "is-odd@file+npm+private+test+vendored+is-odd",
             src = "//npm/private/test/vendored/is-odd:pkg",
             package = "is-odd",
-            version = "0.0.0",
+            version = "file:npm/private/test/vendored/is-odd",
             deps = {
                 "//:.aspect_rules_js/{}/is-number@6.0.0".format(name): "is-number",
             },
@@ -2350,12 +2350,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         )
         _npm_local_package_store(
             link_root_name = name,
-            package_store_name = "semver-max@0.0.0",
+            package_store_name = "semver-max@file+npm+private+test+vendored+semver-max",
             src = "//npm/private/test/vendored/semver-max:pkg",
             package = "semver-max",
-            version = "0.0.0",
+            version = "file:npm/private/test/vendored/semver-max",
             deps = {
-                "//:.aspect_rules_js/{}/is-odd@0.0.0".format(name): "is-odd",
+                "//:.aspect_rules_js/{}/is-odd@file+npm+private+test+vendored+is-odd".format(name): "is-odd",
                 "//:.aspect_rules_js/{}/semver@5.7.2".format(name): "semver",
             },
             visibility = ["//visibility:public"],

--- a/npm/private/test/utils_tests.bzl
+++ b/npm/private/test/utils_tests.bzl
@@ -32,8 +32,9 @@ def test_pnpm_name(ctx):
 def test_link_version(ctx):
     env = unittest.begin(ctx)
     asserts.equals(env, "@scope+y@0.0.0", utils.package_store_name("@scope/y", "link:foo"))
-    asserts.equals(env, "@scope+y@0.0.0", utils.package_store_name("@scope/y", "file:bar"))
-    asserts.equals(env, "@scope+y@0.0.0", utils.package_store_name("@scope/y", "file:@foo/bar"))
+    asserts.equals(env, "@scope+y@file+bar", utils.package_store_name("@scope/y", "file:bar"))
+    asserts.equals(env, "@scope+y@file+..+foo+bar", utils.package_store_name("@scope/y", "file:../foo/bar"))
+    asserts.equals(env, "@scope+y@file+@foo+bar", utils.package_store_name("@scope/y", "file:@foo/bar"))
     return unittest.end(env)
 
 def test_friendly_name(ctx):

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -51,7 +51,9 @@ def _escape_target_name(name):
 def _package_store_name(pnpm_name, pnpm_version):
     "Make a package store name for a given package and version"
 
-    if pnpm_version.startswith("link:") or pnpm_version.startswith("file:"):
+    if pnpm_version.startswith("link:"):
+        # Distinguish local links a 0.0.0 version. This is unlike pnpm which symlinks
+        # local links into the source tree instead of storing them in the package store.
         name = pnpm_name
         version = "0.0.0"
     elif pnpm_version.startswith("npm:"):


### PR DESCRIPTION
This aligns rules_js with pnpm when it comes to `file:` references in the package store, as well as bazel target throughout the various store/link targets.

Now only `workspace:*` deps (which resolve to `link:path` versions) will continue to use `@0.0.0` in the package store. This is different then pnpm where local workspace deps are symlinks into source and do not exist in the package store at all.

Ref #2300 which will depend on this change.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
