### PR TITLE
fix: do not serialize Label() via "".join() when tar command fails

### DIFF
--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -602,7 +602,7 @@ def _download_and_extract_archive(rctx, package_json_only):
     if not package_json_only:
         result = rctx.execute(tar_args)
         if result.return_code:
-            msg = "Failed to extract package tarball. '{}' exited with {}: \nSTDOUT:\n{}\nSTDERR:\n{}".format(" ".join(tar_args), result.return_code, result.stdout, result.stderr)
+            msg = "Failed to extract package tarball. '{}' exited with {}: \nSTDOUT:\n{}\nSTDERR:\n{}".format(tar_args, result.return_code, result.stdout, result.stderr)
             fail(msg)
 
     if not is_windows:


### PR DESCRIPTION
While debugging an error in https://github.com/aspect-build/rules_js/pull/2592 it was failing to output an error message instead saying:
```
expected string for sequence element 0, got '@@aspect_bazel_lib~~toolchains~bsd_tar_darwin_arm64//:tar' of type Label
```

This change makes it output the args in a format such as:
```
Failed to extract package tarball. '[Label("@@aspect_bazel_lib~~toolchains~bsd_tar_darwin_arm64//:tar"), "-xf", "package.tgz", "--strip-components", "1", "-C", "package", "--no-same-owner", "--no-same-permissions"]' exited with 1:
```
which might have the ugly `[...]` braces but at least it's not failing to output the error message.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing
