### PR TITLE
fix: change use of rctx.environ to rctx.getenv

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -131,7 +131,7 @@ def _npm_translate_lock_bzlmod(module_ctx, attr, state, exclude_package_contents
     npm_auth = {}
     if attr.npmrc:
         npmrc = parse_npmrc(module_ctx.read(attr.npmrc))
-        (registries, npm_auth) = npm_translate_lock_helpers.get_npm_auth(npmrc, module_ctx.path(attr.npmrc), module_ctx.os.environ)
+        (registries, npm_auth) = npm_translate_lock_helpers.get_npm_auth(npmrc, module_ctx.path(attr.npmrc), module_ctx)
 
     if attr.use_home_npmrc:
         home_directory = repo_utils.get_home_directory(module_ctx)
@@ -139,7 +139,7 @@ def _npm_translate_lock_bzlmod(module_ctx, attr, state, exclude_package_contents
             home_npmrc_path = "{}/{}".format(home_directory, ".npmrc")
             home_npmrc = parse_npmrc(module_ctx.read(home_npmrc_path))
 
-            (registries2, npm_auth2) = npm_translate_lock_helpers.get_npm_auth(home_npmrc, home_npmrc_path, module_ctx.os.environ)
+            (registries2, npm_auth2) = npm_translate_lock_helpers.get_npm_auth(home_npmrc, home_npmrc_path, module_ctx)
             registries.update(registries2)
             npm_auth.update(npm_auth2)
         else:

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -88,7 +88,7 @@ def _gather_values_from_matching_names(additive, keyed_lists, *names):
     return (result, keys)
 
 ################################################################################
-def _get_npm_auth(npmrc, npmrc_path, environ):
+def _get_npm_auth(npmrc, npmrc_path, rctx):
     """Parses npm tokens, registries and scopes from `.npmrc`.
 
     - creates a token by registry dict: {registry: token}
@@ -135,7 +135,7 @@ def _get_npm_auth(npmrc, npmrc_path, environ):
     Args:
         npmrc: The `.npmrc` file.
         npmrc_path: The file path to `.npmrc`.
-        environ: A map of environment variables with their values.
+        rctx: the repository_ctx or module_ctx to fetch environment vars from
 
     Returns:
         A tuple (registries, auth).
@@ -160,7 +160,7 @@ def _get_npm_auth(npmrc, npmrc_path, environ):
 
             # envvar replacement is supported for `_authToken`
             # https://pnpm.io/npmrc#url_authtoken
-            token = utils.replace_npmrc_token_envvar(v, npmrc_path, environ)
+            token = utils.replace_npmrc_token_envvar(v, npmrc_path, rctx)
 
             if registry not in auth:
                 auth[registry] = {}
@@ -183,7 +183,7 @@ def _get_npm_auth(npmrc, npmrc_path, environ):
             registry = k.removeprefix("//").removesuffix(_NPM_AUTH).removesuffix(":").removesuffix("/")
 
             # envvar replacement is supported for `_auth` as well
-            token = utils.replace_npmrc_token_envvar(v, npmrc_path, environ)
+            token = utils.replace_npmrc_token_envvar(v, npmrc_path, rctx)
 
             if registry not in auth:
                 auth[registry] = {}

--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -464,7 +464,7 @@ def _load_npmrc(priv, rctx, npmrc_path):
     if "registry" in contents:
         priv["default_registry"] = utils.to_registry_url(contents["registry"])
 
-    (registries, auth) = helpers.get_npm_auth(contents, npmrc_path, rctx.os.environ)
+    (registries, auth) = helpers.get_npm_auth(contents, npmrc_path, rctx)
     priv["npm_registries"].update(registries)
     priv["npm_auth"].update(auth)
 

--- a/npm/private/test/npm_auth_test.bzl
+++ b/npm/private/test/npm_auth_test.bzl
@@ -173,6 +173,11 @@ def _plain_username_password_test_impl(ctx):
 def _env_var_token_test_impl(ctx):
     env = unittest.begin(ctx)
 
+    renv = {}
+    rctx = struct(
+        getenv = renv.get,
+    )
+
     asserts.equals(
         env,
         (
@@ -188,10 +193,11 @@ def _env_var_token_test_impl(ctx):
                 "//registry1/:_authToken": "$TOKEN1",
             },
             "",
-            {},
+            rctx,
         ),
     )
 
+    renv["TOKEN1"] = "1234"
     asserts.equals(
         env,
         (
@@ -207,9 +213,7 @@ def _env_var_token_test_impl(ctx):
                 "//registry1/:_authToken": "$TOKEN1",
             },
             "",
-            {
-                "TOKEN1": "1234",
-            },
+            rctx,
         ),
     )
 
@@ -228,12 +232,11 @@ def _env_var_token_test_impl(ctx):
                 "//registry1/:_authToken": "${%s}" % "TOKEN1",
             },
             "",
-            {
-                "TOKEN1": "1234",
-            },
+            rctx,
         ),
     )
 
+    renv["TOKEN2"] = "5678"
     asserts.equals(
         env,
         (
@@ -253,16 +256,16 @@ def _env_var_token_test_impl(ctx):
                 "//registry2/:_authToken": "${%s}" % "TOKEN2",
             },
             "",
-            {
-                "TOKEN1": "1234",
-                "TOKEN2": "5678",
-            },
+            rctx,
         ),
     )
     return unittest.end(env)
 
 def _mixed_token_test_impl(ctx):
     env = unittest.begin(ctx)
+    rctx = struct(
+        getenv = lambda key: ("5678" if key == "TOKEN2" else None),
+    )
 
     asserts.equals(
         env,
@@ -293,9 +296,7 @@ def _mixed_token_test_impl(ctx):
                 "//registry4/:_auth": "c29tZW9uZTpwYXNzd29yZA==",
             },
             "",
-            {
-                "TOKEN2": "5678",
-            },
+            rctx,
         ),
     )
 

--- a/npm/private/utils.bzl
+++ b/npm/private/utils.bzl
@@ -236,14 +236,14 @@ if [ ! -f $1 ]; then exit 42; fi
     else:
         fail(INTERNAL_ERROR_MSG)
 
-def _replace_npmrc_token_envvar(token, npmrc_path, environ):
+def _replace_npmrc_token_envvar(token, npmrc_path, rctx):
     # A token can be a reference to an environment variable
     if token.startswith("$"):
         # ${NPM_TOKEN} -> NPM_TOKEN
         # $NPM_TOKEN -> NPM_TOKEN
         token = token.removeprefix("$").removeprefix("{").removesuffix("}")
-        if environ.get(token, False):
-            token = environ[token]
+        if rctx.getenv(token) != None:
+            token = rctx.getenv(token)
         else:
             # buildifier: disable=print
             print("""


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
