### PR TITLE
refactor: simplify npm_link_package() util macro

### DIFF
--- a/e2e/npm_link_package-rerooted/root/BUILD.bazel
+++ b/e2e/npm_link_package-rerooted/root/BUILD.bazel
@@ -9,19 +9,16 @@ npm_link_package(
     name = "node_modules/@e2e/lib",
     src = "//root/lib:lib_pkg",
     package = "@e2e/lib",
-    root_package = "root",
 )
 
 npm_link_package(
     name = "node_modules/@e2e/pkg",
     src = "//root/pkg:lib_pkg",
-    root_package = "root",
 )
 
 npm_link_package(
     name = "node_modules/@e2e/wrapper-lib",
     src = "//root/wrapper-lib:wrapper-lib_pkg",
-    root_package = "root",
 )
 
 output_files(

--- a/npm/private/npm_link_package.bzl
+++ b/npm/private/npm_link_package.bzl
@@ -6,34 +6,25 @@ load(":utils.bzl", "utils")
 
 def npm_link_package(
         name,
-        root_package = "",
-        link = True,
-        src = None,
+        src,
         deps = {},
-        fail_if_no_link = True,
         auto_manual = True,
         visibility = ["//visibility:public"],
         **kwargs):
-    """"Links an npm package to node_modules if link is True.
+    """"Create a package store entry with the provided source and link to node_modules.
 
-    When called at the root_package, a package store target is generated named `link__{bazelified_name}__store`.
+    This is a convenience macro that creates both an `npm_package_store` and a a single `npm_link_package_store`
+    to link the package into `node_modules/<package>`.
 
-    When linking, a `{name}` target is generated which consists of the `node_modules/<package>` symlink and transitively
-    its package store link and the package store links of the transitive closure of deps.
-
-    When linking, `{name}/dir` filegroup is also generated that refers to a directory artifact can be used to access
+    A `{name}/dir` filegroup is also generated that refers to a directory artifact can be used to access
     the package directory for creating entry points or accessing files in the package.
 
     Args:
         name: The name of the link target to create if `link` is True.
             For first-party deps linked across a workspace, the name must match in all packages
             being linked as it is used to derive the package store link target name.
-        root_package: the root package where the node_modules package store is linked to
-        link: whether or not to link in this package
-            If false, only the npm_package_store target will be created _if_ this is called in the `root_package`.
         src: the target to link; may only to be specified when linking in the root package
         deps: list of npm_package_store; may only to be specified when linking in the root package
-        fail_if_no_link: whether or not to fail if this is called in a package that is not the root package and `link` is False
         auto_manual: whether or not to automatically add a manual tag to the generated targets
             Links tagged "manual" dy default is desirable so that they are not built by `bazel build ...` if they
             are unused downstream. For 3rd party deps, this is particularly important so that 3rd party deps are
@@ -42,26 +33,8 @@ def npm_link_package(
         **kwargs: see attributes of npm_package_store rule
 
     Returns:
-        Label of the npm_link_package_store if created, else None
+        Label of the npm_link_package_store
     """
-    bazel_package = native.package_name()
-    is_root = bazel_package == root_package
-
-    if fail_if_no_link and not is_root and not link:
-        msg = "Nothing to link in bazel package '{bazel_package}' for {name}. This is neither the root package nor a link package.".format(
-            bazel_package = bazel_package,
-            name = name,
-        )
-        fail(msg)
-
-    if deps and not is_root:
-        msg = "deps may only be specified when linking in the root package '{}'".format(root_package)
-        fail(msg)
-
-    if src and not is_root:
-        msg = "src may only be specified when linking in the root package '{}'".format(root_package)
-        fail(msg)
-
     store_target_name = "{package_store_root}/{name}".format(
         name = name,
         package_store_root = utils.package_store_root,
@@ -71,39 +44,34 @@ def npm_link_package(
     if auto_manual and "manual" not in tags:
         tags.append("manual")
 
-    if is_root:
-        # link the package store when linking at the root
-        npm_package_store(
-            name = store_target_name,
-            src = src,
-            deps = deps,
-            visibility = ["//visibility:public"],
-            tags = tags,
-            **kwargs
-        )
+    # link the package store when linking at the root
+    npm_package_store(
+        name = store_target_name,
+        src = src,
+        deps = deps,
+        visibility = ["//visibility:public"],
+        tags = tags,
+        **kwargs
+    )
 
-    link_target = None
-    if link:
-        # create the npm package store for this package
-        npm_link_package_store(
-            name = name,
-            src = "//{root_package}:{store_target_name}".format(
-                root_package = root_package,
-                store_target_name = store_target_name,
-            ),
-            tags = tags,
-            visibility = visibility,
-        )
-        link_target = ":{}".format(name)
+    link_target = ":{}".format(name)
 
-        # filegroup target that provides a single file which is
-        # package directory for use in $(execpath) and $(rootpath)
-        native.filegroup(
-            name = "{}/dir".format(name),
-            srcs = [link_target],
-            output_group = utils.package_directory_output_group,
-            tags = tags,
-            visibility = visibility,
-        )
+    # create the npm package store for this package
+    npm_link_package_store(
+        name = name,
+        src = ":{store_target_name}".format(store_target_name = store_target_name),
+        tags = tags,
+        visibility = visibility,
+    )
+
+    # filegroup target that provides a single file which is
+    # package directory for use in $(execpath) and $(rootpath)
+    native.filegroup(
+        name = "{}/dir".format(name),
+        srcs = [link_target],
+        output_group = utils.package_directory_output_group,
+        tags = tags,
+        visibility = visibility,
+    )
 
     return link_target


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Change the `npm_link_package` convenience macro to _always_ store+link the defined package.

### Test plan

- Covered by existing test cases
