### PR TITLE
refactor: remove npm_translate_lock(root_package)

### DIFF
--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -24,7 +24,7 @@ load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":list_sources.bzl", "list_sources")
 load(":npm_translate_lock_helpers.bzl", "helpers")
-load(":npm_translate_lock_state.bzl", "DEFAULT_ROOT_PACKAGE", "npm_translate_lock_state")
+load(":npm_translate_lock_state.bzl", "npm_translate_lock_state")
 load(":utils.bzl", "utils")
 
 RULES_JS_FROZEN_PNPM_LOCK_ENV = "ASPECT_RULES_JS_FROZEN_PNPM_LOCK"
@@ -60,7 +60,6 @@ _ATTRS = {
     "preupdate": attr.label_list(),
     "public_hoist_packages": attr.string_list_dict(),
     "quiet": attr.bool(default = True),
-    "root_package": attr.string(default = DEFAULT_ROOT_PACKAGE),
     "run_lifecycle_hooks": attr.bool(default = True),
     "update_pnpm_lock": attr.bool(),
     "use_home_npmrc": attr.bool(),

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -455,7 +455,6 @@ ERROR: can not apply both `pnpm.patchedDependencies` and `npm_translate_lock(pat
             patch_args = patch_args,
             patches = patches,
             exclude_package_contents = exclude_package_contents,
-            root_package = root_package,
             lifecycle_hooks = lifecycle_hooks,
             lifecycle_hooks_env = lifecycle_hooks_env,
             lifecycle_hooks_execution_requirements = lifecycle_hooks_execution_requirements,


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Remove `npm_translate_lock(root_package)` and always use the lockfile package as the root package.

### Test plan

- Covered by existing test cases
