### PR TITLE
fix: crash when printing .bazelignore error message with bazel8

### DIFF
--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -569,7 +569,7 @@ Possible fixes:
                 """.format(
                 fixes = "\n".join(missing_ignores),
                 bazelignore = attr.verify_node_modules_ignored,
-                repo = rctx.name,
+                repo = attr.name,
             )
             fail(msg)
 


### PR DESCRIPTION
Fix #2685

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: remove an entry in `.bazelignore` and ensure the correct error message is outputted
