### PR TITLE
chore: update ci bazel9 testing 9.0.0

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -151,7 +151,7 @@ tasks:
           bazel:
               flags: ['--test_tag_filters=-skip-on-bazel9']
           env:
-              USE_BAZEL_VERSION: '9.*'
+              USE_BAZEL_VERSION: '9.x'
     - format:
           queue: aspect-medium
     - buildifier:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
     module_path: 'e2e/bzlmod'
     matrix:
-        bazel: ['7.x', '8.x', '9.*']
+        bazel: ['7.x', '8.x', '9.x']
         platform: ['debian10', 'macos', 'ubuntu2004', 'windows']
     tasks:
         run_tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
                   a=(
                     "major:$m, version:\"$v\""
                     "major:8, version:\"8.1.1\""
-                    "major:9, version:\"9.0.0rc5\""
+                    "major:9, version:\"9.0.0\""
                   )
                   printf -v j '{%s},' "${a[@]}"
                   echo "res=[${j%,}]" | tee -a $GITHUB_OUTPUT
@@ -208,7 +208,6 @@ jobs:
                     test \
                     --config=local \
                     --config=ci \
-                    --incompatible_merge_fixed_and_default_shell_env \
                     --test_tag_filters=-skip-on-bazel${{ matrix.bazel-version.major }} \
                     --build_tag_filters=-skip-on-bazel${{ matrix.bazel-version.major }} \
                     //...
@@ -247,7 +246,6 @@ jobs:
                     coverage \
                     --config=local \
                     --config=ci \
-                    --incompatible_merge_fixed_and_default_shell_env \
                     --test_tag_filters=-skip-on-bazel${{ matrix.bazel-version.major }} \
                     --build_tag_filters=-skip-on-bazel${{ matrix.bazel-version.major }} \
                     --instrument_test_targets \


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
