### PR TITLE
fix: share single package store entry accross all aliases to local projects

### DIFF
--- a/e2e/pnpm_lockfiles/lockfile-test.bzl
+++ b/e2e/pnpm_lockfiles/lockfile-test.bzl
@@ -138,7 +138,6 @@ def lockfile_test(npm_link_all_packages, name = None):
             ":.aspect_rules_js/node_modules/@scoped+b@0.0.0",
             ":.aspect_rules_js/node_modules/@scoped+c@file+..+projects+c_at_scoped_b_projects%sb" % ("_" if lock_version == "v54" else "+"),  # is declared as a file: instead of link:
             ":.aspect_rules_js/node_modules/@scoped+d@0.0.0",
-            ":.aspect_rules_js/node_modules/scoped+bad@0.0.0",
 
             # file: 4.17.21.tgz tarbal
             ":node_modules/lodash",

--- a/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
@@ -225,26 +225,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         _npm_local_package_store(
-            package_store_name = "alias-project-a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "alias-project-a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        _npm_local_package_store(
-            package_store_name = "scoped+bad@0.0.0",
-            src = "//projects/b:pkg",
-            package = "scoped/bad",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+a@0.0.0": "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        _npm_local_package_store(
             package_store_name = "test-c200-d200@0.0.0",
             src = "//projects/peers-combo-2:pkg",
             package = "test-c200-d200",
@@ -330,13 +310,13 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_68("node_modules/uvu", False, "uvu")
             _fp_link_0()
             _fp_link_2()
+            _fp_link_2("alias-project-a")
             _fp_link_3()
+            _fp_link_3("scoped/bad")
             _fp_link_4()
             _fp_link_5()
             _fp_link_6()
             _fp_link_7()
-            _fp_link_8()
-            _fp_link_9()
             link_targets = [
                 ":node_modules/@aspect-test-a-bad-scope",
                 ":node_modules/@aspect-test-custom-scope/a",
@@ -369,10 +349,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 ":node_modules/uvu",
                 ":node_modules/@scoped/c",
                 ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-                ":node_modules/@scoped/d",
                 ":node_modules/alias-project-a",
+                ":node_modules/@scoped/b",
                 ":node_modules/scoped/bad",
+                ":node_modules/@scoped/d",
                 ":node_modules/test-c200-d200",
                 ":node_modules/test-c201-d200",
                 ":node_modules/test-peer-types",
@@ -460,7 +440,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "projects/b":
             link_22("node_modules/@types/node", True, "@types/node")
             _fp_link_2()
-            _fp_link_10()
+            _fp_link_8()
             link_targets = [
                 ":node_modules/@scoped/a",
                 ":node_modules/@types/node",
@@ -484,7 +464,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "projects/c":
             _fp_link_2()
             _fp_link_3()
-            _fp_link_10()
+            _fp_link_8()
             link_targets = [
                 ":node_modules/@scoped/a",
                 ":node_modules/@scoped/b",
@@ -584,10 +564,10 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/uvu",
                 ":node_modules/@scoped/c",
                 ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-                ":node_modules/@scoped/d",
                 ":node_modules/alias-project-a",
+                ":node_modules/@scoped/b",
                 ":node_modules/scoped/bad",
+                ":node_modules/@scoped/d",
                 ":node_modules/test-c200-d200",
                 ":node_modules/test-c201-d200",
                 ":node_modules/test-peer-types",
@@ -659,80 +639,72 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring
-def _fp_link_0():
+def _fp_link_0(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@scoped/c",
+        name = "node_modules/@scoped/c" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+c@file+..+projects+c_at_scoped_b_projects+b",
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package
 # buildifier: disable=function-docstring
-def _fp_link_2():
+def _fp_link_2(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@scoped/a",
+        name = "node_modules/@scoped/a" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+a@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/b" package
 # buildifier: disable=function-docstring
-def _fp_link_3():
+def _fp_link_3(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@scoped/b",
+        name = "node_modules/@scoped/b" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+b@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/d" package
 # buildifier: disable=function-docstring
-def _fp_link_4():
+def _fp_link_4(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@scoped/d",
+        name = "node_modules/@scoped/d" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+d@0.0.0",
-    )
-
-# Generated npm_link_package_store for linking of first-party "alias-project-a" package
-# buildifier: disable=function-docstring
-def _fp_link_5():
-    _npm_local_link_package_store(
-        name = "node_modules/alias-project-a",
-        src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/alias-project-a@0.0.0",
-    )
-
-# Generated npm_link_package_store for linking of first-party "scoped/bad" package
-# buildifier: disable=function-docstring
-def _fp_link_6():
-    _npm_local_link_package_store(
-        name = "node_modules/scoped/bad",
-        src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/scoped+bad@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c200-d200" package
 # buildifier: disable=function-docstring
-def _fp_link_7():
+def _fp_link_5(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/test-c200-d200",
+        name = "node_modules/test-c200-d200" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/test-c200-d200@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c201-d200" package
 # buildifier: disable=function-docstring
-def _fp_link_8():
+def _fp_link_6(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/test-c201-d200",
+        name = "node_modules/test-c201-d200" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/test-c201-d200@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "test-peer-types" package
 # buildifier: disable=function-docstring
-def _fp_link_9():
+def _fp_link_7(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/test-peer-types",
+        name = "node_modules/test-peer-types" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/test-peer-types@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring
-def _fp_link_10():
+def _fp_link_8(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/a-types",
+        name = "node_modules/a-types" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/a-types@0.0.0",
     )

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -225,26 +225,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         _npm_local_package_store(
-            package_store_name = "alias-project-a@0.0.0",
-            src = "//projects/a:pkg",
-            package = "alias-project-a",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        _npm_local_package_store(
-            package_store_name = "scoped+bad@0.0.0",
-            src = "//projects/b:pkg",
-            package = "scoped/bad",
-            version = "0.0.0",
-            deps = {
-                "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+a@0.0.0": "@scoped/a",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        _npm_local_package_store(
             package_store_name = "test-c200-d200@0.0.0",
             src = "//projects/peers-combo-2:pkg",
             package = "test-c200-d200",
@@ -330,13 +310,13 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_68("node_modules/uvu", False, "uvu")
             _fp_link_0()
             _fp_link_2()
+            _fp_link_2("alias-project-a")
             _fp_link_3()
+            _fp_link_3("scoped/bad")
             _fp_link_4()
             _fp_link_5()
             _fp_link_6()
             _fp_link_7()
-            _fp_link_8()
-            _fp_link_9()
             link_targets = [
                 ":node_modules/@aspect-test-a-bad-scope",
                 ":node_modules/@aspect-test-custom-scope/a",
@@ -369,10 +349,10 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 ":node_modules/uvu",
                 ":node_modules/@scoped/c",
                 ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-                ":node_modules/@scoped/d",
                 ":node_modules/alias-project-a",
+                ":node_modules/@scoped/b",
                 ":node_modules/scoped/bad",
+                ":node_modules/@scoped/d",
                 ":node_modules/test-c200-d200",
                 ":node_modules/test-c201-d200",
                 ":node_modules/test-peer-types",
@@ -460,7 +440,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "projects/b":
             link_22("node_modules/@types/node", True, "@types/node")
             _fp_link_2()
-            _fp_link_10()
+            _fp_link_8()
             link_targets = [
                 ":node_modules/@scoped/a",
                 ":node_modules/@types/node",
@@ -484,7 +464,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "projects/c":
             _fp_link_2()
             _fp_link_3()
-            _fp_link_10()
+            _fp_link_8()
             link_targets = [
                 ":node_modules/@scoped/a",
                 ":node_modules/@scoped/b",
@@ -584,10 +564,10 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/uvu",
                 ":node_modules/@scoped/c",
                 ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-                ":node_modules/@scoped/d",
                 ":node_modules/alias-project-a",
+                ":node_modules/@scoped/b",
                 ":node_modules/scoped/bad",
+                ":node_modules/@scoped/d",
                 ":node_modules/test-c200-d200",
                 ":node_modules/test-c201-d200",
                 ":node_modules/test-peer-types",
@@ -659,80 +639,72 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring
-def _fp_link_0():
+def _fp_link_0(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@scoped/c",
+        name = "node_modules/@scoped/c" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+c@file+..+projects+c_at_scoped_b_projects+b",
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/a" package
 # buildifier: disable=function-docstring
-def _fp_link_2():
+def _fp_link_2(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@scoped/a",
+        name = "node_modules/@scoped/a" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+a@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/b" package
 # buildifier: disable=function-docstring
-def _fp_link_3():
+def _fp_link_3(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@scoped/b",
+        name = "node_modules/@scoped/b" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+b@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@scoped/d" package
 # buildifier: disable=function-docstring
-def _fp_link_4():
+def _fp_link_4(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@scoped/d",
+        name = "node_modules/@scoped/d" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/@scoped+d@0.0.0",
-    )
-
-# Generated npm_link_package_store for linking of first-party "alias-project-a" package
-# buildifier: disable=function-docstring
-def _fp_link_5():
-    _npm_local_link_package_store(
-        name = "node_modules/alias-project-a",
-        src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/alias-project-a@0.0.0",
-    )
-
-# Generated npm_link_package_store for linking of first-party "scoped/bad" package
-# buildifier: disable=function-docstring
-def _fp_link_6():
-    _npm_local_link_package_store(
-        name = "node_modules/scoped/bad",
-        src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/scoped+bad@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c200-d200" package
 # buildifier: disable=function-docstring
-def _fp_link_7():
+def _fp_link_5(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/test-c200-d200",
+        name = "node_modules/test-c200-d200" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/test-c200-d200@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "test-c201-d200" package
 # buildifier: disable=function-docstring
-def _fp_link_8():
+def _fp_link_6(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/test-c201-d200",
+        name = "node_modules/test-c201-d200" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/test-c201-d200@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "test-peer-types" package
 # buildifier: disable=function-docstring
-def _fp_link_9():
+def _fp_link_7(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/test-peer-types",
+        name = "node_modules/test-peer-types" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/test-peer-types@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring
-def _fp_link_10():
+def _fp_link_8(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/a-types",
+        name = "node_modules/a-types" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//<LOCKVERSION>:.aspect_rules_js/node_modules/a-types@0.0.0",
     )

--- a/e2e/pnpm_workspace/app/b/BUILD.bazel
+++ b/e2e/pnpm_workspace/app/b/BUILD.bazel
@@ -36,6 +36,6 @@ build_test(
     targets = [
         ":node_modules/@lib/b",
         ":node_modules/@lib/b_alias",
-        "//:.aspect_rules_js/node_modules/@lib+b_alias@0.0.0",
+        "//:.aspect_rules_js/node_modules/@lib+b@0.0.0",
     ],
 )

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -104,18 +104,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         _npm_local_package_store(
-            package_store_name = "@lib+b_alias@0.0.0",
-            src = "//lib/b:pkg",
-            package = "@lib/b_alias",
-            version = "0.0.0",
-            deps = {
-                "//:.aspect_rules_js/node_modules/@aspect-test+f@1.0.0": "@aspect-test/f",
-                "//:.aspect_rules_js/node_modules/@types+sizzle@2.3.8": "alias-1",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        _npm_local_package_store(
             package_store_name = "@lib+c@0.0.0",
             src = "//lib/c:pkg",
             package = "@lib/c",
@@ -182,7 +170,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "app/c":
             link_0("node_modules/@aspect-test/a", False, "@aspect-test/a")
             link_6("node_modules/@aspect-test/g", False, "@aspect-test/g")
-            _fp_link_5()
+            _fp_link_4()
             link_targets = [
                 ":node_modules/@aspect-test/a",
                 ":node_modules/@aspect-test/g",
@@ -238,7 +226,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             }
         elif bazel_package == "app/d":
             link_6("node_modules/@aspect-test/g", False, "@aspect-test/g")
-            _fp_link_6()
+            _fp_link_5()
             link_targets = [
                 ":node_modules/@aspect-test/g",
                 ":node_modules/@lib/d",
@@ -250,7 +238,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "app/b":
             link_7("node_modules/@aspect-test/h", False, "@aspect-test/h")
             _fp_link_3()
-            _fp_link_4()
+            _fp_link_3("@lib/b_alias")
             link_targets = [
                 ":node_modules/@aspect-test/h",
                 ":node_modules/@lib/b",
@@ -369,56 +357,54 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
 # buildifier: disable=function-docstring
-def _fp_link_0():
+def _fp_link_0(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/vendored-a",
+        name = "node_modules/vendored-a" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/vendored-a@file+vendored+a",
     )
 
 # Generated npm_link_package_store for linking of first-party "vendored-b" package
 # buildifier: disable=function-docstring
-def _fp_link_1():
+def _fp_link_1(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/vendored-b",
+        name = "node_modules/vendored-b" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/vendored-b@file+vendored+b_at_lib_b_lib+b",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/a" package
 # buildifier: disable=function-docstring
-def _fp_link_2():
+def _fp_link_2(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/a",
+        name = "node_modules/@lib/a" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@lib+a@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/b" package
 # buildifier: disable=function-docstring
-def _fp_link_3():
+def _fp_link_3(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/b",
+        name = "node_modules/@lib/b" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@lib+b@0.0.0",
-    )
-
-# Generated npm_link_package_store for linking of first-party "@lib/b_alias" package
-# buildifier: disable=function-docstring
-def _fp_link_4():
-    _npm_local_link_package_store(
-        name = "node_modules/@lib/b_alias",
-        src = "//:.aspect_rules_js/node_modules/@lib+b_alias@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/c" package
 # buildifier: disable=function-docstring
-def _fp_link_5():
+def _fp_link_4(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/c",
+        name = "node_modules/@lib/c" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@lib+c@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/d" package
 # buildifier: disable=function-docstring
-def _fp_link_6():
+def _fp_link_5(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/d",
+        name = "node_modules/@lib/d" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@lib+d@0.0.0",
     )

--- a/e2e/pnpm_workspace_rerooted/app/b/BUILD.bazel
+++ b/e2e/pnpm_workspace_rerooted/app/b/BUILD.bazel
@@ -36,6 +36,6 @@ build_test(
     targets = [
         ":node_modules/@lib/b",
         ":node_modules/@lib/b_alias",
-        "//root:.aspect_rules_js/node_modules/@lib+b_alias@0.0.0",
+        "//root:.aspect_rules_js/node_modules/@lib+b@0.0.0",
     ],
 )

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -104,18 +104,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         _npm_local_package_store(
-            package_store_name = "@lib+b_alias@0.0.0",
-            src = "//lib/b:pkg",
-            package = "@lib/b_alias",
-            version = "0.0.0",
-            deps = {
-                "//root:.aspect_rules_js/node_modules/@aspect-test+f@1.0.0": "@aspect-test/f",
-                "//root:.aspect_rules_js/node_modules/@types+sizzle@2.3.8": "alias-1",
-            },
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        _npm_local_package_store(
             package_store_name = "@lib+c@0.0.0",
             src = "//lib/c:pkg",
             package = "@lib/c",
@@ -182,7 +170,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "app/c":
             link_0("node_modules/@aspect-test/a", False, "@aspect-test/a")
             link_6("node_modules/@aspect-test/g", False, "@aspect-test/g")
-            _fp_link_5()
+            _fp_link_4()
             link_targets = [
                 ":node_modules/@aspect-test/a",
                 ":node_modules/@aspect-test/g",
@@ -238,7 +226,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             }
         elif bazel_package == "app/d":
             link_6("node_modules/@aspect-test/g", False, "@aspect-test/g")
-            _fp_link_6()
+            _fp_link_5()
             link_targets = [
                 ":node_modules/@aspect-test/g",
                 ":node_modules/@lib/d",
@@ -250,7 +238,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "app/b":
             link_7("node_modules/@aspect-test/h", False, "@aspect-test/h")
             _fp_link_3()
-            _fp_link_4()
+            _fp_link_3("@lib/b_alias")
             link_targets = [
                 ":node_modules/@aspect-test/h",
                 ":node_modules/@lib/b",
@@ -369,56 +357,54 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
 # buildifier: disable=function-docstring
-def _fp_link_0():
+def _fp_link_0(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/vendored-a",
+        name = "node_modules/vendored-a" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//root:.aspect_rules_js/node_modules/vendored-a@file+..+vendored+a",
     )
 
 # Generated npm_link_package_store for linking of first-party "vendored-b" package
 # buildifier: disable=function-docstring
-def _fp_link_1():
+def _fp_link_1(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/vendored-b",
+        name = "node_modules/vendored-b" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//root:.aspect_rules_js/node_modules/vendored-b@file+..+vendored+b_at_lib_b_lib+b",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/a" package
 # buildifier: disable=function-docstring
-def _fp_link_2():
+def _fp_link_2(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/a",
+        name = "node_modules/@lib/a" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//root:.aspect_rules_js/node_modules/@lib+a@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/b" package
 # buildifier: disable=function-docstring
-def _fp_link_3():
+def _fp_link_3(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/b",
+        name = "node_modules/@lib/b" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//root:.aspect_rules_js/node_modules/@lib+b@0.0.0",
-    )
-
-# Generated npm_link_package_store for linking of first-party "@lib/b_alias" package
-# buildifier: disable=function-docstring
-def _fp_link_4():
-    _npm_local_link_package_store(
-        name = "node_modules/@lib/b_alias",
-        src = "//root:.aspect_rules_js/node_modules/@lib+b_alias@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/c" package
 # buildifier: disable=function-docstring
-def _fp_link_5():
+def _fp_link_4(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/c",
+        name = "node_modules/@lib/c" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//root:.aspect_rules_js/node_modules/@lib+c@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/d" package
 # buildifier: disable=function-docstring
-def _fp_link_6():
+def _fp_link_5(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/d",
+        name = "node_modules/@lib/d" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//root:.aspect_rules_js/node_modules/@lib+d@0.0.0",
     )

--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -150,10 +150,11 @@ npm_link_package_store = rule(
 
 # A private util method to minimize the generated code for local package store links.
 # May be changed/deleted at any time to minimize code from the generated npm_link_all_packages().
-def npm_local_link_package_store_internal(name, src, link_visibility = ["//visibility:public"]):
+def npm_local_link_package_store_internal(name, src, package = None, link_visibility = ["//visibility:public"]):
     npm_link_package_store(
         name = name,
         src = src,
+        package = package,
         visibility = link_visibility,
         tags = ["manual"],
     )

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -1160,7 +1160,7 @@ _NPM_PACKAGE_LOCATIONS = {
     "": ["@babel/cli", "@babel/core", "@babel/plugin-transform-modules-commonjs", "@types/node", "chalk", "inline-fixtures", "jsonpath-plus", "typescript"],
     "examples/js_binary": ["@mycorp/pkg-a"],
     "examples/js_lib_pkg/a": ["@types/node"],
-    "examples/js_lib_pkg/b": ["js_lib_pkg_a", "js_lib_pkg_a-alias_1", "js_lib_pkg_a-alias_2", "@types/node"],
+    "examples/js_lib_pkg/b": ["js_lib_pkg_a", "@types/node"],
     "examples/linked_consumer": ["@lib/test", "@lib/test2"],
     "examples/linked_lib": ["@aspect-test/e", "alias-e", "@aspect-test/f", "@types/node"],
     "examples/linked_pkg": ["@aspect-test/e", "alias-e", "@aspect-test/f", "@types/node"],
@@ -2383,24 +2383,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             tags = ["manual"],
         )
         _npm_local_package_store(
-            package_store_name = "js_lib_pkg_a-alias_1@0.0.0",
-            src = "//examples/js_lib_pkg/a:pkg",
-            package = "js_lib_pkg_a-alias_1",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        _npm_local_package_store(
-            package_store_name = "js_lib_pkg_a-alias_2@0.0.0",
-            src = "//examples/js_lib_pkg/a:pkg",
-            package = "js_lib_pkg_a-alias_2",
-            version = "0.0.0",
-            deps = {},
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-        )
-        _npm_local_package_store(
             package_store_name = "@lib+test@0.0.0",
             src = "//examples/linked_pkg:pkg",
             package = "@lib/test",
@@ -2502,7 +2484,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "js/private/test/image":
             link_6("node_modules/acorn", False, "acorn")
             _fp_link_2()
-            _fp_link_8()
+            _fp_link_6()
             link_targets = [
                 ":node_modules/acorn",
                 ":node_modules/@mycorp/pkg-a",
@@ -2529,8 +2511,8 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_952("node_modules/rollup", True, "rollup")
             link_1089("node_modules/uvu", True, "uvu")
             _fp_link_2()
-            _fp_link_8()
-            _fp_link_9()
+            _fp_link_6()
+            _fp_link_7()
             link_targets = [
                 ":node_modules/acorn",
                 ":node_modules/@aspect-test/a",
@@ -2678,7 +2660,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             link_1070("node_modules/typescript", True, "typescript")
             link_1082("node_modules/unused", True, "unused")
             link_1099("node_modules/webpack-bundle-analyzer", True, "webpack-bundle-analyzer")
-            _fp_link_10()
+            _fp_link_8()
             link_targets = [
                 ":node_modules/@fastify/send",
                 ":node_modules/@figma/nodegit",
@@ -2770,8 +2752,8 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         elif bazel_package == "examples/js_lib_pkg/b":
             link_277("node_modules/@types/node", True, "@types/node")
             _fp_link_3()
-            _fp_link_4()
-            _fp_link_5()
+            _fp_link_3("js_lib_pkg_a-alias_1")
+            _fp_link_3("js_lib_pkg_a-alias_2")
             link_targets = [
                 ":node_modules/js_lib_pkg_a",
                 ":node_modules/js_lib_pkg_a-alias_1",
@@ -2843,8 +2825,8 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 "@mycorp": [":node_modules/@mycorp/pkg-a"],
             }
         elif bazel_package == "examples/linked_consumer":
-            _fp_link_6()
-            _fp_link_7()
+            _fp_link_4()
+            _fp_link_5()
             link_targets = [
                 ":node_modules/@lib/test",
                 ":node_modules/@lib/test2",
@@ -2856,7 +2838,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 ],
             }
         elif bazel_package == "examples/npm_package/packages/pkg_e":
-            _fp_link_8()
+            _fp_link_6()
             link_targets = [":node_modules/@mycorp/pkg-d"]
             scope_targets = {
                 "@mycorp": [":node_modules/@mycorp/pkg-d"],
@@ -3126,75 +3108,66 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-a" package
 # buildifier: disable=function-docstring
-def _fp_link_2():
+def _fp_link_2(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@mycorp/pkg-a",
+        name = "node_modules/@mycorp/pkg-a" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@mycorp+pkg-a@0.0.0",
         link_visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
     )
 
 # Generated npm_link_package_store for linking of first-party "js_lib_pkg_a" package
 # buildifier: disable=function-docstring
-def _fp_link_3():
+def _fp_link_3(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/js_lib_pkg_a",
+        name = "node_modules/js_lib_pkg_a" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/js_lib_pkg_a@0.0.0",
-    )
-
-# Generated npm_link_package_store for linking of first-party "js_lib_pkg_a-alias_1" package
-# buildifier: disable=function-docstring
-def _fp_link_4():
-    _npm_local_link_package_store(
-        name = "node_modules/js_lib_pkg_a-alias_1",
-        src = "//:.aspect_rules_js/node_modules/js_lib_pkg_a-alias_1@0.0.0",
-    )
-
-# Generated npm_link_package_store for linking of first-party "js_lib_pkg_a-alias_2" package
-# buildifier: disable=function-docstring
-def _fp_link_5():
-    _npm_local_link_package_store(
-        name = "node_modules/js_lib_pkg_a-alias_2",
-        src = "//:.aspect_rules_js/node_modules/js_lib_pkg_a-alias_2@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/test" package
 # buildifier: disable=function-docstring
-def _fp_link_6():
+def _fp_link_4(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/test",
+        name = "node_modules/@lib/test" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@lib+test@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@lib/test2" package
 # buildifier: disable=function-docstring
-def _fp_link_7():
+def _fp_link_5(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@lib/test2",
+        name = "node_modules/@lib/test2" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@lib+test2@0.0.0",
     )
 
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-d" package
 # buildifier: disable=function-docstring
-def _fp_link_8():
+def _fp_link_6(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@mycorp/pkg-d",
+        name = "node_modules/@mycorp/pkg-d" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@mycorp+pkg-d@0.0.0",
         link_visibility = ["//examples:__subpackages__", "//js/private/test/image:__subpackages__"],
     )
 
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-e" package
 # buildifier: disable=function-docstring
-def _fp_link_9():
+def _fp_link_7(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/@mycorp/pkg-e",
+        name = "node_modules/@mycorp/pkg-e" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/@mycorp+pkg-e@0.0.0",
         link_visibility = ["//examples:__subpackages__"],
     )
 
 # Generated npm_link_package_store for linking of first-party "test-npm_package" package
 # buildifier: disable=function-docstring
-def _fp_link_10():
+def _fp_link_8(alias = None):
     _npm_local_link_package_store(
-        name = "node_modules/test-npm_package",
+        name = "node_modules/test-npm_package" if alias == None else "node_modules/{}".format(alias),
+        package = alias,
         src = "//:.aspect_rules_js/node_modules/test-npm_package@0.0.0",
     )


### PR DESCRIPTION
Multiple aliases referring to the same local workspace project should share a single entry in the package store.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; see diff of snapshot files
