### PR TITLE
refactor: add simplified package store definition for no-hook non-circular packages

### DIFF
--- a/e2e/gyp_no_install_script/snapshots/segfault-handler_defs.bzl
+++ b/e2e/gyp_no_install_script/snapshots/segfault-handler_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "segfault-handler"
 VERSION = "1.3.0"

--- a/e2e/npm_translate_lock_disable_hooks/snapshots/aspect_test_c_links_defs.bzl
+++ b/e2e/npm_translate_lock_disable_hooks/snapshots/aspect_test_c_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "@aspect-test/c"
 VERSION = "2.0.0"
@@ -17,21 +19,14 @@ _PACKAGE_STORE_NAME = "@aspect-test+c@2.0.0"
 # Generated npm_imported_package_store_internal() wrapper target for npm package @aspect-test/c@2.0.0
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = {},
         ref_deps = {},
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@aspect_rules_js~~npm~npm__at_aspect-test_c__2.0.0//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/e2e/pnpm_lockfiles/v101/snapshots/aspect_test_a_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/aspect_test_a_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "@aspect-test/a"
 VERSION = "5.0.2"

--- a/e2e/pnpm_lockfiles/v101/snapshots/aspect_test_b_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/aspect_test_b_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "@aspect-test/b"
 VERSION = "5.0.2"

--- a/e2e/pnpm_lockfiles/v101/snapshots/aspect_test_c_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/aspect_test_c_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "@aspect-test/c"
 VERSION = "2.0.0"

--- a/e2e/pnpm_lockfiles/v101/snapshots/esbuild_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/esbuild_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "esbuild"
 VERSION = "0.27.0"
@@ -17,11 +19,10 @@ _PACKAGE_STORE_NAME = "esbuild@0.27.0"
 # Generated npm_imported_package_store_internal() wrapper target for npm package esbuild@0.27.0
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = select({
             "@aspect_rules_js//platforms/pnpm:aix_ppc64": {
                 ":.aspect_rules_js/node_modules/@esbuild+aix-ppc64@0.27.0": "@esbuild/aix-ppc64",
@@ -160,14 +161,8 @@ def npm_imported_package_store_internal():
             },
             "//conditions:default": {},
         }),
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@aspect_rules_js~~npm~lock-<LOCKVERSION>__esbuild__0.27.0//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/e2e/pnpm_lockfiles/v101/snapshots/lodash-4.17.21_tgz_defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/lodash-4.17.21_tgz_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "lodash"
 VERSION = "file:../vendored/lodash-4.17.21.tgz"
@@ -17,21 +19,14 @@ _PACKAGE_STORE_NAME = "lodash@file+..+vendored+lodash-4.17.21.tgz"
 # Generated npm_imported_package_store_internal() wrapper target for npm package lodash@file:../vendored/lodash-4.17.21.tgz
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = {},
         ref_deps = {},
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@aspect_rules_js~~npm~lock-<LOCKVERSION>__lodash__file_.._vendored_lodash-4.17.21.tgz//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/e2e/pnpm_lockfiles/v101/snapshots/rollup_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/rollup_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "rollup"
 VERSION = "2.14.0"
@@ -17,11 +19,10 @@ _PACKAGE_STORE_NAME = "rollup@2.14.0"
 # Generated npm_imported_package_store_internal() wrapper target for npm package rollup@2.14.0
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = select({
             "@aspect_rules_js//platforms/pnpm:darwin": {
                 ":.aspect_rules_js/node_modules/fsevents@2.3.3": "fsevents",
@@ -34,14 +35,8 @@ def npm_imported_package_store_internal():
             },
             "//conditions:default": {},
         }),
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@aspect_rules_js~~npm~lock-<LOCKVERSION>__rollup__2.14.0//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/e2e/pnpm_lockfiles/v90/snapshots/aspect_test_a_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/aspect_test_a_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "@aspect-test/a"
 VERSION = "5.0.2"

--- a/e2e/pnpm_lockfiles/v90/snapshots/aspect_test_b_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/aspect_test_b_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "@aspect-test/b"
 VERSION = "5.0.2"

--- a/e2e/pnpm_lockfiles/v90/snapshots/aspect_test_c_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/aspect_test_c_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "@aspect-test/c"
 VERSION = "2.0.0"

--- a/e2e/pnpm_lockfiles/v90/snapshots/esbuild_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/esbuild_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "esbuild"
 VERSION = "0.27.0"
@@ -17,11 +19,10 @@ _PACKAGE_STORE_NAME = "esbuild@0.27.0"
 # Generated npm_imported_package_store_internal() wrapper target for npm package esbuild@0.27.0
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = select({
             "@aspect_rules_js//platforms/pnpm:aix_ppc64": {
                 ":.aspect_rules_js/node_modules/@esbuild+aix-ppc64@0.27.0": "@esbuild/aix-ppc64",
@@ -160,14 +161,8 @@ def npm_imported_package_store_internal():
             },
             "//conditions:default": {},
         }),
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@aspect_rules_js~~npm~lock-<LOCKVERSION>__esbuild__0.27.0//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/e2e/pnpm_lockfiles/v90/snapshots/lodash-4.17.21_tgz_defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/lodash-4.17.21_tgz_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "lodash"
 VERSION = "file:../vendored/lodash-4.17.21.tgz"
@@ -17,21 +19,14 @@ _PACKAGE_STORE_NAME = "lodash@file+..+vendored+lodash-4.17.21.tgz"
 # Generated npm_imported_package_store_internal() wrapper target for npm package lodash@file:../vendored/lodash-4.17.21.tgz
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = {},
         ref_deps = {},
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@aspect_rules_js~~npm~lock-<LOCKVERSION>__lodash__file_.._vendored_lodash-4.17.21.tgz//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/e2e/pnpm_lockfiles/v90/snapshots/rollup_links_defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/rollup_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "rollup"
 VERSION = "2.14.0"
@@ -17,11 +19,10 @@ _PACKAGE_STORE_NAME = "rollup@2.14.0"
 # Generated npm_imported_package_store_internal() wrapper target for npm package rollup@2.14.0
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = select({
             "@aspect_rules_js//platforms/pnpm:darwin": {
                 ":.aspect_rules_js/node_modules/fsevents@2.3.3": "fsevents",
@@ -34,14 +35,8 @@ def npm_imported_package_store_internal():
             },
             "//conditions:default": {},
         }),
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@aspect_rules_js~~npm~lock-<LOCKVERSION>__rollup__2.14.0//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/npm/private/test/snapshots/circular_links_defs.bzl
+++ b/npm/private/test/snapshots/circular_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "es5-ext"
 VERSION = "0.10.64"

--- a/npm/private/test/snapshots/closure-compiler_links_defs.bzl
+++ b/npm/private/test/snapshots/closure-compiler_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "google-closure-compiler"
 VERSION = "20251111.0.0"
@@ -17,11 +19,10 @@ _PACKAGE_STORE_NAME = "google-closure-compiler@20251111.0.0"
 # Generated npm_imported_package_store_internal() wrapper target for npm package google-closure-compiler@20251111.0.0
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = {
             ":.aspect_rules_js/node_modules/chalk@5.1.1": "chalk",
             ":.aspect_rules_js/node_modules/google-closure-compiler-java@20251111.0.0": "google-closure-compiler-java",
@@ -76,14 +77,8 @@ def npm_imported_package_store_internal():
             },
             "//conditions:default": {},
         }),
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@_main~npm~npm__google-closure-compiler__20251111.0.0//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/npm/private/test/snapshots/fsevents_links_defs.bzl
+++ b/npm/private/test/snapshots/fsevents_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_package_store_internal = "npm_imported_package_store_internal")
 
 PACKAGE = "fsevents"
 VERSION = "2.3.3"

--- a/npm/private/test/snapshots/next_links_defs.bzl
+++ b/npm/private/test/snapshots/next_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "next"
 VERSION = "15.2.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)"
@@ -17,11 +19,10 @@ _PACKAGE_STORE_NAME = "next@15.2.6_1315089095"
 # Generated npm_imported_package_store_internal() wrapper target for npm package next@15.2.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = {
             ":.aspect_rules_js/node_modules/@next+env@15.2.6": "@next/env",
             ":.aspect_rules_js/node_modules/@swc+counter@0.1.3": "@swc/counter",
@@ -90,14 +91,8 @@ def npm_imported_package_store_internal():
             },
             "//conditions:default": {},
         }),
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@_main~npm~npm__next__15.2.6_1315089095//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/npm/private/test/snapshots/rollup_links_defs.bzl
+++ b/npm/private/test/snapshots/rollup_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "rollup"
 VERSION = "2.70.2"
@@ -17,11 +19,10 @@ _PACKAGE_STORE_NAME = "rollup@2.70.2"
 # Generated npm_imported_package_store_internal() wrapper target for npm package rollup@2.70.2
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = select({
             "@aspect_rules_js//platforms/pnpm:darwin": {
                 ":.aspect_rules_js/node_modules/fsevents@2.3.3": "fsevents",
@@ -34,14 +35,8 @@ def npm_imported_package_store_internal():
             },
             "//conditions:default": {},
         }),
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@_main~npm~npm__rollup__2.70.2//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 

--- a/npm/private/test/snapshots/unused_links_defs.bzl
+++ b/npm/private/test/snapshots/unused_links_defs.bzl
@@ -3,10 +3,12 @@
 # buildifier: disable=bzl-visibility
 load(
     "@aspect_rules_js//npm/private:npm_import.bzl",
-    _npm_imported_package_store_internal = "npm_imported_package_store_internal",
     _npm_link_imported_package_internal = "npm_link_imported_package_internal",
     _npm_link_imported_package_store_internal = "npm_link_imported_package_store_internal",
 )
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_import.bzl", _npm_imported_simple_package_store_internal = "npm_imported_simple_package_store_internal")
 
 PACKAGE = "unused"
 VERSION = "0.2.2"
@@ -17,11 +19,10 @@ _PACKAGE_STORE_NAME = "unused@0.2.2"
 # Generated npm_imported_package_store_internal() wrapper target for npm package unused@0.2.2
 # buildifier: disable=function-docstring
 def npm_imported_package_store_internal():
-    _npm_imported_package_store_internal(
+    _npm_imported_simple_package_store_internal(
         key = _KEY,
         package = PACKAGE,
         version = VERSION,
-        root_package = _ROOT_PACKAGE,
         deps = {
             ":.aspect_rules_js/node_modules/esprima@1.0.0": "esprima",
             ":.aspect_rules_js/node_modules/optimist@0.6.0": "optimist",
@@ -30,14 +31,8 @@ def npm_imported_package_store_internal():
             ":.aspect_rules_js/node_modules/esprima@1.0.0/ref": "esprima",
             ":.aspect_rules_js/node_modules/optimist@0.6.0/ref": "optimist",
         },
-        lc_deps = {},
-        has_lifecycle_build_target = False,
-        has_transitive_closure = False,
         npm_package_target = "@@_main~npm~npm__unused__0.2.2//:pkg",
         package_store_name = _PACKAGE_STORE_NAME,
-        lifecycle_hooks_env = {},
-        lifecycle_hooks_execution_requirements = {},
-        use_default_shell_env = False,
         exclude_package_contents = [],
     )
 


### PR DESCRIPTION
Add a simplified codepath (`npm_imported_simple_package_store_internal`) for packages with no circular deps and no lifecycle hooks. While it adds a bit of code it makes the most common scenario much simpler to follow.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
