### PR TITLE
refactor: directly use tar.bzl module (#2460)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,7 @@ bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "rules_nodejs", version = "6.3.0")
+bazel_dep(name = "tar.bzl", version = "0.5.5")
 bazel_dep(name = "yq.bzl", version = "0.3.2")
 
 tel = use_extension("@aspect_tools_telemetry//:extension.bzl", "telemetry")
@@ -36,16 +37,8 @@ pnpm.pnpm(name = "pnpm")
 use_repo(pnpm, "pnpm", "pnpm__links")
 
 bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
-bazel_lib_toolchains.tar()
 use_repo(
     bazel_lib_toolchains,
-    "bsd_tar_darwin_amd64",
-    "bsd_tar_darwin_arm64",
-    "bsd_tar_linux_amd64",
-    "bsd_tar_linux_arm64",
-    "bsd_tar_toolchains",
-    "bsd_tar_windows_amd64",
-    "bsd_tar_windows_arm64",
     "coreutils_toolchains",
 )
 
@@ -59,6 +52,18 @@ use_repo(
     "yq_linux_ppc64le",
     "yq_linux_s390x",
     "yq_windows_amd64",
+)
+
+tar_toolchains = use_extension("@tar.bzl//tar:extensions.bzl", "toolchains")
+use_repo(
+    tar_toolchains,
+    "bsd_tar_toolchains",
+    "bsd_tar_toolchains_darwin_amd64",
+    "bsd_tar_toolchains_darwin_arm64",
+    "bsd_tar_toolchains_linux_amd64",
+    "bsd_tar_toolchains_linux_arm64",
+    "bsd_tar_toolchains_windows_amd64",
+    "bsd_tar_toolchains_windows_arm64",
 )
 
 ####### Dev dependencies ########

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -100,7 +100,7 @@ bzl_library(
     name = "js_image_layer",
     srcs = ["js_image_layer.bzl"],
     deps = [
-        "@aspect_bazel_lib//lib:tar",
         "@bazel_skylib//lib:paths",
+        "@tar.bzl//tar",
     ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
 )

--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -13,8 +13,8 @@ js_image_layer(
 ```
 """
 
-load("@aspect_bazel_lib//lib:tar.bzl", "tar_lib")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@tar.bzl//tar:tar.bzl", "tar_lib")
 
 _DEFAULT_LAYER_GROUPS = {
     "node": "/js/private/node-patches/|/bin/nodejs/",
@@ -594,7 +594,7 @@ def _js_image_layer_impl(ctx):
             outputs = [output],
             mnemonic = "JsImageLayer",
             progress_message = "JsImageLayer " + typ + " %{label}",
-            toolchain = "@aspect_bazel_lib//lib:tar_toolchain_type",
+            toolchain = tar_lib.toolchain_type,
         )
 
     return [

--- a/js/toolchains.bzl
+++ b/js/toolchains.bzl
@@ -7,10 +7,10 @@ load(
     _register_copy_to_directory_toolchains = "register_copy_to_directory_toolchains",
     _register_coreutils_toolchains = "register_coreutils_toolchains",
     _register_jq_toolchains = "register_jq_toolchains",
-    _register_tar_toolchains = "register_tar_toolchains",
     _register_yq_toolchains = "register_yq_toolchains",
 )
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains", _DEFAULT_NODE_REPOSITORY = "DEFAULT_NODE_REPOSITORY", _DEFAULT_NODE_VERSION = "DEFAULT_NODE_VERSION")
+load("@tar.bzl//tar:extensions.bzl", _tar_create_repositories = "create_repositories")
 
 DEFAULT_NODE_REPOSITORY = _DEFAULT_NODE_REPOSITORY
 DEFAULT_NODE_VERSION = _DEFAULT_NODE_VERSION
@@ -69,7 +69,8 @@ def rules_js_register_toolchains(
     if kwargs.pop("register_jq_toolchain", True) and not native.existing_rule("jq_toolchains"):
         _register_jq_toolchains()
     if kwargs.pop("register_tar_toolchain", True) and not native.existing_rule("tar_toolchains"):
-        _register_tar_toolchains()
+        _tar_create_repositories()
+        native.register_toolchains("@bsd_tar_toolchains//:all")
     if kwargs.pop("register_yq_toolchain", True) and not native.existing_rule("yq_toolchains"):
         _register_yq_toolchains()
     if kwargs.pop("register_nodejs_toolchain", True) and not native.existing_rule("{}_toolchains".format(DEFAULT_NODE_REPOSITORY)):

--- a/npm/private/BUILD.bazel
+++ b/npm/private/BUILD.bazel
@@ -67,6 +67,7 @@ bzl_library(
         "//js:providers",
         "@aspect_bazel_lib//lib:copy_directory",
         "@bazel_skylib//lib:paths",
+        "@tar.bzl//tar",
     ],
 )
 

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -580,7 +580,7 @@ def _download_and_extract_archive(rctx, package_json_only):
             exclude_pattern_args.append("--exclude")
             exclude_pattern_args.append(pattern)
 
-    tar = Label("@bsd_tar_{}//:tar{}".format(repo_utils.platform(rctx), ".exe" if is_windows else ""))
+    tar = Label("@bsd_tar_toolchains_{}//:tar{}".format(repo_utils.platform(rctx), ".exe" if is_windows else ""))
 
     # npm packages are always published with one top-level directory inside the tarball, tho the name is not predictable
     # so we use tar here which takes a --strip-components N argument instead of rctx.download_and_extract

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -1,6 +1,7 @@
 "npm_package_store rule"
 
 load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory_bin_action")
+load("@tar.bzl//tar:tar.bzl", "tar_lib")
 
 # buildifier: disable=bzl-visibility
 load("//js/private:js_info.bzl", "JsInfo", "js_info")
@@ -229,7 +230,7 @@ def _npm_package_store_impl(ctx):
                 # tho the name is not predictable we can use the --strip-components 1 argument with
                 # tar to strip one directory level. Some packages have directory permissions missing
                 # executable which make the directories not listable (pngjs@5.0.0 for example).
-                bsdtar = ctx.toolchains["@aspect_bazel_lib//lib:tar_toolchain_type"]
+                bsdtar = ctx.toolchains[tar_lib.toolchain_type]
 
                 args = ctx.actions.args()
                 args.add("--extract")
@@ -440,7 +441,7 @@ npm_package_store_lib = struct(
     provides = [DefaultInfo, NpmPackageStoreInfo],
     toolchains = [
         Label("@aspect_bazel_lib//lib:copy_directory_toolchain_type"),
-        Label("@aspect_bazel_lib//lib:tar_toolchain_type"),
+        tar_lib.toolchain_type,
     ],
 )
 


### PR DESCRIPTION
Cherry-pick into 2.x

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
