### PR TITLE
docs: remove references to WORKSPACE and non-bzlmod APIs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ Other recommendations:
 
 rules_js depends on rules_nodejs version 6.1.0 or greater.
 
-Installation is included in the `MODULE` or `WORKSPACE` snippet you pasted from the Installation instructions above.
+Installation is included in the `MODULE.bazel` snippet you pasted from the Installation instructions above.
 
 **API docs:**
 
@@ -70,7 +70,7 @@ $ bazel run -- @pnpm//:pnpm --dir $PWD install --lockfile-only
 ```
 
 Next, you'll typically use `npm_translate_lock` to translate the lock file to Starlark, which Bazel extensions understand.
-The `MODULE` or `WORKSPACE` snippet you pasted above already contains this code.
+The `MODULE.bazel` snippet you pasted above already contains this code.
 
 Technically, we run a port of pnpm rather than pnpm itself. Here are some design details:
 
@@ -232,7 +232,7 @@ This shows locations on disk where the npm packages can be loaded.
 
 > [!NOTE]
 > These queries only work when `generate_bzl_library_targets = True` is passed to `npm_translate_lock`.
-> If you get no results, check the settings in your `MODULE.bazel` or `WORKSPACE` file and try again.
+> If you get no results, check the settings in your `MODULE.bazel` file and try again.
 
 To see the definition of one of these targets, you can run another `bazel query`:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -74,8 +74,7 @@ use_repo(pnpm, "pnpm")
 ```
 
 This defines the `@pnpm` repository so that you can create the lockfile with
-`bazel run -- @pnpm//:pnpm --dir $PWD install --lockfile-only`, and then once the file exists you'll
-be able to add the `pnpm_translate_lock` to the `WORKSPACE` which requires the lockfile.
+`bazel run -- @pnpm//:pnpm --dir $PWD install --lockfile-only`.
 
 Consider documenting running pnpm through bazel as a good practice for your team, so that all developers run the exact same pnpm and node versions that Bazel does.
 

--- a/docs/pnpm.md
+++ b/docs/pnpm.md
@@ -33,8 +33,8 @@ For example:
 
 ```
 pnpm-lock.yaml
-WORKSPACE.bazel
-> npm_translate_lock()
+MODULE.bazel
+> npm.npm_translate_lock()
 BUILD.bazel
 > npm_link_all_packages()
 ├── A/
@@ -62,13 +62,13 @@ The `:node_modules/{package}` targets accessible to a package align with how Nod
 
 ## Using npm_translate_lock
 
-In `WORKSPACE`, call the repository rule pointing to your `pnpm-lock.yaml` file:
+In `MODULE.bazel`, use the `npm` extension pointing to your `pnpm-lock.yaml` file:
 
 ```starlark
-load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock")
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 
 # Uses the pnpm-lock.yaml file to automate creation of npm_import rules
-npm_translate_lock(
+npm.npm_translate_lock(
     # Creates a new repository named "@npm" - you could choose any name you like
     name = "npm",
     pnpm_lock = "//:pnpm-lock.yaml",
@@ -78,23 +78,11 @@ npm_translate_lock(
     # in REPO.bazel
     verify_node_modules_ignored = "//:.bazelignore",
 )
+
+use_repo(npm, "npm")
 ```
 
-You can immediately load from the generated `repositories.bzl` file in `WORKSPACE`.
-This is similar to the
-[`pip_parse`](https://github.com/bazelbuild/rules_python/blob/main/docs/pip.md#pip_parse)
-rule in rules_python for example.
-It has the advantage of also creating aliases for simpler dependencies that don't require
-spelling out the version of the packages.
-
-```starlark
-# Following our example above, we named this "npm"
-load("@npm//:repositories.bzl", "npm_repositories")
-
-npm_repositories()
-```
-
-Note that you could call `npm_translate_lock` more than once, if you have more than one pnpm workspace in your Bazel workspace.
+Note that you could call `npm.npm_translate_lock` more than once, if you have more than one pnpm workspace in your repository.
 
 If you really don't want to rely on this being generated at runtime, we have experimental support
 to check in the result instead. See [checked-in repositories.bzl](#checked-in-repositoriesbzl) below.
@@ -389,4 +377,4 @@ write_source_files(
 )
 ```
 
-Then in `WORKSPACE`, load from that checked-in copy or instruct your users to do so.
+Then in `MODULE.bazel`, load from that checked-in copy or instruct your users to do so.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,10 +109,10 @@ If the lockfile is in `some/subpkg/pnpm-lock.yaml` then `"some/subpkg"` should a
 
 For example:
 
-`WORKSPACE`
+`MODULE.bazel`
 
 ```starlark
-npm_translate_lock(
+npm.npm_translate_lock(
     ...
     public_hoist_packages = {
         "eslint-config-react-app": [""],

--- a/examples/npm_deps/BUILD.bazel
+++ b/examples/npm_deps/BUILD.bazel
@@ -92,7 +92,7 @@ js_test(
 
 #######################################
 # Use case 4: custom postinstall creates a file
-# See postinstall on @aspect-test/c in WORKSPACE
+# See lifecycle_hooks on @aspect-test/c in MODULE.bazel
 
 write_file(
     name = "write4",

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -24,8 +24,8 @@ load(":js_helpers.bzl", "LOG_LEVELS", "envs_for_log_level", "gather_runfiles")
 
 _DOC = """Execute a program in the Node.js runtime.
 
-The version of Node.js is determined by Bazel's toolchain selection. In the WORKSPACE you used
-`nodejs_register_toolchains` to provide options to Bazel. Then Bazel selects from these options
+The version of Node.js is determined by Bazel's toolchain selection. Use the `node` extension
+from `rules_nodejs` to register Node.js toolchains. Then Bazel selects from these options
 based on the requested target platform. Use the
 [`--toolchain_resolution_debug`](https://docs.bazel.build/versions/main/command-line-reference.html#flag--toolchain_resolution_debug)
 Bazel option to see more detail about the selection.
@@ -39,17 +39,17 @@ such as rules_go. See [PR #1690](https://github.com/aspect-build/rules_js/pull/1
 
 The following environment variables are made available to the Node.js runtime based on available Bazel [Make variables](https://bazel.build/reference/be/make-variables#predefined_variables):
 
-* JS_BINARY__BINDIR: the WORKSPACE-relative Bazel bin directory; equivalent to the `$(BINDIR)` Make variable of the `js_binary` target
+* JS_BINARY__BINDIR: the Bazel bin directory; equivalent to the `$(BINDIR)` Make variable of the `js_binary` target
 * JS_BINARY__COMPILATION_MODE: One of `fastbuild`, `dbg`, or `opt` as set by [`--compilation_mode`](https://bazel.build/docs/user-manual#compilation-mode); equivalent to `$(COMPILATION_MODE)` Make variable of the `js_binary` target
 * JS_BINARY__TARGET_CPU: the target cpu architecture; equivalent to `$(TARGET_CPU)` Make variable of the `js_binary` target
 
 The following environment variables are made available to the Node.js runtime based on the rule context:
 
-* JS_BINARY__BUILD_FILE_PATH: the WORKSPACE-relative path to the BUILD file of the Bazel target being run; equivalent to `ctx.build_file_path` of the `js_binary` target's rule context
+* JS_BINARY__BUILD_FILE_PATH: the path to the BUILD file of the Bazel target being run; equivalent to `ctx.build_file_path` of the `js_binary` target's rule context
 * JS_BINARY__PACKAGE: the package of the Bazel target being run; equivalent to `ctx.label.package` of the `js_binary` target's rule context
 * JS_BINARY__TARGET: the full label of the Bazel target being run; a stringified version of `ctx.label` of the `js_binary` target's rule context
 * JS_BINARY__TARGET_NAME: the name of the Bazel target being run; equivalent to `ctx.label.name` of the `js_binary` target's rule context
-* JS_BINARY__WORKSPACE: the Bazel workspace name; equivalent to `ctx.workspace_name` of the `js_binary` target's rule context
+* JS_BINARY__WORKSPACE: the Bazel repository name; equivalent to `ctx.workspace_name` of the `js_binary` target's rule context
 
 The following environment variables are made available to the Node.js runtime based the runtime environment:
 

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -52,17 +52,17 @@ def js_run_binary(
 
     The following environment variables are made available to the Node.js runtime based on available Bazel [Make variables](https://bazel.build/reference/be/make-variables#predefined_variables):
 
-    * BAZEL_BINDIR: the WORKSPACE-relative bazel bin directory; equivalent to the `$(BINDIR)` Make variable of the `js_run_binary` target
+    * BAZEL_BINDIR: the bazel bin directory; equivalent to the `$(BINDIR)` Make variable of the `js_run_binary` target
     * BAZEL_COMPILATION_MODE: One of `fastbuild`, `dbg`, or `opt` as set by [`--compilation_mode`](https://bazel.build/docs/user-manual#compilation-mode); equivalent to `$(COMPILATION_MODE)` Make variable of the `js_run_binary` target
     * BAZEL_TARGET_CPU: the target cpu architecture; equivalent to `$(TARGET_CPU)` Make variable of the `js_run_binary` target
 
     The following environment variables are made available to the Node.js runtime based on the rule context:
 
-    * BAZEL_BUILD_FILE_PATH: the WORKSPACE-relative path to the BUILD file of the bazel target being run; equivalent to `ctx.build_file_path` of the `js_run_binary` target's rule context
+    * BAZEL_BUILD_FILE_PATH: the path to the BUILD file of the bazel target being run; equivalent to `ctx.build_file_path` of the `js_run_binary` target's rule context
     * BAZEL_PACKAGE: the package of the bazel target being run; equivalent to `ctx.label.package` of the `js_run_binary` target's rule context
     * BAZEL_TARGET_NAME: the full label of the bazel target being run; a stringified version of `ctx.label` of the `js_run_binary` target's rule context
     * BAZEL_TARGET: the name of the bazel target being run; equivalent to `ctx.label.name` of the  `js_run_binary` target's rule context
-    * BAZEL_WORKSPACE: the bazel workspace name; equivalent to `ctx.workspace_name` of the `js_run_binary` target's rule context
+    * BAZEL_WORKSPACE: the bazel repository name; equivalent to `ctx.workspace_name` of the `js_run_binary` target's rule context
 
     Args:
         name: Target name
@@ -372,9 +372,7 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
         fixed_env["JS_BINARY__ALLOW_EXECROOT_ENTRY_POINT_WITH_NO_COPY_DATA_TO_BIN"] = "1"
 
     # Pass use_default_shell_env via kwargs and only if it is not None since older versions of
-    # bazel_lib run_binary don't support this attribute. We set the correct 1.x minimum for
-    # bzlmod but users could have a 2.x version < 2.4.2. For users using WORKSPACE, an older
-    # bazel_lib may sneak in since order matters for WORKSPACE deps.
+    # bazel_lib run_binary don't support this attribute.
     if use_default_shell_env != None:
         kwargs["use_default_shell_env"] = use_default_shell_env
 

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -919,7 +919,6 @@ You can create these manually if you want to have exact control.
 Bazel will only fetch the given package from an external registry if the package is
 required for the user-requested targets to be build/tested.
 
-This is a repository rule, which should be called from your `WORKSPACE` file.
 For example, in `MODULE.bazel`:
 
 ```starlark

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -195,7 +195,7 @@ Args:
 
         ```
         public_hoist_packages = {
-            "@foo/bar": [""] # link to the root package in the WORKSPACE
+            "@foo/bar": [""] # link to the root package
             "fum@0.0.1": ["some/sub/package"]
         },
         ```

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -515,7 +515,7 @@ def _collect_dep_constraints(packages, package_info):
 def _link_package(root_package, import_path, rel_path = "."):
     link_package = paths.normalize(paths.join(root_package, import_path, rel_path))
     if link_package.startswith("../"):
-        msg = "Invalid link_package outside of the WORKSPACE: {}".format(link_package)
+        msg = "Invalid link_package outside of the repository: {}".format(link_package)
         fail(msg)
     if link_package == ".":
         link_package = ""


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
