### PR TITLE
feat: support reproducible pnpm downloads using bazel facts api

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -358,8 +358,15 @@ def _pnpm_extension_impl(module_ctx):
         pnpm_repository(
             name = name,
             pnpm_version = pnpm["version"],
+            integrity = pnpm["integrity"],
             include_npm = pnpm["include_npm"],
         )
+
+    kwargs = {}
+    if resolved.facts:
+        kwargs["facts"] = resolved.facts
+
+    return module_ctx.extension_metadata(reproducible = True, **kwargs)
 
 pnpm = module_extension(
     implementation = _pnpm_extension_impl,

--- a/npm/private/pnpm_repository.bzl
+++ b/npm/private/pnpm_repository.bzl
@@ -10,7 +10,7 @@ LATEST_PNPM_VERSION = PNPM_VERSIONS.keys()[-1]
 # Default to the latest pnpm v10
 DEFAULT_PNPM_VERSION = [v for v in PNPM_VERSIONS.keys() if v.startswith("10")][-1]
 
-def pnpm_repository(name, pnpm_version = DEFAULT_PNPM_VERSION, include_npm = False, integrity = None):
+def pnpm_repository(name, pnpm_version, include_npm, integrity):
     """Import https://npmjs.com/package/pnpm and provide a js_binary to run the tool.
 
     Useful as a way to run exactly the same pnpm as Bazel does, for example with:
@@ -22,43 +22,39 @@ def pnpm_repository(name, pnpm_version = DEFAULT_PNPM_VERSION, include_npm = Fal
 
             May also be a tuple of (version, integrity) where the integrity value may be fetched like:
             `curl --silent https://registry.npmjs.org/pnpm | jq '.versions["8.6.11"].dist.integrity'`
-        integrity: optional integrity hash for the pnpm version, if not provided it will be
-            looked up in PNPM_VERSIONS defined in versions.bzl
+        integrity: integrity hash for the pnpm version (optional)
         include_npm: if True, include the npm package along with pnpm binary
     """
 
-    if not native.existing_rule(name):
-        if not integrity:
-            integrity = PNPM_VERSIONS.get(pnpm_version, None)
-            if not integrity:
-                fail("Unknown pnpm version {}, please provide an integrity hash".format(pnpm_version))
+    if native.existing_rule(name):
+        fail("Repository with name '{}' already exists".format(name))
 
-        key = "{}@{}".format("pnpm", pnpm_version)
+    key = "{}@{}".format("pnpm", pnpm_version)
 
-        _npm_import_rule(
-            name = name,
-            key = key,
-            integrity = integrity,
-            package = "pnpm",
-            root_package = "",
-            version = pnpm_version,
-            extra_build_content = "\n".join([
-                """load("@aspect_rules_js//js:defs.bzl", "js_binary")""",
-                """js_binary(
+    _npm_import_rule(
+        name = name,
+        key = key,
+        integrity = integrity,
+        package = "pnpm",
+        root_package = "",
+        version = pnpm_version,
+        extra_build_content = "\n".join([
+            """load("@aspect_rules_js//js:defs.bzl", "js_binary")""",
+            """js_binary(
     name = "pnpm",
     data = glob(["package/**"]),
     entry_point = "package/dist/pnpm.cjs",
     include_npm = {include_npm},
     visibility = ["//visibility:public"],
 )""".format(include_npm = include_npm),
-            ]),
-            extract_full_archive = True,
-        )
+        ]),
+        extract_full_archive = True,
+    )
 
-        _npm_import_links_rule(
-            name = "{}{}".format(name, utils.links_repo_suffix),
-            key = key,
-            package = "pnpm",
-            root_package = "",
-            version = pnpm_version,
-        )
+    _npm_import_links_rule(
+        name = "{}{}".format(name, utils.links_repo_suffix),
+        key = key,
+        package = "pnpm",
+        root_package = "",
+        version = pnpm_version,
+    )

--- a/npm/private/test/pnpm_test.bzl
+++ b/npm/private/test/pnpm_test.bzl
@@ -26,6 +26,7 @@ def _resolve_test(ctx, repositories = [], notes = [], modules = [], package_json
     expected = struct(
         repositories = repositories,
         notes = notes,
+        facts = None,
     )
 
     result = resolve_pnpm_repositories(struct(modules = modules, read = lambda f: package_json_content))
@@ -77,7 +78,7 @@ def _override(ctx):
     # What happens when the root overrides the pnpm version.
     return _resolve_test(
         ctx,
-        repositories = {"pnpm": {"version": "9.1.0", "integrity": None, "include_npm": False}},
+        repositories = {"pnpm": {"version": "9.1.0", "integrity": "sha512-Z/WHmRapKT5c8FnCOFPVcb6vT3U8cH9AyyK+1fsVeMaq07bEEHzLO6CzW+AD62IaFkcayDbIe+tT+dVLtGEnJA==", "include_npm": False}},
         notes = [],
         modules = [
             _fake_mod(
@@ -104,7 +105,7 @@ def _latest(ctx):
     # - Accept a brittle test.
     return _resolve_test(
         ctx,
-        repositories = {"pnpm": {"version": LATEST_PNPM_VERSION, "integrity": None, "include_npm": False}},
+        repositories = {"pnpm": {"version": LATEST_PNPM_VERSION, "integrity": "sha512-fX27yp6ZRHt8O/enMoavqva+mSUeuUmLrvp9QGiS9nuHmts6HX5of8TMwaOIxxdfuq5WeiarRNEGe1T8sNajFg==", "include_npm": False}},
         modules = [
             _fake_mod(True, _fake_pnpm_tag(version = "latest")),
         ],
@@ -114,8 +115,8 @@ def _include_npm(ctx):
     return _resolve_test(
         ctx,
         repositories = {
-            "pnpm": {"version": "9.1.0", "integrity": None, "include_npm": True},
-            "wnpm": {"version": "9.2.0", "integrity": None, "include_npm": True},
+            "pnpm": {"version": "9.1.0", "integrity": "sha512-Z/WHmRapKT5c8FnCOFPVcb6vT3U8cH9AyyK+1fsVeMaq07bEEHzLO6CzW+AD62IaFkcayDbIe+tT+dVLtGEnJA==", "include_npm": True},
+            "wnpm": {"version": "9.2.0", "integrity": "sha512-mKgP0RwucJZ0d2IwQQZDKz3cZ9z1S1qMAck/aKLNXgXmghhJUioG+3YoTUGiZg1eM08u47vykYO/LnObHa+ncQ==", "include_npm": True},
         },
         modules = [
             _fake_mod(True, _fake_pnpm_tag(version = "9.1.0", include_npm = True)),
@@ -128,7 +129,7 @@ def _custom_name(ctx):
     return _resolve_test(
         ctx,
         repositories = {
-            "my-pnpm": {"version": "9.1.0", "integrity": None, "include_npm": False},
+            "my-pnpm": {"version": "9.1.0", "integrity": "sha512-Z/WHmRapKT5c8FnCOFPVcb6vT3U8cH9AyyK+1fsVeMaq07bEEHzLO6CzW+AD62IaFkcayDbIe+tT+dVLtGEnJA==", "include_npm": False},
             "pnpm": {"version": "8.6.7", "integrity": "8.6.7-integrity", "include_npm": False},
         },
         modules = [


### PR DESCRIPTION
Close #2695

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

PNPM versions not known to rules_js may now be used without manually specifying integrity hashes by using the Bazel 9 [facts API](https://bazel.build/rules/lib/builtins/module_ctx#facts) to fetch+persist pnpm integrity hashes in the MODULE lock file.

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce: when using bazel9, update MODULE.bazel to use a `pnpm_version` not specified in `npm/private/versions.bzl`
