### PR TITLE
Make node 22 the default node version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -135,7 +135,7 @@ use_repo(node_dev, "node24_linux_arm64")
 use_repo(node_dev, "node24_linux_s390x")
 use_repo(node_dev, "node24_linux_ppc64le")
 use_repo(node_dev, "node24_windows_amd64")
-node_dev.toolchain(node_version = "18.20.4")
+node_dev.toolchain(node_version = "22.21.1")
 node_dev.toolchain(
     name = "node16",
     node_version = "16.20.0",
@@ -150,7 +150,7 @@ node_dev.toolchain(
 )
 node_dev.toolchain(
     name = "node22",
-    node_version = "22.20.0",
+    node_version = "22.21.1",
 )
 node_dev.toolchain(
     name = "node24",


### PR DESCRIPTION
https://nodejs.org/en/about/previous-releases says that Node 18 is already EOL and 20 will become EOL in April. So I am proposing to use Node 22 by default to not run on old and unsupported node versions in case someone does not configure their own node toolchain

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: No relevant docs found
- Breaking change (forces users to change their own code or config): Could happen if they don't declare a node toolchain.
- Suggested release notes appear below: Switch default Node toolchain from Node 18 to Node 22

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
