### PR TITLE
refactor: use attr instead of rctx.attr in lockfile parsing to prep for extension

### DIFF
--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -532,9 +532,9 @@ def _to_apparent_repo_name(canonical_name):
     return canonical_name[max(canonical_name.rfind("~"), canonical_name.rfind("+")) + 1:]
 
 ################################################################################
-def _verify_node_modules_ignored(rctx, importers, root_package):
-    if rctx.attr.verify_node_modules_ignored != None:
-        missing_ignores = _find_missing_bazel_ignores(root_package, importers.keys(), rctx.read(rctx.path(rctx.attr.verify_node_modules_ignored)))
+def _verify_node_modules_ignored(rctx, attr, importers, root_package):
+    if attr.verify_node_modules_ignored != None:
+        missing_ignores = _find_missing_bazel_ignores(root_package, importers.keys(), rctx.read(rctx.path(attr.verify_node_modules_ignored)))
         if missing_ignores:
             msg = """
 
@@ -551,7 +551,7 @@ Possible fixes:
 {fixes}
                 """.format(
                 fixes = "\n".join(missing_ignores),
-                bazelignore = rctx.attr.verify_node_modules_ignored,
+                bazelignore = attr.verify_node_modules_ignored,
                 repo = rctx.name,
             )
             fail(msg)
@@ -609,8 +609,8 @@ removed the requiresBuild attribute from the lockfile in v9.
 """)
 
 ################################################################################
-def _verify_patches(rctx, state):
-    if rctx.attr.verify_patches and rctx.attr.patches != None:
+def _verify_patches(rctx, attr, state):
+    if attr.verify_patches and attr.patches != None:
         rctx.report_progress("Verifying patches in {}".format(state.label_store.relative_path("verify_patches")))
 
         # Patches in the patch list verification file


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases