### PR TITLE
refactor: extricate lockfile verification from npm_translate_lock repo rule

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -110,9 +110,14 @@ npm_translate_lock_lib = struct(
     attrs = _ATTRS,
 )
 
-################################################################################
-def _npm_translate_lock_impl(rctx):
-    rctx.report_progress("Initializing")
+def parse_and_verify_lock(rctx):
+    """Helper to parse and validate the lockfile
+
+    Args:
+        rctx: repository context
+    Returns:
+        state, importers, and packages
+    """
 
     state = npm_translate_lock_state.new(rctx.name, rctx, rctx.attr)
 
@@ -152,6 +157,14 @@ See https://github.com/aspect-build/rules_js/issues/1445
         rctx.attr.dev,
         rctx.attr.no_optional,
     )
+
+    return state, importers, packages
+
+################################################################################
+def _npm_translate_lock_impl(rctx):
+    rctx.report_progress("Initializing")
+
+    state, importers, packages = parse_and_verify_lock(rctx)
 
     rctx.report_progress("Generating starlark for npm dependencies")
 


### PR DESCRIPTION
After this we should be able to do the work in module extension pretty easily. I'm not sure about the bootstrap step, may need a hack. let's see how it goes!

---

### Changes are visible to end-users: no

### Test plan
- Covered by existing test cases
