### PR TITLE
feat: upgrade rules_nodejs to 6.7, default node version to v22

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")
-bazel_dep(name = "rules_nodejs", version = "6.6.2")
+bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Ensure any version of aspect_bazel_lib used includes:
 # https://github.com/bazel-contrib/bazel-lib/commit/371362199e5e5bde58aeb15b54ea6cfb164af337

--- a/e2e/npm_link_package-esm/lib/index.mjs
+++ b/e2e/npm_link_package-esm/lib/index.mjs
@@ -1,4 +1,4 @@
-import packageJson from './package.json' assert { type: 'json' }
+import packageJson from './package.json' with { type: 'json' }
 import * as assert from 'uvu/assert'
 assert.is(2 + 2, 4)
 export const id = () =>

--- a/e2e/npm_link_package-esm/pkg/index.mjs
+++ b/e2e/npm_link_package-esm/pkg/index.mjs
@@ -1,4 +1,4 @@
-import packageJson from './package.json' assert { type: 'json' }
+import packageJson from './package.json' with { type: 'json' }
 import * as assert from 'uvu/assert'
 import * as lib from '@e2e/lib'
 assert.is(2 + 2, 4)

--- a/examples/js_binary/npm_version_test.js
+++ b/examples/js_binary/npm_version_test.js
@@ -1,4 +1,4 @@
 const assert = require('assert')
 const child_process = require('child_process')
 const npmVersion = child_process.execSync('npm --version').toString().trim()
-assert.equal(npmVersion, '10.8.2')
+assert.equal(npmVersion, '10.9.4')

--- a/examples/npm_package/packages/pkg_c/src/index.mjs
+++ b/examples/npm_package/packages/pkg_c/src/index.mjs
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import pkgC from './pkg-c.json' assert { type: 'json' }
+import pkgC from './pkg-c.json' with { type: 'json' }
 
 export default pkgC
 

--- a/js/private/test/BUILD.bazel
+++ b/js/private/test/BUILD.bazel
@@ -65,14 +65,14 @@ write_file(
     out = "binary_version.js",
     content = ["""
 if (parseInt(process.version.slice(1)) !== parseInt(process.argv[2])) {
-    throw new Error(`Expected node version ${parseInt(process.version)}.* but got ${parseInt(process.argv[2])}`)
+    throw new Error(`Expected node version ~'${process.argv[2]}' but got ${process.version}`)
 }
 """],
 )
 
 js_test(
     name = "main_default_toolchain",
-    args = ["20"],
+    args = ["22"],
     entry_point = "binary_version.js",
 )
 

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-50af5fea724651ca61d47fed08d476ab369bbdef2c24f92cab9dd9317bb52580  js/private/test/image/cksum_node.tar
+8fc69600f1f334af341785b642217395b09edd6b4f0e8032fa09693b03d21439  js/private/test/image/cksum_node.tar
 052600f3a82ab6a4cc12cab7384971c960f9c589fdbfcf21bca563c36ff7d16e  js/private/test/image/cksum_package_store_3p.tar
 bcd3826edb788a083e88ae3dbfb7fbd86bb1de8d8ef1db881b6488d63d715245  js/private/test/image/cksum_package_store_1p.tar
 febf95a6d554c9bda3f0515bfd5ef273ac67d31c231d8162beaef8c4b7bc72f3  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -14,4 +14,4 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/
--r-xr-xr-x  0 0      0    97607264 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node
+-r-xr-xr-x  0 0      0   123405064 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -13,4 +13,4 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/
--r-xr-xr-x  0 100    0    97607264 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node
+-r-xr-xr-x  0 100    0   123405064 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -13,4 +13,4 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/
--r-xr-xr-x  0 0      0    97607264 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node
+-r-xr-xr-x  0 0      0   123405064 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
@@ -14,4 +14,4 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/
--r-xr-xr-x  0 0      0    97607264 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node
+-r-xr-xr-x  0 0      0   123405064 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -14,4 +14,4 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/
--r-xr-xr-x  0 0      0    97607264 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node
+-r-xr-xr-x  0 0      0   123405064 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs~~node~nodejs_linux_amd64/bin/nodejs/bin/node


### PR DESCRIPTION
This updates the minimum for rules_js v3, including incrementing the default node version to 22.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

The default node version inherited from rules_nodejs is now `22.x`. See release notes or rules_nodejs docs for snippet to customize the default node version.

### Test plan

- Covered by existing test cases
