### PR TITLE
fix: Expand directories in js_run_devserver

### DIFF
--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -73,7 +73,7 @@ def _js_run_devserver_impl(ctx):
     entries.add("[")
     entries.add_joined(
         depset(transitive = transitive_runfiles + [dep.files for dep in ctx.attr.data] + default_data_runfiles),
-        expand_directories = False,
+        expand_directories = True,
         map_each = _file_to_entry_json,
         join_with = ",",
     )


### PR DESCRIPTION
This fixes a bug I encountered where it seems like the args file that is being constructed is not invalidated when files that are passed into `js_run_devserver` are renamed.

The exact steps I had to do to reproduce this were:
1. Have a NextJS project which takes in a `ts_project` as input in srcs
2. Run `nextjs_dev` and everything works fine
3. Rename a .ts file
4. Run `nextjs_dev` again
5. `js_run_devserver` complains that it can't find a file with the same name as BEFORE the rename.
6. Run `bazel clean`
7. Run `nextjs_dev` again
8. Everything works again

I narrowed this bug down to the changes in this PR: https://github.com/aspect-build/rules_js/pull/2255

