### PR TITLE
refactor: removing trailing whitespace in generated code

### DIFF
--- a/e2e/npm_translate_lock_disable_hooks/snapshots/defs.bzl
+++ b/e2e/npm_translate_lock_disable_hooks/snapshots/defs.bzl
@@ -20,7 +20,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~npm//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
 
-
     if is_root:
         store_0(name)
 
@@ -34,7 +33,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets = {
                 "@aspect-test": [":{}/@aspect-test/c".format(name)],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -46,7 +44,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():

--- a/e2e/npm_translate_lock_empty/snapshots/bzlmod/npm_defs.bzl
+++ b/e2e/npm_translate_lock_empty/snapshots/bzlmod/npm_defs.bzl
@@ -21,7 +21,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~npm//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
 
-
     if is_root:
         store_0(name)
         store_1(name)
@@ -29,7 +28,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     link_targets = None
     scope_targets = None
 
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -41,7 +39,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():

--- a/e2e/npm_translate_lock_empty/snapshots/wksp/npm_defs.bzl
+++ b/e2e/npm_translate_lock_empty/snapshots/wksp/npm_defs.bzl
@@ -21,7 +21,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         msg = "The npm_link_all_packages() macro loaded from @npm//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
 
-
     if is_root:
         store_0(name)
         store_1(name)
@@ -29,7 +28,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     link_targets = None
     scope_targets = None
 
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -41,7 +39,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():

--- a/e2e/npm_translate_lock_replace_packages/snapshots/bzlmod/npm_defs.bzl
+++ b/e2e/npm_translate_lock_replace_packages/snapshots/bzlmod/npm_defs.bzl
@@ -21,7 +21,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~npm//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
 
-
     if is_root:
         store_0(name)
         store_1(name)
@@ -37,7 +36,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 ":{}/chalk".format(name),
                 ":{}/lodash".format(name),
             ]
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -49,7 +47,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():

--- a/e2e/npm_translate_lock_replace_packages/snapshots/wksp/npm_defs.bzl
+++ b/e2e/npm_translate_lock_replace_packages/snapshots/wksp/npm_defs.bzl
@@ -21,7 +21,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         msg = "The npm_link_all_packages() macro loaded from @npm//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
 
-
     if is_root:
         store_0(name)
         store_1(name)
@@ -37,7 +36,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 ":{}/chalk".format(name),
                 ":{}/lodash".format(name),
             ]
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -49,7 +47,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():

--- a/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
@@ -109,7 +109,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")
 
 _IMPORTER_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/alts", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -125,7 +125,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     if not is_root and not link:
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~lock-<LOCKVERSION>//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '<LOCKVERSION>', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
-
 
     if is_root:
         store_0(name)
@@ -584,7 +583,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                     ":{}/@scoped/b".format(name),
                 ],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -596,7 +594,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():
@@ -731,7 +728,6 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":{}/@scoped/b".format(name),
             ])
     return link_targets
-
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v54/snapshots/defs.bzl
@@ -108,7 +108,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")
 
 _IMPORTER_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/alts", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -124,7 +124,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     if not is_root and not link:
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~lock-<LOCKVERSION>//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '<LOCKVERSION>', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
-
 
     if is_root:
         store_0(name)
@@ -578,7 +577,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets = {
                 "@scoped": [":{}/@scoped/a".format(name)],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -590,7 +588,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():
@@ -718,7 +715,6 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
         if prod:
             link_targets.extend([":{}/@scoped/a".format(name)])
     return link_targets
-
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v60/snapshots/defs.bzl
@@ -109,7 +109,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")
 
 _IMPORTER_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/alts", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -125,7 +125,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     if not is_root and not link:
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~lock-<LOCKVERSION>//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '<LOCKVERSION>', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
-
 
     if is_root:
         store_0(name)
@@ -596,7 +595,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                     ":{}/@scoped/b".format(name),
                 ],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -608,7 +606,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():
@@ -743,7 +740,6 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":{}/@scoped/b".format(name),
             ])
     return link_targets
-
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v61/snapshots/defs.bzl
@@ -109,7 +109,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")
 
 _IMPORTER_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/alts", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -125,7 +125,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     if not is_root and not link:
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~lock-<LOCKVERSION>//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '<LOCKVERSION>', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
-
 
     if is_root:
         store_0(name)
@@ -596,7 +595,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                     ":{}/@scoped/b".format(name),
                 ],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -608,7 +606,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():
@@ -743,7 +740,6 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":{}/@scoped/b".format(name),
             ])
     return link_targets
-
 
 # Generated npm_link_package_store for linking of first-party "a-types" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -109,7 +109,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")
 
 _IMPORTER_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/alts", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
@@ -125,7 +125,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     if not is_root and not link:
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~lock-<LOCKVERSION>//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '<LOCKVERSION>', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
-
 
     if is_root:
         store_0(name)
@@ -584,7 +583,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                     ":{}/@scoped/b".format(name),
                 ],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -596,7 +594,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():
@@ -731,7 +728,6 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":{}/@scoped/b".format(name),
             ])
     return link_targets
-
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -21,7 +21,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")
 
 _IMPORTER_PACKAGES = ["", "app/a", "app/b", "app/c", "app/d", "lib/a", "lib/b", "lib/c", "lib/d"]
 
@@ -37,7 +37,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     if not is_root and not link:
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~npm//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
-
 
     if is_root:
         store_0(name)
@@ -268,7 +267,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                     ":{}/@lib/b_alias".format(name),
                 ],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -280,7 +278,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():
@@ -368,7 +365,6 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":{}/@lib/b_alias".format(name),
             ])
     return link_targets
-
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -21,7 +21,7 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")
 
 _IMPORTER_PACKAGES = ["root", "", "app/a", "app/b", "app/c", "app/d", "lib/a", "lib/b", "lib/c", "lib/d"]
 
@@ -37,7 +37,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     if not is_root and not link:
         msg = "The npm_link_all_packages() macro loaded from @aspect_rules_js~~npm~npm//:defs.bzl and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: 'root', pnpm workspace projects: %s" % (bazel_package, "'" + "', '".join(_IMPORTER_PACKAGES) + "'")
         fail(msg)
-
 
     if is_root:
         store_0(name)
@@ -268,7 +267,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                     ":{}/@lib/b_alias".format(name),
                 ],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -280,7 +278,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():
@@ -368,7 +365,6 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":{}/@lib/b_alias".format(name),
             ])
     return link_targets
-
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
 # buildifier: disable=function-docstring

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -39,7 +39,7 @@ _FP_STORE_TMPL = \
         )"""
 
 _FP_DIRECT_TMPL = \
-    """
+    """\
 # Generated npm_link_package_store for linking of first-party "{pkg}" package
 # buildifier: disable=function-docstring
 def _fp_link_{i}(name):
@@ -228,8 +228,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     if not is_root and not link:
         msg = "The npm_link_all_packages() macro loaded from {defs_bzl_file} and called in bazel package '%s' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '{root_package}', pnpm workspace projects: %s" % (bazel_package, {link_packages_comma_separated})
         fail(msg)
-{validation_call}
-""".format(
+{validation_call}""".format(
             defs_bzl_file = "@{}//:{}".format(rctx.name, rctx.attr.defs_bzl_filename),
             link_packages_comma_separated = "\"'\" + \"', '\".join(_IMPORTER_PACKAGES) + \"'\"" if package_to_importer else "\"\"",
             root_package = root_package,
@@ -448,7 +447,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             first_link = False
 
     # Invoke and collect link targets from the `imported_links` param
-    npm_link_all_packages_bzl.append("""    
+    npm_link_all_packages_bzl.append("""\
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -459,8 +458,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
                 scope_targets = {}
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
-            scope_targets[_scope].extend(_targets)
-""")
+            scope_targets[_scope].extend(_targets)""")
 
     # Generate catch all & scoped js_library targets
     # TODO(3.0): don't generate empty js_library targets?
@@ -487,19 +485,18 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     defs_bzl_header.append("# buildifier: disable=bzl-visibility")
     defs_bzl_header.append("""load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")""")
 
-    # Only add visibility load if package visibility is configured
-    if has_package_visibility:
-        defs_bzl_header.append("")
-        defs_bzl_header.append("# buildifier: disable=bzl-visibility")
-        defs_bzl_header.append("""load("@aspect_rules_js//npm/private:npm_package_visibility.bzl", _npm_validate_package_visibility = "validate_npm_package_visibility")""")
-
     if fp_links:
         defs_bzl_header.append("")
         defs_bzl_header.append("# buildifier: disable=bzl-visibility")
         defs_bzl_header.append("""load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")""")
         defs_bzl_header.append("")
         defs_bzl_header.append("# buildifier: disable=bzl-visibility")
-        defs_bzl_header.append("""load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")""")
+        defs_bzl_header.append("""load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")""")
+
+    if has_package_visibility:
+        defs_bzl_header.append("")
+        defs_bzl_header.append("# buildifier: disable=bzl-visibility")
+        defs_bzl_header.append("""load("@aspect_rules_js//npm/private:npm_package_visibility.bzl", _npm_validate_package_visibility = "validate_npm_package_visibility")""")
 
     # Build the defs.bzl file contents
     defs_bzl_contents = [
@@ -518,7 +515,7 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
         "",
         "\n".join(npm_link_targets_bzl),
         "",
-        "\n".join(link_factories_bzl),
+        "\n\n".join(link_factories_bzl),
     ])
 
     rctx_files[rctx.attr.defs_bzl_filename] = defs_bzl_contents

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -1093,13 +1093,13 @@ load("@@_main~npm~npm__zod__3.21.4__links//:defs.bzl", store_1087 = "npm_importe
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_visibility.bzl", _npm_validate_package_visibility = "validate_npm_package_visibility")
-
-# buildifier: disable=bzl-visibility
 load("@aspect_rules_js//npm/private:npm_link_package_store.bzl", _npm_local_link_package_store = "npm_local_link_package_store_internal")
 
 # buildifier: disable=bzl-visibility
-load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_package_store = "npm_package_store", _npm_local_package_store = "npm_local_package_store_internal")
+load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_store = "npm_local_package_store_internal")
+
+# buildifier: disable=bzl-visibility
+load("@aspect_rules_js//npm/private:npm_package_visibility.bzl", _npm_validate_package_visibility = "validate_npm_package_visibility")
 
 _IMPORTER_PACKAGES = ["", "examples/js_binary", "examples/js_lib_pkg/a", "examples/js_lib_pkg/b", "examples/linked_consumer", "examples/linked_empty_node_modules", "examples/linked_lib", "examples/linked_pkg", "examples/macro", "examples/nextjs", "examples/npm_deps", "examples/npm_package/libs/lib_a", "examples/npm_package/packages/pkg_a", "examples/npm_package/packages/pkg_b", "examples/npm_package/packages/pkg_d", "examples/npm_package/packages/pkg_e", "examples/runfiles", "examples/stack_traces", "examples/webpack_cli", "js/private/coverage/bundle", "js/private/devserver/src", "js/private/test/image", "js/private/test/js_run_devserver", "js/private/test/node-patches", "js/private/worker/src", "npm/private/test", "npm/private/test/npm_package", "npm/private/test/npm_package_publish"]
 
@@ -1154,7 +1154,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
 
     # Validate package visibility before creating any targets
     _npm_validate_package_visibility(bazel_package, _NPM_PACKAGE_LOCATIONS, _NPM_PACKAGE_VISIBILITY)
-
 
     if is_root:
         store_0(name)
@@ -2788,7 +2787,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             scope_targets = {
                 "@mycorp": [":{}/@mycorp/pkg-d".format(name)],
             }
-    
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -2800,7 +2798,6 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             if _scope not in scope_targets:
                 scope_targets[_scope] = []
             scope_targets[_scope].extend(_targets)
-
 
     if scope_targets:
         for scope, scoped_targets in scope_targets.items():
@@ -3052,7 +3049,6 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
         if prod:
             link_targets.extend([":{}/@mycorp/pkg-d".format(name)])
     return link_targets
-
 
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-a" package
 # buildifier: disable=function-docstring


### PR DESCRIPTION
The generated files still have some buildifier errors but this reduces it a bit, and removes one unused import in the generated code.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
