### PR TITLE
fix: ensure COVERAGE_DIR is writable for split coverage postprocessing

### DIFF
--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var require$$0$2 = require('path');
+var require$$0$1 = require('path');
 var require$$2$1 = require('node:url');
 var require$$1$1 = require('node:path');
-var require$$0$1 = require('fs');
+var fs = require('fs');
 var require$$4 = require('node:fs');
 var require$$5 = require('node:fs/promises');
 var require$$0 = require('node:events');
 var require$$1 = require('node:stream');
 var require$$2 = require('node:string_decoder');
 var require$$2$2 = require('util');
-var require$$0$3 = require('os');
+var require$$0$2 = require('os');
 var require$$1$2 = require('tty');
 var require$$1$3 = require('url');
-var require$$0$4 = require('assert');
+var require$$0$3 = require('assert');
 var require$$12 = require('module');
 
 var c8 = {};
@@ -4808,7 +4808,7 @@ function requireCommonjs$1 () {
 	const lru_cache_1 = /*@__PURE__*/ requireCommonjs$3();
 	const node_path_1 = require$$1$1;
 	const node_url_1 = require$$2$1;
-	const fs_1 = require$$0$1;
+	const fs_1 = fs;
 	const actualFS = __importStar(require$$4);
 	const realpathSync = fs_1.realpathSync.native;
 	// TODO: test perf of fs/promises realpath vs realpathCB,
@@ -8756,7 +8756,7 @@ function requireIsOutsideDirWin32 () {
 	if (hasRequiredIsOutsideDirWin32) return isOutsideDirWin32;
 	hasRequiredIsOutsideDirWin32 = 1;
 
-	const path = require$$0$2;
+	const path = require$$0$1;
 	const { minimatch } = requireCommonjs$4();
 
 	const dot = { dot: true, windowsPathsNoEscape: true };
@@ -8774,7 +8774,7 @@ function requireIsOutsideDirPosix () {
 	if (hasRequiredIsOutsideDirPosix) return isOutsideDirPosix;
 	hasRequiredIsOutsideDirPosix = 1;
 
-	const path = require$$0$2;
+	const path = require$$0$1;
 
 	isOutsideDirPosix = function(dir, filename) {
 	    return /^\.\./.test(path.relative(dir, filename));
@@ -8803,7 +8803,7 @@ function requireTestExclude () {
 	if (hasRequiredTestExclude) return testExclude;
 	hasRequiredTestExclude = 1;
 
-	const path = require$$0$2;
+	const path = require$$0$1;
 	const { glob } = requireCommonjs();
 	const { minimatch } = requireCommonjs$4();
 	const { defaults } = requireSchema();
@@ -10535,8 +10535,8 @@ var hasRequiredMakeDir;
 function requireMakeDir () {
 	if (hasRequiredMakeDir) return makeDir.exports;
 	hasRequiredMakeDir = 1;
-	const fs = require$$0$1;
-	const path = require$$0$2;
+	const fs$1 = fs;
+	const path = require$$0$1;
 	const {promisify} = require$$2$2;
 	const semverGte = requireGte();
 
@@ -10559,7 +10559,7 @@ function requireMakeDir () {
 	const processOptions = options => {
 		const defaults = {
 			mode: 0o777,
-			fs
+			fs: fs$1
 		};
 
 		return {
@@ -10586,7 +10586,7 @@ function requireMakeDir () {
 		const mkdir = promisify(options.fs.mkdir);
 		const stat = promisify(options.fs.stat);
 
-		if (useNativeRecursiveOption && options.fs.mkdir === fs.mkdir) {
+		if (useNativeRecursiveOption && options.fs.mkdir === fs$1.mkdir) {
 			const pth = path.resolve(input);
 
 			await mkdir(pth, {
@@ -10643,10 +10643,10 @@ function requireMakeDir () {
 		checkPath(input);
 		options = processOptions(options);
 
-		if (useNativeRecursiveOption && options.fs.mkdirSync === fs.mkdirSync) {
+		if (useNativeRecursiveOption && options.fs.mkdirSync === fs$1.mkdirSync) {
 			const pth = path.resolve(input);
 
-			fs.mkdirSync(pth, {
+			fs$1.mkdirSync(pth, {
 				mode: options.mode,
 				recursive: true
 			});
@@ -10714,7 +10714,7 @@ var hasRequiredSupportsColor;
 function requireSupportsColor () {
 	if (hasRequiredSupportsColor) return supportsColor_1;
 	hasRequiredSupportsColor = 1;
-	const os = require$$0$3;
+	const os = require$$0$2;
 	const tty = require$$1$2;
 	const hasFlag = requireHasFlag();
 
@@ -10861,8 +10861,8 @@ function requireFileWriter () {
 	 Copyright 2012-2015, Yahoo Inc.
 	 Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
 	 */
-	const path = require$$0$2;
-	const fs = require$$0$1;
+	const path = require$$0$1;
+	const fs$1 = fs;
 	const mkdirp = requireMakeDir();
 	const supportsColor = requireSupportsColor();
 
@@ -10913,11 +10913,11 @@ function requireFileWriter () {
 	    }
 
 	    write(str) {
-	        fs.writeSync(this.fd, str);
+	        fs$1.writeSync(this.fd, str);
 	    }
 
 	    close() {
-	        fs.closeSync(this.fd);
+	        fs$1.closeSync(this.fd);
 	    }
 	}
 
@@ -11018,11 +11018,11 @@ function requireFileWriter () {
 	        mkdirp.sync(path.dirname(dest));
 	        let contents;
 	        if (header) {
-	            contents = header + fs.readFileSync(source, 'utf8');
+	            contents = header + fs$1.readFileSync(source, 'utf8');
 	        } else {
-	            contents = fs.readFileSync(source);
+	            contents = fs$1.readFileSync(source);
 	        }
-	        fs.writeFileSync(dest, contents);
+	        fs$1.writeFileSync(dest, contents);
 	    }
 
 	    /**
@@ -11040,7 +11040,7 @@ function requireFileWriter () {
 	        }
 	        file = path.resolve(this.baseDir, file);
 	        mkdirp.sync(path.dirname(file));
-	        return new FileContentWriter(fs.openSync(file, 'w'));
+	        return new FileContentWriter(fs$1.openSync(file, 'w'));
 	    }
 	}
 
@@ -11327,7 +11327,7 @@ function requirePath () {
 	if (hasRequiredPath) return path_1;
 	hasRequiredPath = 1;
 
-	const path = require$$0$2;
+	const path = require$$0$1;
 	let parsePath = path.parse;
 	let SEP = path.sep;
 	const origParser = parsePath;
@@ -11796,7 +11796,7 @@ function requireContext () {
 	 Copyright 2012-2015, Yahoo Inc.
 	 Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
 	 */
-	const fs = require$$0$1;
+	const fs$1 = fs;
 	const FileWriter = requireFileWriter();
 	const XMLWriter = requireXmlWriter();
 	const tree = requireTree();
@@ -11805,7 +11805,7 @@ function requireContext () {
 
 	function defaultSourceLookup(path) {
 	    try {
-	        return fs.readFileSync(path, 'utf8');
+	        return fs$1.readFileSync(path, 'utf8');
 	    } catch (ex) {
 	        throw new Error(`Unable to lookup source: ${path} (${ex.message})`);
 	    }
@@ -12038,7 +12038,7 @@ function requireLcovonly () {
 	        const branches = fc.b;
 	        const branchMap = fc.branchMap;
 	        const summary = node.getCoverageSummary();
-	        const path = require$$0$2;
+	        const path = require$$0$1;
 
 	        writer.println('TN:');
 	        const fileName = path.relative(this.projectRoot, fc.path);
@@ -12149,7 +12149,7 @@ function requireSourceMapFromFile () {
 	// https://github.com/nodejs/node/blob/master/lib/internal/source_map/source_map_cache.js
 	// we should to upstream and downstream fixes.
 
-	const { readFileSync } = require$$0$1;
+	const { readFileSync } = fs;
 	const { fileURLToPath, pathToFileURL } = require$$1$3;
 	const util = require$$2$2;
 	const debuglog = util.debuglog('c8');
@@ -14189,18 +14189,18 @@ var hasRequiredV8ToIstanbul$1;
 function requireV8ToIstanbul$1 () {
 	if (hasRequiredV8ToIstanbul$1) return v8ToIstanbul$1;
 	hasRequiredV8ToIstanbul$1 = 1;
-	const assert = require$$0$4;
+	const assert = require$$0$3;
 	const convertSourceMap = requireConvertSourceMap();
 	const util = require$$2$2;
 	const debuglog = util.debuglog('c8');
-	const { dirname, isAbsolute, join, resolve } = require$$0$2;
+	const { dirname, isAbsolute, join, resolve } = require$$0$1;
 	const { fileURLToPath } = require$$1$3;
 	const CovBranch = requireBranch();
 	const CovFunction = require_function();
 	const CovSource = requireSource();
 	const { sliceRange } = requireRange();
 	const compatError = Error(`requires Node.js ${require$$9.engines.node}`);
-	const { readFileSync } = require$$0$1;
+	const { readFileSync } = fs;
 	let readFile = () => { throw compatError };
 	try {
 	  readFile = require('fs').promises.readFile;
@@ -15519,10 +15519,10 @@ function requireReport () {
 	try {
 	  ;({ readFile } = require('fs/promises'));
 	} catch (err) {
-({ readFile } = require$$0$1.promises);
+({ readFile } = fs.promises);
 	}
-	const { readdirSync, readFileSync, statSync } = require$$0$1;
-	const { isAbsolute, resolve, extname } = require$$0$2;
+	const { readdirSync, readFileSync, statSync } = fs;
+	const { isAbsolute, resolve, extname } = require$$0$1;
 	const { pathToFileURL, fileURLToPath } = require$$1$3;
 	const getSourceMapFromFile = requireSourceMapFromFile();
 	// TODO: switch back to @c88/v8-coverage once patch is landed.
@@ -16070,7 +16070,7 @@ var c8Exports = requireC8();
 // bazel will create the COVERAGE_OUTPUT_FILE whilst setting up the sandbox.
 // therefore, should be doing a file size check rather than presence.
 try {
-    const stats = require$$0$1.statSync(process.env.COVERAGE_OUTPUT_FILE);
+    const stats = fs.statSync(process.env.COVERAGE_OUTPUT_FILE);
     if (stats.size != 0) {
         // early exit here does not affect the outcome of the tests.
         // bazel will only execute _lcov_merger when tests pass.
@@ -16079,7 +16079,25 @@ try {
     // in case file doesn't exist or some other error is thrown, just ignore it.
 } catch {}
 
-const include = require$$0$1
+// When --experimental_split_coverage_postprocessing is enabled, Bazel runs
+// coverage post-processing as a separate action. The COVERAGE_DIR may have been
+// created by a previous action with restrictive permissions. Ensure we can write
+// to it by making the directory writable.
+try {
+    const coverageDir = process.env.COVERAGE_DIR;
+    if (coverageDir) {
+        const stats = fs.statSync(coverageDir, { throwIfNoEntry: false });
+        // Check if directory exists and is not writable by owner
+        if (stats && (stats.mode & 0o200) === 0) {
+            fs.chmodSync(coverageDir, stats.mode | 0o200);
+        }
+    }
+} catch {
+    // Ignore errors - if we can't fix permissions, the write will fail with
+    // a more descriptive error message below
+}
+
+const include = fs
     .readFileSync(process.env.COVERAGE_MANIFEST)
     .toString('utf8')
     .split('\n')
@@ -16087,7 +16105,7 @@ const include = require$$0$1
 
 // TODO: can or should we instrument files from other repositories as well?
 // if so then the path.join call below will yield invalid paths since files will have external/wksp as their prefix.
-const pwd = require$$0$2.join(process.env.RUNFILES, process.env.TEST_WORKSPACE);
+const pwd = require$$0$1.join(process.env.RUNFILES, process.env.TEST_WORKSPACE);
 process.chdir(pwd);
 
 new c8Exports.Report({
@@ -16102,8 +16120,8 @@ new c8Exports.Report({
 })
     .run()
     .then(() => {
-        require$$0$1.renameSync(
-            require$$0$2.join(process.env.COVERAGE_DIR, 'lcov.info'),
+        fs.renameSync(
+            require$$0$1.join(process.env.COVERAGE_DIR, 'lcov.info'),
             process.env.COVERAGE_OUTPUT_FILE
         );
     })


### PR DESCRIPTION
When Bazel's --experimental_split_coverage_postprocessing flag is enabled,
   coverage post-processing runs as a separate action from the test execution.
   The COVERAGE_DIR directory may be created by a previous action with
   restrictive permissions (read-only), causing the coverage merger to fail
   with EACCES (permission denied) when attempting to write lcov.info.

---

### Changes are visible to end-users: yes

   This fix checks if COVERAGE_DIR exists and ensures it has write permissions
   before the coverage report attempts to write to it.

```
Error: EACCES: permission denied, open '/home/runner/.cache/bazel/_bazel_runner/be54bd8ac890d1817c772d91eb8f6cb4/execroot/_main/bazel-out/k8-fastbuild/testlogs/types/test/index.spec/_coverage/lcov.info'
    at Object.openSync (node:fs:561:18)
    at FileWriter.writeFile (/home/runner/.cache/bazel/_bazel_runner/be54bd8ac890d1817c772d91eb8f6cb4/external/aspect_rules_js+/js/private/coverage/coverage.js:11043:42)
    at LcovOnlyReport.onStart (/home/runner/.cache/bazel/_bazel_runner/be54bd8ac890d1817c772d91eb8f6cb4/external/aspect_rules_js+/js/private/coverage/coverage.js:12029:46)
    at Visitor.value (/home/runner/.cache/bazel/_bazel_runner/be54bd8ac890d1817c772d91eb8f6cb4/external/aspect_rules_js+/js/private/coverage/coverage.js:11192:39)
    at ReportTree.visit (/home/runner/.cache/bazel/_bazel_runner/be54bd8ac890d1817c772d91eb8f6cb4/external/aspect_rules_js+/js/private/coverage/coverage.js:11280:18)
    at LcovOnlyReport.execute (/home/runner/.cache/bazel/_bazel_runner/be54bd8ac890d1817c772d91eb8f6cb4/external/aspect_rules_js+/js/private/coverage/coverage.js:11945:45)
    at Report.run (/home/runner/.cache/bazel/_bazel_runner/be54bd8ac890d1817c772d91eb8f6cb4/external/aspect_rules_js+/js/private/coverage/coverage.js:15606:11) {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/home/runner/.cache/bazel/_bazel_runner/be54bd8ac890d1817c772d91eb8f6cb4/execroot/_main/bazel-out/k8-fastbuild/testlogs/types/test/index.spec/_coverage/lcov.info'
}
```

### Test plan

<!-- Delete any which do not apply -->

- Manual testing; please provide instructions so we can reproduce:
1. Enable on `--experimental_split_coverage_postprocessing`
2. Build using `bazel build --config=coverage`
3. Run a js_test with `bazel coverage //...`


### Related

Had to disable the flag to use js_test... https://github.com/cloudflare/workerd/pull/5881/changes/16fa7f2fcfe07166b1d44071c6229fdbec8d15dd