### PR TITLE
refactor: remove npm_translate_lock(defs_bzl_filename)

### DIFF
--- a/e2e/npm_translate_lock_link_workspace/MODULE.bazel
+++ b/e2e/npm_translate_lock_link_workspace/MODULE.bazel
@@ -16,17 +16,16 @@ npm.npm_translate_lock(
     name = "foo",
     additional_file_contents = {
         "BUILD.bazel": [
-            """load("//:npm_link_all_packages.bzl", "npm_link_all_packages")""",
+            """load("//:defs.bzl", "npm_link_all_packages")""",
             """npm_link_all_packages(name = "node_modules")""",
         ],
         # Test that we can add statements to the generated defs bzl file
-        "npm_link_all_packages.bzl": [
+        "defs.bzl": [
             """load("@aspect_rules_js//js:defs.bzl", _js_run_binary = "js_run_binary")""",
             """def js_run_binary(**kwargs):
     _js_run_binary(**kwargs)""",
         ],
     },
-    defs_bzl_filename = "npm_link_all_packages.bzl",
     # We'll be linking in the @foo repository and not the repository where the pnpm-lock file is located
     link_workspace = "foo",
     pnpm_lock = "//foo:pnpm-lock.yaml",

--- a/e2e/npm_translate_lock_link_workspace/foo/BUILD.bazel
+++ b/e2e/npm_translate_lock_link_workspace/foo/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 load("@foo//:@aspect-test/a/package_json.bzl", "bin")
-load("@foo//:npm_link_all_packages.bzl", "js_run_binary")
+load("@foo//:defs.bzl", "js_run_binary")
 
 bin.bin_a_binary(name = "main")
 

--- a/e2e/npm_translate_lock_link_workspace/foo/repositories.bzl
+++ b/e2e/npm_translate_lock_link_workspace/foo/repositories.bzl
@@ -10,14 +10,13 @@ def foo_repositories():
         link_workspace = "foo",
         # Override the Bazel package where pnpm-lock.yaml is located and link to the specified package instead
         root_package = "",
-        defs_bzl_filename = "npm_link_all_packages.bzl",
         additional_file_contents = {
             "BUILD.bazel": [
                 """load("//:npm_link_all_packages.bzl", "npm_link_all_packages")""",
                 """npm_link_all_packages()""",
             ],
             # Test that we can add statements to the generated defs bzl file
-            "npm_link_all_packages.bzl": [
+            "defs.bzl": [
                 """load("@aspect_rules_js//js:defs.bzl", _js_run_binary = "js_run_binary")""",
                 """def js_run_binary(**kwargs):
     _js_run_binary(**kwargs)""",

--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -163,7 +163,6 @@ The 'replace_packages' attribute will be removed in rules_js version 3.0.
         verify_patches = attr.verify_patches,
         yarn_lock = attr.yarn_lock,
         exclude_package_contents = exclude_package_contents_config,
-        defs_bzl_filename = attr.defs_bzl_filename,
         additional_file_contents = attr.additional_file_contents,
     )
 

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -41,7 +41,6 @@ load(":utils.bzl", "utils")
 RULES_JS_FROZEN_PNPM_LOCK_ENV = "ASPECT_RULES_JS_FROZEN_PNPM_LOCK"
 
 ################################################################################
-DEFAULT_DEFS_BZL_FILENAME = "defs.bzl"
 
 def _normalize_exclude_package_contents(exclude_package_contents):
     """Normalize exclude_package_contents dictionary for string_list_dict format."""
@@ -73,7 +72,6 @@ _ATTRS = {
     "bins": attr.string_list_dict(),
     "custom_postinstalls": attr.string_dict(),
     "data": attr.label_list(),
-    "defs_bzl_filename": attr.string(default = DEFAULT_DEFS_BZL_FILENAME),
     "dev": attr.bool(),
     "external_repository_action_cache": attr.string(default = utils.default_external_repository_action_cache()),
     "generate_bzl_library_targets": attr.bool(),
@@ -581,7 +579,6 @@ def npm_translate_lock(
     # Gather undocumented attributes
     root_package = kwargs.pop("root_package", None)
     additional_file_contents = kwargs.pop("additional_file_contents", {})
-    defs_bzl_filename = kwargs.pop("defs_bzl_filename", None)
     generate_bzl_library_targets = kwargs.pop("generate_bzl_library_targets", None)
 
     if len(kwargs):
@@ -658,7 +655,6 @@ def npm_translate_lock(
         link_workspace = link_workspace,
         root_package = root_package,
         additional_file_contents = additional_file_contents,
-        defs_bzl_filename = defs_bzl_filename,
         generate_bzl_library_targets = generate_bzl_library_targets,
         data = data,
         preupdate = preupdate,

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -8,6 +8,8 @@ load(":utils.bzl", "utils")
 
 ################################################################################
 
+_DEFS_BZL_FILENAME = "defs.bzl"
+
 _BIN_TMPL = \
     """load("{repo_package_json_bzl}", _bin = "bin")
 bin = _bin
@@ -67,7 +69,7 @@ js_binary(name = "sync", entry_point = "noop.js")
 """,
             "",
             "exports_files({})".format(starlark_codegen_utils.to_list_attr([
-                rctx.attr.defs_bzl_filename,
+                _DEFS_BZL_FILENAME,
             ])),
         ],
     }
@@ -208,7 +210,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         fail(msg)
 {validation_call}
 """.format(
-            defs_bzl_file = "@{}//:{}".format(rctx.name, rctx.attr.defs_bzl_filename),
+            defs_bzl_file = "@{}//:{}".format(rctx.name, _DEFS_BZL_FILENAME),
             link_packages_comma_separated = "\"'\" + \"', '\".join(_IMPORTER_PACKAGES) + \"'\"" if package_to_importer else "\"\"",
             root_package = root_package,
             pnpm_lock_label = rctx.attr.pnpm_lock,
@@ -499,7 +501,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         "\n".join(link_factories_bzl),
     ])
 
-    rctx_files[rctx.attr.defs_bzl_filename] = defs_bzl_contents
+    rctx_files[_DEFS_BZL_FILENAME] = defs_bzl_contents
 
     for filename, contents in rctx.attr.additional_file_contents.items():
         if not rctx_files.get(filename, False):


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Remove `npm_translate_lock(defs_bzl_filename)`

### Test plan

- Covered by existing test cases
