### PR TITLE
feat: add include_npm to pnpm module extension

### DIFF
--- a/npm/private/pnpm_repository.bzl
+++ b/npm/private/pnpm_repository.bzl
@@ -10,7 +10,7 @@ LATEST_PNPM_VERSION = PNPM_VERSIONS.keys()[-1]
 # Default to the latest pnpm v10
 DEFAULT_PNPM_VERSION = [v for v in PNPM_VERSIONS.keys() if v.startswith("10")][-1]
 
-def pnpm_repository(name, pnpm_version = DEFAULT_PNPM_VERSION):
+def pnpm_repository(name, pnpm_version = DEFAULT_PNPM_VERSION, include_npm = False, integrity = None):
     """Import https://npmjs.com/package/pnpm and provide a js_binary to run the tool.
 
     Useful as a way to run exactly the same pnpm as Bazel does, for example with:
@@ -22,16 +22,16 @@ def pnpm_repository(name, pnpm_version = DEFAULT_PNPM_VERSION):
 
             May also be a tuple of (version, integrity) where the integrity value may be fetched like:
             `curl --silent https://registry.npmjs.org/pnpm | jq '.versions["8.6.11"].dist.integrity'`
+        integrity: optional integrity hash for the pnpm version, if not provided it will be
+            looked up in PNPM_VERSIONS defined in versions.bzl
+        include_npm: if True, include the npm package along with pnpm binary
     """
 
     if not native.existing_rule(name):
-        if type(pnpm_version) == "tuple":
-            integrity = pnpm_version[1]
-            pnpm_version = pnpm_version[0]
-        elif type(pnpm_version) == "string":
-            integrity = PNPM_VERSIONS[pnpm_version]
-        else:
-            fail("pnpm_version should be string or tuple, got " + type(pnpm_version))
+        if not integrity:
+            integrity = PNPM_VERSIONS.get(pnpm_version, None)
+            if not integrity:
+                fail("Unknown pnpm version {}, please provide an integrity hash".format(pnpm_version))
 
         key = "{}@{}".format("pnpm", pnpm_version)
 
@@ -44,7 +44,13 @@ def pnpm_repository(name, pnpm_version = DEFAULT_PNPM_VERSION):
             version = pnpm_version,
             extra_build_content = "\n".join([
                 """load("@aspect_rules_js//js:defs.bzl", "js_binary")""",
-                """js_binary(name = "pnpm", data = glob(["package/**"]), entry_point = "package/dist/pnpm.cjs", visibility = ["//visibility:public"])""",
+                """js_binary(
+    name = "pnpm",
+    data = glob(["package/**"]),
+    entry_point = "package/dist/pnpm.cjs",
+    include_npm = {include_npm},
+    visibility = ["//visibility:public"],
+)""".format(include_npm = include_npm),
             ]),
             extract_full_archive = True,
         )


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add `pnpm(include_npm)` to include npm in the pnpm binary configured with the pnpm extension.

### Test plan

- Covered by existing test cases
- New test cases added
