### PR TITLE
refactor: do not expose RUNFILES var, use JS_BINARY__RUNFILES

### DIFF
--- a/examples/stack_traces/stacks.cjs
+++ b/examples/stack_traces/stacks.cjs
@@ -1,8 +1,8 @@
 // Register source-map-support for source maps to be applied on stack traces.
 require('source-map-support/register')
 
-let basePath = process.env.RUNFILES
-    ? `${process.env.RUNFILES}/${process.env.JS_BINARY__WORKSPACE}`
+let basePath = process.env.JS_BINARY__RUNFILES
+    ? `${process.env.JS_BINARY__RUNFILES}/${process.env.JS_BINARY__WORKSPACE}`
     : process.cwd()
 
 if (!basePath.endsWith('/')) {

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -22,7 +22,10 @@ const include = fs
 
 // TODO: can or should we instrument files from other repositories as well?
 // if so then the path.join call below will yield invalid paths since files will have external/wksp as their prefix.
-const pwd = path.join(process.env.RUNFILES, process.env.TEST_WORKSPACE)
+const pwd = path.join(
+    process.env.JS_COVERAGE__RUNFILES,
+    process.env.TEST_WORKSPACE
+)
 process.chdir(pwd)
 
 new Report({

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16087,7 +16087,10 @@ const include = require$$0$1
 
 // TODO: can or should we instrument files from other repositories as well?
 // if so then the path.join call below will yield invalid paths since files will have external/wksp as their prefix.
-const pwd = require$$0$2.join(process.env.RUNFILES, process.env.TEST_WORKSPACE);
+const pwd = require$$0$2.join(
+    process.env.JS_COVERAGE__RUNFILES,
+    process.env.TEST_WORKSPACE
+);
 process.chdir(pwd);
 
 new c8Exports.Report({

--- a/js/private/coverage/coverage.sh.tpl
+++ b/js/private/coverage/coverage.sh.tpl
@@ -27,7 +27,8 @@ if [ $SPLIT_COVERAGE_POST_PROCESSING == 1 ]; then
     RUNFILES=$(_normalize_path "$LCOV_MERGER.runfiles")
 fi
 
-export RUNFILES
+JS_COVERAGE__RUNFILES="$RUNFILES"
+export JS_COVERAGE__RUNFILES
 
 # ==============================================================================
 # Prepare to run coverage program

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -147,7 +147,6 @@ trap _exit EXIT
 # Initialize RUNFILES environment variable
 # ==============================================================================
 {{initialize_runfiles}}
-export RUNFILES
 JS_BINARY__RUNFILES="$RUNFILES"
 export JS_BINARY__RUNFILES
 

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_app.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_app.listing
@@ -4,7 +4,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/
--r-xr-xr-x  0 0      0       24076 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2
+-r-xr-xr-x  0 0      0       24060 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
@@ -14,7 +14,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/
 -r-xr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/ㅑㅕㅣㅇ.ㄴㅅ
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_/
--r-xr-xr-x  0 0      0       24076 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_/bin2
+-r-xr-xr-x  0 0      0       24060 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_/bin2
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_node_bin/
 -r-xr-xr-x  0 0      0         133 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_node_bin/node
 -r-xr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/empty empty.ㄴㅅ

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -264,7 +264,6 @@ if [ "${RUNFILES:0:1}" != "/" ]; then
     RUNFILES="$PWD/$RUNFILES"
 fi
 
-export RUNFILES
 JS_BINARY__RUNFILES="$RUNFILES"
 export JS_BINARY__RUNFILES
 


### PR DESCRIPTION
Everything else is either `JS_BINARY__*` or something such as `TEST_WORKSPACE` from bazel.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Remove `RUNFILES` environment alias of `JS_BINARY__RUNFILES` variable.

### Test plan

- Covered by existing test cases
