### PR TITLE
fix(pnpm): Parse integrity hash from package.json packageManager if provided

### DIFF
--- a/npm/private/pnpm_extension.bzl
+++ b/npm/private/pnpm_extension.bzl
@@ -56,9 +56,13 @@ def resolve_pnpm_repositories(mctx):
                 if not package_manager.startswith("pnpm@"):
                     fail("packageManager field must specify pnpm, got: " + package_manager)
 
-                # Extract version from "pnpm@8.15.9" format
+                # Extract version and optional integrity from "pnpm@8.15.9+sha512.<hash>" format
                 v = package_manager[5:]  # Remove "pnpm@" prefix
-                v = v.rsplit("+sha512.")[0]  # Remove optional "+sha512.<hash>" suffix
+                if "+sha512." in v:
+                    parts = v.rsplit("+sha512.", 1)
+                    v = parts[0]
+                    # Store the integrity hash (prepend "sha512-" as that's the expected format)
+                    integrity[v] = "sha512-" + parts[1]
 
             elif attr.pnpm_version == "latest":
                 v = LATEST_PNPM_VERSION

--- a/npm/private/test/pnpm_test.bzl
+++ b/npm/private/test/pnpm_test.bzl
@@ -48,6 +48,8 @@ def _basic(ctx):
     )
 
 def _from_package_json_simple(ctx):
+    # Test reading pnpm version from package.json without integrity hash.
+    # packageManager: "pnpm@1.2.3" -> version only, no integrity tuple
     return _resolve_test(
         ctx,
         repositories = {"pnpm": "1.2.3"},
@@ -58,9 +60,11 @@ def _from_package_json_simple(ctx):
     )
 
 def _from_package_json_with_hash(ctx):
+    # Test reading pnpm version from package.json with integrity hash.
+    # packageManager: "pnpm@1.2.3+sha512.xxx" -> (version, integrity) tuple
     return _resolve_test(
         ctx,
-        repositories = {"pnpm": "1.2.3"},
+        repositories = {"pnpm": ("1.2.3", "sha512-97462997561378b6f52ac5c614f3a3b923a652ad5ac987100286e4aa2d84a6a0642e9e45f3d01d30c46b12b20beb0f86aeb790bf9a82bc59db42b67fe69d1a25")},
         modules = [
             _fake_mod(True, _fake_pnpm_tag(pnpm_version_from = "//:package.json")),
         ],


### PR DESCRIPTION
When specifying `pnpm_version` and `pnpm_version_integrity` directly in MODULE.bazel, both version and integrity were used correctly. However, when using `pnpm_version_from` to read from package.json's `packageManager` field, the integrity hash was being discarded.

The `packageManager` field is the standard way to pin package manager versions in the Node.js ecosystem. This fix ensures that projects using the standard `packageManager` format can use the same package.json with both local Node.js tooling and Bazel tooling.

Changes:

- Modified the `packageManager` parsing logic to extract and store the integrity hash when present. The hash format is converted from +sha512.xxx (npm/corepack format) to sha512-xxx
- Updated `from_package_json_with_hash_test` to verify hash extraction, as `from_package_json_simple_test` covers the case without it
