### PR TITLE
fix: npm_import(extract_full_archive) bzlmod attribute not being passed through

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -229,8 +229,8 @@ def _npm_import_bzlmod(i):
         name = i.name,
         key = package_key,
         generate_package_json_bzl = True,  # Always generate package_json.bzl explicitly declared imports
-        generate_bzl_library_targets = None,
-        extract_full_archive = None,
+        generate_bzl_library_targets = None,  # Not supported via bzlmod
+        extract_full_archive = i.extract_full_archive,
         bins = i.bins,
         commit = i.commit,
         custom_postinstall = i.custom_postinstall,

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -904,8 +904,6 @@ _ATTRS = _COMMON_ATTRS | {
     "extra_build_content": attr.string(),
     "extract_full_archive": attr.bool(),
     "exclude_package_contents": attr.string_list(default = []),
-    "generate_package_json_bzl": attr.bool(),
-    "generate_bzl_library_targets": attr.bool(),
     "integrity": attr.string(),
     "lifecycle_hooks": attr.string_list(),
     "npm_auth": attr.string(),
@@ -1193,7 +1191,10 @@ npm_import_links_rule = repository_rule(
 
 npm_import_rule = repository_rule(
     implementation = _npm_import_rule_impl,
-    attrs = _ATTRS | _INTERNAL_COMMON_ATTRS,
+    attrs = _ATTRS | _INTERNAL_COMMON_ATTRS | {
+        "generate_package_json_bzl": attr.bool(),
+        "generate_bzl_library_targets": attr.bool(),
+    },
 )
 
 # Private API for importing + linking a single npm package


### PR DESCRIPTION
Fix #2577

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
