### PR TITLE
fix: return full label paths from npm_link_targets

### DIFF
--- a/e2e/npm_translate_lock_disable_hooks/snapshots/defs.bzl
+++ b/e2e/npm_translate_lock_disable_hooks/snapshots/defs.bzl
@@ -78,4 +78,4 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
     if bazel_package == "":
         if prod:
             link_targets.extend([":node_modules/@aspect-test/c"])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]

--- a/e2e/npm_translate_lock_empty/snapshots/npm_defs.bzl
+++ b/e2e/npm_translate_lock_empty/snapshots/npm_defs.bzl
@@ -70,4 +70,4 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     link_targets = []
 
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]

--- a/e2e/npm_translate_lock_replace_packages/snapshots/npm_defs.bzl
+++ b/e2e/npm_translate_lock_replace_packages/snapshots/npm_defs.bzl
@@ -84,4 +84,4 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/chalk",
                 ":node_modules/lodash",
             ])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]

--- a/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
@@ -718,7 +718,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/@scoped/a",
                 ":node_modules/@scoped/b",
             ])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -718,7 +718,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/@scoped/a",
                 ":node_modules/@scoped/b",
             ])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -350,7 +350,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/@lib/b",
                 ":node_modules/@lib/b_alias",
             ])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
 # buildifier: disable=function-docstring

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -350,7 +350,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/@lib/b",
                 ":node_modules/@lib/b_alias",
             ])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package
 # buildifier: disable=function-docstring

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -552,7 +552,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 targets = starlark_codegen_utils.to_list_attr(lists["dev"], 3, 4, quote_value = False),
             ))
         first_link = False
-    npm_link_targets_bzl.append("""    return link_targets""")
+    npm_link_targets_bzl.append("""    return ["//%s%s" % (bazel_package, target) for target in link_targets]""")
     return npm_link_targets_bzl
 
 def _generate_npm_visibility_config(package_visibility_attr):

--- a/npm/private/npm_translate_lock_generate.docs.bzl
+++ b/npm/private/npm_translate_lock_generate.docs.bzl
@@ -18,7 +18,7 @@ load("@npm//:defs.bzl", "npm_link_targets", "npm_link_all_packages")
 
 # buildifier: disable=unused-variable
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
-    """Generated list of target names that are linked by npm_link_all_packages()
+    """Generated list of target labels that are linked by npm_link_all_packages()
 
     Args:
         name: name of catch all target to generate for all packages linked
@@ -35,7 +35,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
             Default True includes development dependencies.
 
     Returns:
-        A list of target names that are linked by npm_link_all_packages()
+        A list of target labels (full package labels) that are linked by npm_link_all_packages()
     """
     pass
 

--- a/npm/private/test/snapshots/npm_defs-no_dev.bzl
+++ b/npm/private/test/snapshots/npm_defs-no_dev.bzl
@@ -3004,7 +3004,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/@mycorp/pkg-b",
                 ":node_modules/@mycorp/pkg-d",
             ])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "js_lib_pkg_a" package
 # buildifier: disable=function-docstring

--- a/npm/private/test/snapshots/npm_defs-no_optional.bzl
+++ b/npm/private/test/snapshots/npm_defs-no_optional.bzl
@@ -3017,7 +3017,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/@mycorp/pkg-d",
                 ":node_modules/@mycorp/pkg-b",
             ])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-a" package
 # buildifier: disable=function-docstring

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -3509,7 +3509,7 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
                 ":node_modules/@mycorp/pkg-d",
                 ":node_modules/@mycorp/pkg-b",
             ])
-    return link_targets
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@mycorp/pkg-a" package
 # buildifier: disable=function-docstring


### PR DESCRIPTION
Fix #2417

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
