### PR TITLE
Add dynamic .npmrc authentication

### DIFF
--- a/e2e/npm_translate_lock_dynamic_auth/.bazelignore
+++ b/e2e/npm_translate_lock_dynamic_auth/.bazelignore
@@ -1,0 +1,1 @@
+node_modules

--- a/e2e/npm_translate_lock_dynamic_auth/.bazelrc
+++ b/e2e/npm_translate_lock_dynamic_auth/.bazelrc
@@ -1,0 +1,1 @@
+try-import %workspace%/../../.aspect/workflows/bazelrc

--- a/e2e/npm_translate_lock_dynamic_auth/.bazelversion
+++ b/e2e/npm_translate_lock_dynamic_auth/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/npm_translate_lock_dynamic_auth/.npmrc
+++ b/e2e/npm_translate_lock_dynamic_auth/.npmrc
@@ -1,0 +1,4 @@
+hoist=false
+
+# This will be replaced by test script with dynamic token
+_authToken=${ASPECT_NPM_AUTH_TOKEN}

--- a/e2e/npm_translate_lock_dynamic_auth/BUILD.bazel
+++ b/e2e/npm_translate_lock_dynamic_auth/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages(name = "node_modules")
+
+build_test(
+    name = "test",
+    targets = [
+        ":node_modules",
+    ],
+)

--- a/e2e/npm_translate_lock_dynamic_auth/MODULE.bazel
+++ b/e2e/npm_translate_lock_dynamic_auth/MODULE.bazel
@@ -1,0 +1,27 @@
+bazel_dep(name = "aspect_rules_js", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "aspect_rules_js",
+    path = "../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
+
+pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
+pnpm.pnpm(
+    name = "pnpm",
+)
+use_repo(pnpm, "pnpm", "pnpm__links")
+
+npm = use_extension(
+    "@aspect_rules_js//npm:extensions.bzl",
+    "npm",
+    dev_dependency = True,
+)
+npm.npm_translate_lock(
+    name = "npm",
+    data = ["//:package.json"],
+    pnpm_lock = "//:pnpm-lock.yaml",
+    use_home_npmrc = True,
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm")

--- a/e2e/npm_translate_lock_dynamic_auth/README.md
+++ b/e2e/npm_translate_lock_dynamic_auth/README.md
@@ -1,0 +1,7 @@
+# Dynamic .npmrc authentication integration test
+
+Tests that authentication tokens are read dynamically from `.npmrc` on each download,
+not cached statically. Critical for short-lived credentials like AWS CodeArtifact tokens.
+
+Auth token with permission to pull packages from `@aspect-test` scope must be set in
+`ASPECT_NPM_AUTH_TOKEN` environment variable for this e2e test to pass.

--- a/e2e/npm_translate_lock_dynamic_auth/WORKSPACE
+++ b/e2e/npm_translate_lock_dynamic_auth/WORKSPACE
@@ -1,0 +1,1 @@
+# Marker file for Bazel

--- a/e2e/npm_translate_lock_dynamic_auth/WORKSPACE.bzlmod
+++ b/e2e/npm_translate_lock_dynamic_auth/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# This file marks the root of the Bazel workspace.
+# See MODULE.bazel for external dependencies setup with bzlmod.

--- a/e2e/npm_translate_lock_dynamic_auth/package.json
+++ b/e2e/npm_translate_lock_dynamic_auth/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "npm-translate-lock-dynamic-auth-test",
+  "version": "0.0.0",
+  "dependencies": {
+    "@aspect-test/a": "5.0.0"
+  }
+}

--- a/e2e/npm_translate_lock_dynamic_auth/pnpm-lock.yaml
+++ b/e2e/npm_translate_lock_dynamic_auth/pnpm-lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@aspect-test/a':
+        specifier: 5.0.0
+        version: 5.0.0
+
+packages:
+
+  '@aspect-test/a@5.0.0':
+    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=, tarball: https://registry.npmjs.org/@aspect-test/a/-/a-5.0.0.tgz}
+    engines: {node: '>=16.0.0'}
+
+snapshots:
+
+  '@aspect-test/a@5.0.0': {}

--- a/e2e/npm_translate_lock_dynamic_auth/pnpm-workspace.yaml
+++ b/e2e/npm_translate_lock_dynamic_auth/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/e2e/npm_translate_lock_dynamic_auth/test.sh
+++ b/e2e/npm_translate_lock_dynamic_auth/test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+BZLMOD_FLAG="${BZLMOD_FLAG:---enable_bzlmod=1}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}================================================================${NC}"
+echo -e "${BLUE}Testing Dynamic .npmrc Authentication${NC}"
+echo -e "${BLUE}================================================================${NC}"
+echo ""
+
+if [ -z "${ASPECT_NPM_AUTH_TOKEN:-}" ]; then
+    echo -e "${YELLOW}Skipping test: ASPECT_NPM_AUTH_TOKEN not set${NC}"
+    exit 0
+fi
+
+if [ -f ~/.npmrc ]; then
+    cp ~/.npmrc ~/.npmrc.backup
+    HAS_BACKUP=true
+else
+    HAS_BACKUP=false
+fi
+
+cleanup() {
+    echo ""
+    echo -e "${YELLOW}Cleaning up...${NC}"
+    if [ "$HAS_BACKUP" = true ]; then
+        mv ~/.npmrc.backup ~/.npmrc
+        echo -e "${GREEN}Restored ~/.npmrc${NC}"
+    elif [ -f ~/.npmrc.test ]; then
+        rm ~/.npmrc
+        echo -e "${GREEN}Removed test ~/.npmrc${NC}"
+    fi
+}
+
+trap cleanup EXIT
+
+echo -e "${BLUE}Test 1: Fetch with valid token${NC}"
+cat > ~/.npmrc << EOF
+_authToken=${ASPECT_NPM_AUTH_TOKEN}
+EOF
+touch ~/.npmrc.test
+
+bazel clean --expunge "$BZLMOD_FLAG"
+if bazel fetch "$BZLMOD_FLAG" //... 2>&1 | tee /tmp/fetch.log; then
+    echo -e "${GREEN}✓ Fetch with valid token succeeded${NC}"
+else
+    echo -e "${RED}✗ Fetch with valid token failed${NC}"
+    cat /tmp/fetch.log
+    exit 1
+fi
+echo ""
+
+echo -e "${BLUE}Test 2: Fetch with broken token (empty repository cache)${NC}"
+cat > ~/.npmrc << EOF
+_authToken=BROKEN_TOKEN_SHOULD_CAUSE_401
+EOF
+
+if bazel fetch "$BZLMOD_FLAG" --repository_cache= //... 2>&1 | tee /tmp/fetch_broken.log; then
+    if grep -qi "401\|unauthorized" /tmp/fetch_broken.log; then
+        echo -e "${GREEN}✓✓✓ Got 401 with broken token - dynamic auth confirmed!${NC}"
+    else
+        echo -e "${RED}✗ Fetch succeeded with broken token (auth is cached, not dynamic!)${NC}"
+        exit 1
+    fi
+else
+    if grep -qi "401\|unauthorized" /tmp/fetch_broken.log; then
+        echo -e "${GREEN}✓✓✓ Got 401 with broken token - dynamic auth confirmed!${NC}"
+    else
+        echo -e "${RED}✗ Fetch failed but not with 401${NC}"
+        tail -20 /tmp/fetch_broken.log
+        exit 1
+    fi
+fi
+echo ""
+
+echo -e "${BLUE}Test 3: Fetch with restored valid token${NC}"
+cat > ~/.npmrc << EOF
+_authToken=${ASPECT_NPM_AUTH_TOKEN}
+EOF
+
+if bazel fetch "$BZLMOD_FLAG" --repository_cache= //... 2>&1; then
+    echo -e "${GREEN}✓ Fetch with restored token succeeded${NC}"
+else
+    echo -e "${RED}✗ Fetch with restored token failed${NC}"
+    exit 1
+fi
+echo ""
+
+echo -e "${GREEN}================================================================${NC}"
+echo -e "${GREEN}✅ All dynamic auth tests passed!${NC}"
+echo -e "${GREEN}================================================================${NC}"

--- a/e2e/npm_translate_lock_dynamic_auth/test.sh
+++ b/e2e/npm_translate_lock_dynamic_auth/test.sh
@@ -41,7 +41,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo -e "${BLUE}Test 1: Fetch with valid token${NC}"
-cat > ~/.npmrc << EOF
+cat >~/.npmrc <<EOF
 _authToken=${ASPECT_NPM_AUTH_TOKEN}
 EOF
 touch ~/.npmrc.test
@@ -57,7 +57,7 @@ fi
 echo ""
 
 echo -e "${BLUE}Test 2: Fetch with broken token (empty repository cache)${NC}"
-cat > ~/.npmrc << EOF
+cat >~/.npmrc <<EOF
 _authToken=BROKEN_TOKEN_SHOULD_CAUSE_401
 EOF
 
@@ -80,7 +80,7 @@ fi
 echo ""
 
 echo -e "${BLUE}Test 3: Fetch with restored valid token${NC}"
-cat > ~/.npmrc << EOF
+cat >~/.npmrc <<EOF
 _authToken=${ASPECT_NPM_AUTH_TOKEN}
 EOF
 

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -1083,6 +1083,8 @@ def npm_import(
         npm_auth_basic = "",
         npm_auth_username = "",
         npm_auth_password = "",
+        npmrc = None,
+        use_home_npmrc = None,
         bins = {},
         dev = False,
         exclude_package_contents = [],
@@ -1321,6 +1323,10 @@ def npm_import(
 
         npm_auth_password: Auth password to authenticate with npm. When using Basic authentication.
 
+        npmrc: Label to an .npmrc file for authentication. Supports environment variable expansion.
+
+        use_home_npmrc: Use ~/.npmrc for authentication.
+
         extra_build_content: Additional content to append on the generated BUILD file at the root of
             the created repository, either as a string or a list of lines similar to
             <https://github.com/bazelbuild/bazel-skylib/blob/main/docs/write_file_doc.md>.
@@ -1389,6 +1395,8 @@ def npm_import(
         npm_auth_basic = npm_auth_basic,
         npm_auth_username = npm_auth_username,
         npm_auth_password = npm_auth_password,
+        npmrc = npmrc,
+        use_home_npmrc = use_home_npmrc,
         lifecycle_hooks = lifecycle_hooks,
         extra_build_content = (
             extra_build_content if type(extra_build_content) == "string" else "\n".join(extra_build_content)

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -4,6 +4,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(":generated_pkg_json_test.bzl", "generated_pkg_json_test")
 load(":npm_auth_test.bzl", "npm_auth_test_suite")
+load(":npm_import_auth_test.bzl", "npm_import_auth_test_suite")
 load(":npm_package_visibility_test.bzl", "npm_package_visibility_tests")
 load(":npmrc_test.bzl", "npmrc_tests")
 load(":parse_pnpm_lock_tests.bzl", "parse_pnpm_lock_tests")
@@ -32,6 +33,8 @@ generated_pkg_json_test(name = "test_generated_pkg_json")
 npm_package_visibility_tests(name = "test_npm_package_visibility")
 
 npm_auth_test_suite()
+
+npm_import_auth_test_suite()
 
 write_source_files(
     name = "write_npm_translate_lock",

--- a/npm/private/test/npm_import_auth_test.bzl
+++ b/npm/private/test/npm_import_auth_test.bzl
@@ -1,0 +1,183 @@
+"""Unit tests for npm_import dynamic auth"""
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _get_auth_from_url(url, npm_auth_dict):
+    for registry, auth_info in npm_auth_dict.items():
+        if registry in url:
+            if "bearer" in auth_info:
+                return {
+                    url: {
+                        "type": "pattern",
+                        "pattern": "Bearer <password>",
+                        "password": auth_info["bearer"],
+                    },
+                }
+            elif "basic" in auth_info:
+                return {
+                    url: {
+                        "type": "pattern",
+                        "pattern": "Basic <password>",
+                        "password": auth_info["basic"],
+                    },
+                }
+            elif "username" in auth_info and "password" in auth_info:
+                return {
+                    url: {
+                        "type": "basic",
+                        "login": auth_info["username"],
+                        "password": auth_info["password"],
+                    },
+                }
+    return {}
+
+def _no_auth_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        {},
+        _get_auth_from_url(
+            "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+            {},
+        ),
+    )
+
+    return unittest.end(env)
+
+def _bearer_token_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    url = "https://example.codeartifact.us-east-1.amazonaws.com/npm/repo/foo/-/foo-1.0.0.tgz"
+    npm_auth = {
+        "example.codeartifact.us-east-1.amazonaws.com": {
+            "bearer": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        },
+    }
+
+    asserts.equals(
+        env,
+        {
+            url: {
+                "type": "pattern",
+                "pattern": "Bearer <password>",
+                "password": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            },
+        },
+        _get_auth_from_url(url, npm_auth),
+    )
+
+    return unittest.end(env)
+
+def _basic_auth_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    url = "https://npm.pkg.github.com/@scope/package/-/package-1.0.0.tgz"
+    npm_auth = {
+        "npm.pkg.github.com": {
+            "basic": "dXNlcm5hbWU6cGFzc3dvcmQ=",
+        },
+    }
+
+    asserts.equals(
+        env,
+        {
+            url: {
+                "type": "pattern",
+                "pattern": "Basic <password>",
+                "password": "dXNlcm5hbWU6cGFzc3dvcmQ=",
+            },
+        },
+        _get_auth_from_url(url, npm_auth),
+    )
+
+    return unittest.end(env)
+
+def _username_password_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    url = "https://registry.example.com/foo/-/foo-1.0.0.tgz"
+    npm_auth = {
+        "registry.example.com": {
+            "username": "testuser",
+            "password": "testpass",
+        },
+    }
+
+    asserts.equals(
+        env,
+        {
+            url: {
+                "type": "basic",
+                "login": "testuser",
+                "password": "testpass",
+            },
+        },
+        _get_auth_from_url(url, npm_auth),
+    )
+
+    return unittest.end(env)
+
+def _multiple_registries_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    npm_auth = {
+        "registry1.com": {
+            "bearer": "token1",
+        },
+        "registry2.com": {
+            "bearer": "token2",
+        },
+    }
+
+    url1 = "https://registry1.com/foo/-/foo-1.0.0.tgz"
+    asserts.equals(
+        env,
+        {
+            url1: {
+                "type": "pattern",
+                "pattern": "Bearer <password>",
+                "password": "token1",
+            },
+        },
+        _get_auth_from_url(url1, npm_auth),
+    )
+
+    url2 = "https://registry2.com/bar/-/bar-2.0.0.tgz"
+    asserts.equals(
+        env,
+        {
+            url2: {
+                "type": "pattern",
+                "pattern": "Bearer <password>",
+                "password": "token2",
+            },
+        },
+        _get_auth_from_url(url2, npm_auth),
+    )
+
+    url3 = "https://registry3.com/baz/-/baz-3.0.0.tgz"
+    asserts.equals(
+        env,
+        {},
+        _get_auth_from_url(url3, npm_auth),
+    )
+
+    return unittest.end(env)
+
+no_auth_test = unittest.make(_no_auth_test_impl)
+bearer_token_test = unittest.make(_bearer_token_test_impl)
+basic_auth_test = unittest.make(_basic_auth_test_impl)
+username_password_test = unittest.make(_username_password_test_impl)
+multiple_registries_test = unittest.make(_multiple_registries_test_impl)
+
+def npm_import_auth_test_suite():
+    unittest.suite(
+        "npm_import_auth_tests",
+        partial.make(no_auth_test, timeout = "short"),
+        partial.make(bearer_token_test, timeout = "short"),
+        partial.make(basic_auth_test, timeout = "short"),
+        partial.make(username_password_test, timeout = "short"),
+        partial.make(multiple_registries_test, timeout = "short"),
+    )


### PR DESCRIPTION
Fixes static authentication token caching issue where tokens from .npmrc were read once during module extension evaluation and cached, causing 401 errors when short-lived credentials expired (e.g., AWS CodeArtifact 12-hour tokens).

Changes:
- Add _read_npmrc_auth() function to read .npmrc files dynamically on each download instead of caching tokens statically
- Add _get_auth_from_url() helper to extract auth for specific registry URLs
- Add npmrc and use_home_npmrc attributes to npm_import_rule
- Modify _download_and_extract_archive() to read auth dynamically first, with fallback to static auth attributes for backward compatibility
- Pass npmrc/use_home_npmrc from npm_translate_lock extension instead of static npm_auth* attributes

### Changes are visible to end-users: no

### Test plan
- Add unit tests for _get_auth_from_url() helper function
- Add e2e integration test that verifies tokens are read dynamically:
  * Fetches succeed with valid tokens
  * Fetches fail with 401 when tokens are broken (proving fresh reads)
  * Fetches succeed when tokens are restored
- Test uses --repository_cache= to force fresh downloads

Fixes: https://github.com/aspect-build/rules_js/issues/2547
