### PR TITLE
refactor: remove internal struct merging of importer deps

### DIFF
--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -258,10 +258,7 @@ def _get_npm_imports(importers, packages, replace_packages, patched_dependencies
     # make a lookup table of package to link name for each importer
     importer_links = {}
     for import_path, importer in importers.items():
-        dependencies = importer["all_deps"]
-        if type(dependencies) != "dict":
-            msg = "expected dict of dependencies in processed importer '{}'".format(import_path)
-            fail(msg)
+        dependencies = importer["dependencies"] | importer["optional_dependencies"] | importer["dev_dependencies"]
         links = {
             "link_package": _link_package(root_package, import_path),
         }

--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -8,7 +8,7 @@ load(":npm_translate_lock_helpers.bzl", "helpers")
 load(":npmrc.bzl", "parse_npmrc")
 load(":pnpm.bzl", "pnpm")
 load(":repository_label_store.bzl", "repository_label_store")
-load(":transitive_closure.bzl", "translate_to_transitive_closure")
+load(":transitive_closure.bzl", "calculate_transitive_closures")
 load(":utils.bzl", "INTERNAL_ERROR_MSG", "utils")
 
 NPM_RC_FILENAME = ".npmrc"
@@ -466,7 +466,7 @@ def _load_lockfile(priv, rctx, attr, pnpm_lock_path, is_windows):
             attr.no_optional,
         )
 
-    translate_to_transitive_closure(importers, packages)
+    calculate_transitive_closures(packages)
 
     priv["importers"] = importers
     priv["packages"] = packages

--- a/npm/private/transitive_closure.bzl
+++ b/npm/private/transitive_closure.bzl
@@ -69,36 +69,12 @@ def gather_transitive_closure(packages, package, cache = {}):
 def _get_package_info_deps(package_info):
     return package_info["dependencies"] | package_info["optional_dependencies"]
 
-def translate_to_transitive_closure(importers, packages):
-    """Implementation detail of translate_package_lock, converts pnpm-lock to a different dictionary with more data.
+def calculate_transitive_closures(packages):
+    """Calculate the transitive closure of dependencies for each package.
 
     Args:
-        importers: workspace projects (pnpm "importers")
         packages: all package info by name
-
-    Returns:
-        Nested dictionary suitable for further processing in our repository rule
     """
-
-    # Collect deps of each importer (workspace projects)
-    importers_deps = {}
-    for lock_importer in importers.values():
-        prod_deps = lock_importer["dependencies"]
-        dev_deps = lock_importer["dev_dependencies"]
-        opt_deps = lock_importer["optional_dependencies"]
-
-        deps = prod_deps | opt_deps
-        all_deps = prod_deps | dev_deps | opt_deps
-
-        # TODO(3.0): remove this property
-        # deps this importer should pass on if it is linked as a first-party package; this does
-        # not include devDependencies
-        lock_importer["deps"] = deps
-
-        # TODO(3.0): remove this property
-        # all deps of this importer to link in the node_modules folder of that Bazel package and
-        # make available to all build targets; this includes devDependencies
-        lock_importer["all_deps"] = all_deps
 
     # Collect transitive dependencies for each package
     cache = {}
@@ -111,5 +87,3 @@ def translate_to_transitive_closure(importers, packages):
 
         packages[package]["transitive_closure"] = transitive_closure
         cache[package] = transitive_closure
-
-    return (importers_deps, packages)


### PR DESCRIPTION
This makes the `transitive_closure.bzl` logic purely about calculating the transitive closure and no longer has any additional odd side-effects.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
