### PR TITLE
refactor: do not duplicate js_library result JsInfo in runfiles

### DIFF
--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -20,7 +20,7 @@ load("@bazel_lib//lib:directory_path.bzl", "DirectoryPathInfo")
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:windows_utils.bzl", "create_windows_native_launcher_script")
 load(":bash.bzl", "BASH_INITIALIZE_RUNFILES")
-load(":js_helpers.bzl", "LOG_LEVELS", "envs_for_log_level", "gather_runfiles")
+load(":js_helpers.bzl", "LOG_LEVELS", "envs_for_log_level", "gather_files_from_js_infos", "gather_runfiles")
 
 _DOC = """Execute a program in the Node.js runtime.
 
@@ -519,14 +519,18 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
         data_files = [entry_point] + ctx.files.data,
         copy_data_files_to_bin = ctx.attr.copy_data_to_bin,
         no_copy_to_bin = ctx.files.no_copy_to_bin,
-        include_sources = ctx.attr.include_sources,
-        include_types = ctx.attr.include_types,
-        include_transitive_sources = ctx.attr.include_transitive_sources,
-        include_transitive_types = ctx.attr.include_transitive_types,
-        include_npm_sources = ctx.attr.include_npm_sources,
     ).merge(ctx.runfiles(
         files = launcher_files,
         transitive_files = transitive_launcher_files,
+    )).merge(ctx.runfiles(
+        transitive_files = gather_files_from_js_infos(
+            targets = ctx.attr.data,
+            include_sources = ctx.attr.include_sources,
+            include_types = ctx.attr.include_types,
+            include_transitive_sources = ctx.attr.include_transitive_sources,
+            include_transitive_types = ctx.attr.include_transitive_types,
+            include_npm_sources = ctx.attr.include_npm_sources,
+        ),
     ))
 
     return struct(

--- a/js/private/js_helpers.bzl
+++ b/js/private/js_helpers.bzl
@@ -117,12 +117,7 @@ def gather_runfiles(
         deps = [],
         data_files = [],
         copy_data_files_to_bin = False,
-        no_copy_to_bin = [],
-        include_sources = True,
-        include_types = False,
-        include_transitive_sources = True,
-        include_transitive_types = False,
-        include_npm_sources = True):
+        no_copy_to_bin = []):
     """Creates a runfiles object containing files in `sources`, default outputs from `data` and transitive runfiles from `data` & `deps`.
 
     As a defense in depth against `data` & `deps` targets not supplying all required runfiles, also
@@ -158,16 +153,6 @@ def gather_runfiles(
             file such as a file in an external repository. In most cases, this option is not needed.
             See `copy_data_files_to_bin` docstring for more info.
 
-        include_sources: see js_info_files documentation
-
-        include_types: see js_info_files documentation
-
-        include_transitive_sources: see js_info_files documentation
-
-        include_transitive_types: see js_info_files documentation
-
-        include_npm_sources: see js_info_files documentation
-
     Returns:
         A [runfiles](https://bazel.build/rules/lib/runfiles) object created with [ctx.runfiles](https://bazel.build/rules/lib/ctx#runfiles).
     """
@@ -181,18 +166,6 @@ def gather_runfiles(
     # Gather the default outputs of data targets
     for target in data:
         transitive_files_depsets.append(target[DefaultInfo].files)
-
-    data_deps = data + deps
-
-    # Gather files from JsInfo providers of data & deps
-    transitive_files_depsets.append(gather_files_from_js_infos(
-        targets = data_deps,
-        include_sources = include_sources,
-        include_types = include_types,
-        include_transitive_sources = include_transitive_sources,
-        include_transitive_types = include_transitive_types,
-        include_npm_sources = include_npm_sources,
-    ))
 
     # Use `data_files` as-is if `copy_data_files_to_bin` is False
     if copy_data_files_to_bin:
@@ -211,7 +184,10 @@ def gather_runfiles(
         transitive_files = depset(transitive = transitive_files_depsets),
     ).merge_all([
         target[DefaultInfo].default_runfiles
-        for target in data_deps
+        for target in data
+    ]).merge_all([
+        target[DefaultInfo].default_runfiles
+        for target in deps
     ])
 
 LOG_LEVELS = {

--- a/js/private/js_library.bzl
+++ b/js/private/js_library.bzl
@@ -240,17 +240,11 @@ def _js_library_impl(ctx):
 
     runfiles = gather_runfiles(
         ctx = ctx,
-        sources = transitive_sources,
         data = ctx.attr.data,
         deps = srcs_types_deps,
         data_files = ctx.files.data,
         copy_data_files_to_bin = ctx.attr.copy_data_to_bin,
         no_copy_to_bin = ctx.files.no_copy_to_bin,
-        include_sources = True,
-        include_types = False,
-        include_transitive_sources = True,
-        include_transitive_types = False,
-        include_npm_sources = True,
     )
 
     return [


### PR DESCRIPTION
The rules_js providers should not be destructed into generic runfiles/`DefaultInfo` until necessary such as `js_binary` preparing for executing node.

See https://github.com/aspect-build/rules_js/pull/1781 for more context.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

The `@aspect_rules_js//js:libs.bzl` `js_lib_helpers.gather_runfiles` only gathers runfiles and no longer gathers files from `JsInfo`. To gather files from `JsInfo` use `js_lib_helpers.gather_files_from_js_infos`.

As a result `js_library`, the `aspect_rules_ts` `ts_project` any similar rules using `gather_runfiles` will no longer collect `JsInfo` provider files as runfiles. It is the responsibility of a `*_binary`-like target to convert the rules_js specific `JsInfo` into generic bazel runfiles.

### Test plan

- Covered by existing test cases
