### PR TITLE
refactor: remove bazel6 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,6 @@ jobs:
                   a=(
                     "major:$m, version:\"$v\""
                     "major:8, version:\"8.1.1\""
-                    "major:6, version:\"6.5.0\""
                   )
                   printf -v j '{%s},' "${a[@]}"
                   echo "res=[${j%,}]" | tee -a $GITHUB_OUTPUT
@@ -133,16 +132,6 @@ jobs:
                     # Don't run bzlmod smoke test under workspace
                     - bzlmod: 0
                       folder: e2e/bzlmod
-                    # Don't run replace_packages test with bzlmod+Bazel 6 due to use of Bazel 7 bzlmod features
-                    - bazel-version:
-                          major: 6
-                      bzlmod: 1
-                      folder: e2e/npm_translate_lock_replace_packages
-                    # Don't run workspace tests with Bazel 6 to reduce the size of the test matrix
-                    # and remove the need for bazel 6 workspace support for local development.
-                    - bazel-version:
-                          major: 6
-                      bzlmod: 0
                     # Don't run workspace tests unit tests.
                     - bzlmod: 0
                       folder: .
@@ -170,24 +159,6 @@ jobs:
                       folder: e2e/npm_link_package
                     - bzlmod: 1
                       folder: e2e/rules_foo
-                    # gyp_no_install_script+patch_from_repo+js_run_devserver are broken in an usual way on 6.5.0
-                    # that is not worth investigating as we're dropping Bazel 6 support soon
-                    - bazel-version:
-                          major: 6
-                      folder: e2e/gyp_no_install_script
-                    - bazel-version:
-                          major: 6
-                      folder: e2e/patch_from_repo
-                    # devservers on bazel6+bzlmod also broken in an odd way
-                    - bazel-version:
-                          major: 6
-                      folder: e2e/js_run_devserver
-                    - bazel-version:
-                          major: 6
-                      folder: e2e/webpack_devserver
-                    - bazel-version:
-                          major: 6
-                      folder: e2e/webpack_devserver_esm
                     # @bazel/runfiles seems broken with non-bzlmod + bazel7
                     # https://github.com/bazel-contrib/rules_nodejs/issues/3797
                     - bzlmod: 0
@@ -216,20 +187,6 @@ jobs:
                     - bazel-version:
                           major: 7
                           version: 7.4.0
-                      bzlmod: 1
-                      os: macos
-                      config: local
-                      folder: e2e/bzlmod
-                    - bazel-version:
-                          major: 6
-                          version: 6.5.0
-                      bzlmod: 1
-                      os: windows
-                      config: local
-                      folder: e2e/bzlmod
-                    - bazel-version:
-                          major: 6
-                          version: 6.5.0
                       bzlmod: 1
                       os: macos
                       config: local

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -25,7 +25,7 @@ Many companies are successfully building with rules_js.
 If you're getting value from the project, please let us know!
 Just comment on our [Adoption Discussion](https://github.com/aspect-build/rules_js/discussions/1000).
 
-## Using Bzlmod with Bazel 6:
+## Using Bzlmod:
 
 Add to your \`MODULE.bazel\` file:
 \`\`\`starlark

--- a/docs/docs.bzl
+++ b/docs/docs.bzl
@@ -3,16 +3,11 @@
 """
 
 load("@aspect_bazel_lib//lib:docs.bzl", _stardoc_with_diff_test = "stardoc_with_diff_test", _update_docs = "update_docs")
-load("@aspect_bazel_lib//lib:utils.bzl", "is_bazel_7_or_greater")
 
 def stardoc_with_diff_test(name, **kwargs):
     """
         Wrapper around stardoc_with_diff_test that only runs the test if Bazel 7 or greater is being used.
     """
-    if is_bazel_7_or_greater():
-        _stardoc_with_diff_test(name, renderer = "//tools:stardoc_renderer", **kwargs)
-    else:
-        # buildifier: disable=print
-        print("WARNING: Skipping stardoc_with_diff_test for %s because it requires Bazel 7 or greater" % name)
+    _stardoc_with_diff_test(name, renderer = "//tools:stardoc_renderer", **kwargs)
 
 update_docs = _update_docs

--- a/e2e/gyp_no_install_script/BUILD.bazel
+++ b/e2e/gyp_no_install_script/BUILD.bazel
@@ -19,7 +19,6 @@ write_source_files(
         "snapshots/wksp/segfault-handler_defs.bzl": "@npm__segfault-handler__1.3.0__links//:defs.bzl",
     },
     # Target names may be different on bazel versions
-    tags = ["skip-on-bazel6"],
     target_compatible_with = select({
         "@aspect_bazel_lib//lib:bzlmod": ["@platforms//:incompatible"],
         "//conditions:default": [],
@@ -32,7 +31,6 @@ write_source_files(
         "snapshots/bzlmod/segfault-handler_defs.bzl": "@npm__segfault-handler__1.3.0__links//:defs.bzl",
     },
     # Target names may be different on bazel versions
-    tags = ["skip-on-bazel6"],
     target_compatible_with = select({
         "@aspect_bazel_lib//lib:bzlmod": [],
         "//conditions:default": ["@platforms//:incompatible"],

--- a/e2e/npm_translate_lock_disable_hooks/BUILD.bazel
+++ b/e2e/npm_translate_lock_disable_hooks/BUILD.bazel
@@ -17,7 +17,6 @@ write_source_files(
         "snapshots/wksp/repositories.bzl": "@npm//:repositories.bzl",
     },
     # Target names may be different on bazel versions
-    tags = ["skip-on-bazel6"],
     target_compatible_with = select({
         "@aspect_bazel_lib//lib:bzlmod": ["@platforms//:incompatible"],
         "//conditions:default": [],
@@ -31,7 +30,6 @@ write_source_files(
         "snapshots/aspect_test_c_links_defs.bzl": "@npm__at_aspect-test_c__2.0.0__links//:defs.bzl",
     },
     # Target names may be different on bazel versions
-    tags = ["skip-on-bazel6"],
     target_compatible_with = select({
         "@aspect_bazel_lib//lib:bzlmod": [],
         "//conditions:default": ["@platforms//:incompatible"],

--- a/e2e/npm_translate_lock_empty/BUILD.bazel
+++ b/e2e/npm_translate_lock_empty/BUILD.bazel
@@ -18,7 +18,6 @@ write_source_files(
         "snapshots/bzlmod/npm_defs.bzl": "@npm//:defs.bzl",
     },
     # Target names may be different on bazel versions
-    tags = ["skip-on-bazel6"],
     target_compatible_with = select({
         "@aspect_bazel_lib//lib:bzlmod": [],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -32,7 +31,6 @@ write_source_files(
         "snapshots/wksp/npm_defs.bzl": "@npm//:defs.bzl",
     },
     # Target names may be different on bazel versions
-    tags = ["skip-on-bazel6"],
     target_compatible_with = select({
         "@aspect_bazel_lib//lib:bzlmod": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -249,8 +249,6 @@ def lockfile_test(npm_link_all_packages, name = None):
             "@aspect_bazel_lib//lib:bzlmod": [],
             "//conditions:default": ["@platforms//:incompatible"],
         }),
-        # Target names may be different on bazel versions
-        tags = ["skip-on-bazel6"],
     )
 
     # buildifier: disable=no-effect
@@ -286,6 +284,4 @@ def lockfile_test(npm_link_all_packages, name = None):
             "@aspect_bazel_lib//lib:bzlmod": ["@platforms//:incompatible"],
             "//conditions:default": [],
         }),
-        # Target names may be different on bazel versions
-        tags = ["skip-on-bazel6"],
     )

--- a/e2e/pnpm_workspace/BUILD.bazel
+++ b/e2e/pnpm_workspace/BUILD.bazel
@@ -34,8 +34,6 @@ write_source_files(
     files = {
         "snapshots/defs.bzl": "@npm//:defs.bzl",
     },
-    # Target names may be different on bazel versions
-    tags = ["skip-on-bazel6"],
     # Target names may be different on workspace vs bzlmod
     target_compatible_with = select({
         "@aspect_bazel_lib//lib:bzlmod": [],

--- a/e2e/pnpm_workspace_rerooted/BUILD.bazel
+++ b/e2e/pnpm_workspace_rerooted/BUILD.bazel
@@ -34,8 +34,6 @@ write_source_files(
     files = {
         "snapshots/defs.bzl": "@npm//:defs.bzl",
     },
-    # Target names may be different on bazel versions
-    tags = ["skip-on-bazel6"],
     # Target names may be different on workspace vs bzlmod
     target_compatible_with = select({
         "@aspect_bazel_lib//lib:bzlmod": [],

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -1,6 +1,5 @@
 "Public API"
 
-load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
@@ -46,7 +45,8 @@ bzl_library(
     srcs = ["repositories.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "@bazel_tools//tools/build_defs/repo:cache.bzl",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
+    ],
 )

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -1,6 +1,5 @@
 "Internal implementation details"
 
-load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -21,7 +20,8 @@ bzl_library(
     srcs = ["js_info_files.bzl"],
     deps = [
         ":js_helpers",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
+        "@bazel_tools//tools/build_defs/repo:cache.bzl",
+    ],
 )
 
 bzl_library(
@@ -37,7 +37,8 @@ bzl_library(
         "@aspect_bazel_lib//lib:windows_utils",
         "@bazel_lib//lib:directory_path",
         "@bazel_skylib//lib:dicts",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
+        "@bazel_tools//tools/build_defs/repo:cache.bzl",
+    ],
 )
 
 bzl_library(
@@ -58,7 +59,8 @@ bzl_library(
         ":js_info",
         "@aspect_bazel_lib//lib:copy_to_bin",
         "@bazel_skylib//lib:dicts",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
+        "@bazel_tools//tools/build_defs/repo:cache.bzl",
+    ],
 )
 
 bzl_library(
@@ -81,7 +83,8 @@ bzl_library(
         ":js_binary",
         ":js_helpers",
         "@bazel_skylib//lib:dicts",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
+        "@bazel_tools//tools/build_defs/repo:cache.bzl",
+    ],
 )
 
 bzl_library(
@@ -102,5 +105,6 @@ bzl_library(
     deps = [
         "@aspect_bazel_lib//lib:tar",
         "@bazel_skylib//lib:paths",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
+        "@bazel_tools//tools/build_defs/repo:cache.bzl",
+    ],
 )

--- a/js/private/test/BUILD.bazel
+++ b/js/private/test/BUILD.bazel
@@ -36,7 +36,6 @@ write_source_files(
         "snapshots/launcher.sh": ":shell_launcher_sed",
     },
     tags = [
-        "skip-on-bazel6",
         "skip-on-bazel8",
         "skip-on-bazel9",
     ],

--- a/js/private/test/image/asserts.bzl
+++ b/js/private/test/image/asserts.bzl
@@ -25,7 +25,7 @@ def assert_tar_listing(name, actual, expected):
         in_file = actual_listing,
         out_file = expected,
         testonly = True,
-        tags = ["skip-on-bazel6", "skip-on-bazel8", "skip-on-bazel9"],
+        tags = ["skip-on-bazel8", "skip-on-bazel9"],
     )
 
 layers = [
@@ -52,7 +52,7 @@ def assert_js_image_layer_listings(name, js_image_layer, additional_layers = [])
             "assert_{}_{}".format(name, layer)
             for layer in all_layers
         ],
-        tags = ["skip-on-bazel6", "skip-on-bazel8", "skip-on-bazel9"],
+        tags = ["skip-on-bazel8", "skip-on-bazel9"],
         testonly = True,
     )
 
@@ -102,5 +102,5 @@ echo "$${RESULT//$$BINDIR/}" | $$COREUTILS_BIN head -n -1 > $@
         testonly = True,
         in_file = name,
         out_file = name + ".expected",
-        tags = ["skip-on-bazel6", "skip-on-bazel8", "skip-on-bazel9"],
+        tags = ["skip-on-bazel8", "skip-on-bazel9"],
     )

--- a/npm/private/BUILD.bazel
+++ b/npm/private/BUILD.bazel
@@ -1,7 +1,6 @@
 "Internal implementation details"
 
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
-load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
@@ -191,7 +190,8 @@ bzl_library(
         "@aspect_bazel_lib//lib:repo_utils",
         "@aspect_bazel_lib//lib:utils",
         "@bazel_skylib//lib:types",
-    ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
+        "@bazel_tools//tools/build_defs/repo:cache.bzl",
+    ],
 )
 
 bzl_library(

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -579,9 +579,8 @@ def npm_translate_lock(
 
         **kwargs: Internal use only
     """
-    if not bazel_lib_utils.is_bazel_6_or_greater():
-        # ctx.actions.declare_symlink was added in Bazel 6
-        fail("A minimum version of Bazel 6 required to use rules_js")
+    if not bazel_lib_utils.is_bazel_7_or_greater():
+        fail("A minimum version of Bazel 7 required to use rules_js")
 
     # Gather undocumented attributes
     root_package = kwargs.pop("root_package", None)

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -44,7 +44,6 @@ write_source_files(
         "snapshots/package_json_with_dashes.bzl": "@npm__webpack-bundle-analyzer__4.5.0_bufferutil_4.0.8//npm/private/test:package_json.bzl",
     },
     tags = [
-        "skip-on-bazel6",
         "skip-on-bazel8",
         "skip-on-bazel9",
     ],

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -20,7 +20,6 @@ bazelrc_preset(
     doc_link_template = "https://registry.build/flag/bazel?filter={flag}",
     # The output is specific to the version in .bazelversion
     tags = [
-        "skip-on-bazel6",
         "skip-on-bazel8",
         "skip-on-bazel9",
     ],


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Remove bazel 6 support

### Test plan

- Covered by existing test cases
