### PR TITLE
refactor: directly use yq.bzl module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,7 @@ module(
 # Do not bump these unless rules_js requires a newer version to function.
 bazel_dep(name = "aspect_bazel_lib", version = "2.17.1")  # TODO(alexeagle): remove
 bazel_dep(name = "tar.bzl", version = "0.6.0")
+bazel_dep(name = "yq.bzl", version = "0.3.1")
 bazel_dep(name = "aspect_tools_telemetry", version = "0.2.8")
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_lib", version = "3.0.0")
@@ -39,6 +40,11 @@ bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "t
 use_repo(
     bazel_lib_toolchains,
     "coreutils_toolchains",
+)
+
+yq_toolchain = use_extension("@yq.bzl//yq:extensions.bzl", "yq")
+use_repo(
+    yq_toolchain,
     "yq_darwin_amd64",
     "yq_darwin_arm64",
     "yq_linux_amd64",

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -68,7 +68,6 @@ _ATTRS = {
     "verify_node_modules_ignored": attr.label(),
     "verify_patches": attr.label(),
     "yarn_lock": attr.label(),
-    "yq_toolchain_prefix": attr.string(default = "yq"),
 }
 
 _DOCS = """Repository macro to generate starlark code from a lock file.
@@ -113,8 +112,6 @@ Args:
         Read more: [using update_pnpm_lock](/docs/pnpm.md#update_pnpm_lock)
 
     node_toolchain_prefix: the prefix of the node toolchain to use when generating the pnpm lockfile.
-
-    yq_toolchain_prefix: the prefix of the yq toolchain to use for parsing the pnpm lockfile.
 
     preupdate: Node.js scripts to run in this repository rule before auto-updating the pnpm lock file.
 

--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -450,7 +450,7 @@ def _load_lockfile(priv, rctx, attr, pnpm_lock_path, is_windows):
     patched_dependencies = {}
     lock_parse_err = None
 
-    host_yq = Label("@{}_{}//:yq{}".format(attr.yq_toolchain_prefix, repo_utils.platform(rctx), ".exe" if is_windows else ""))
+    host_yq = Label("@yq_{}//:yq{}".format(repo_utils.platform(rctx), ".exe" if is_windows else ""))
     yq_args = [
         str(rctx.path(host_yq)),
         str(pnpm_lock_path),


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Remove `npm_translate_lock(yq_toolchain_prefix)`. Use bazel modules instead.

### Test plan

- Covered by existing test cases
