### PR TITLE
chore: run github workflows tests on ubuntu-22.04-4core runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
             os: ${{ steps.os.outputs.res }}
 
     test:
-        runs-on: ${{ matrix.os }}-latest
+        runs-on: ${{ matrix.os == 'macos' && 'macos-latest' || matrix.os == 'windows' && 'windows-latest' || 'ubuntu-22.04-4core' }}
         needs:
             - matrix-prep
         defaults:


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
