### PR TITLE
refactor: remove npm_import(transitive_closure) from public extension

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -259,7 +259,7 @@ def _npm_import_bzlmod(i):
         exclude_package_contents = i.exclude_package_contents,
         replace_package = i.replace_package,
         root_package = i.root_package,
-        transitive_closure = i.transitive_closure,
+        transitive_closure = None,
         url = i.url,
         version = i.version,
     )

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -891,7 +891,6 @@ _ATTRS_LINKS = _COMMON_ATTRS | {
     "lifecycle_hooks_env": attr.string_list(),
     "lifecycle_hooks_execution_requirements": attr.string_list(default = ["no-sandbox"]),
     "lifecycle_hooks_use_default_shell_env": attr.bool(),
-    "transitive_closure": attr.string_list_dict(doc = "Mapping of package store entry labels to a list of names to reference that package as"),
     "package_visibility": attr.string_list(default = ["//visibility:public"]),
     "replace_package": attr.string(),
     "exclude_package_contents": attr.string_list(default = []),
@@ -1034,9 +1033,6 @@ Args:
     version: Version of the npm package, such as `8.4.0`
 
     deps: A dict other npm packages this one depends on where the key is the package name and value is the version
-
-    transitive_closure: A dict all npm packages this one depends on directly or transitively where the key is the
-        package name and value is a list of version(s) depended on in the closure.
 
     root_package: The root package where the node_modules package store is linked to.
         Typically this is the package that the pnpm-lock.yaml file is located when using `npm_translate_lock`.
@@ -1208,6 +1204,7 @@ npm_import_links_rule = repository_rule(
     implementation = _npm_import_links_rule_impl,
     attrs = _ATTRS_LINKS | _INTERNAL_COMMON_ATTRS | {
         "deps_constraints": attr.string_list_dict(),
+        "transitive_closure": attr.string_list_dict(doc = "Mapping of package store entry labels to a list of names to reference that package as"),
     },
 )
 


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

The internal `npm_import(transitive_closure)` attribute is no longer publicly accessible. Packages defined within bazel should not depend on internal rules_js logic for handling circular dependencies.

### Test plan

- Covered by existing test cases
