### PR TITLE
refactor: expose npm_import repo rule for other extensions to use

### DIFF
--- a/npm/repositories.bzl
+++ b/npm/repositories.bzl
@@ -1,10 +1,53 @@
 """Repository rules to fetch third-party npm packages"""
 
+load("//npm/private:npm_import.bzl", _npm_import = "npm_import")
 load("//npm/private:npm_translate_lock.bzl", _list_patches = "list_patches")
 load("//npm/private:pnpm_repository.bzl", _DEFAULT_PNPM_VERSION = "DEFAULT_PNPM_VERSION", _LATEST_PNPM_VERSION = "LATEST_PNPM_VERSION", _pnpm_repository = "pnpm_repository")
 
 DEFAULT_PNPM_VERSION = _DEFAULT_PNPM_VERSION
 LATEST_PNPM_VERSION = _LATEST_PNPM_VERSION
 
+# PRIVATE: exposed only for ruleset-internal use.
+
 list_patches = _list_patches
 pnpm_repository = _pnpm_repository
+
+# A trivial wrapper for fetching a single standalone package.
+def npm_import(name, package, integrity, version, **kwargs):
+    _npm_import(
+        name = name,
+        key = name,
+        package = package,
+        integrity = integrity,
+        version = version,
+        deps = {},
+        deps_constraints = {},
+        extra_build_content = None,
+        transitive_closure = None,
+        root_package = "",
+        lifecycle_hooks = kwargs.pop("lifecycle_hooks", None),  # rules_esbuild specifies empty hooks
+        lifecycle_hooks_execution_requirements = None,
+        lifecycle_hooks_env = None,
+        lifecycle_hooks_use_default_shell_env = None,
+        url = None,
+        commit = None,
+        replace_package = None,
+        package_visibility = None,
+        patch_tool = None,
+        patch_args = None,
+        patches = None,
+        custom_postinstall = None,
+        npm_auth = None,
+        npm_auth_basic = None,
+        npm_auth_username = None,
+        npm_auth_password = None,
+        bins = None,
+        dev = None,
+        generate_bzl_library_targets = None,
+        generate_package_json_bzl = None,
+        extract_full_archive = None,
+        exclude_package_contents = None,
+    )
+
+    if len(kwargs) != 0:
+        fail("Minimal repositories.bzl npm_import received unexpected keyword arguments: %s" % ", ".join(kwargs.keys()))


### PR DESCRIPTION
This is still used by other module extensions such as rules_esbuild so I think we still need to make it "public".

This is essentially [for esbuild](https://github.com/aspect-build/rules_esbuild/blob/v0.24.0/esbuild/repositories.bzl#L143-L150) to avoid forcing an upgrade there, and avoid such an upgrade having to manually list all the params.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
