### PR TITLE
fix: add check to ensure home npmrc exists in module extension

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -123,11 +123,12 @@ def _npm_translate_lock_bzlmod(module_ctx, attr, exclude_package_contents_config
         home_directory = repo_utils.get_home_directory(module_ctx)
         if home_directory:
             home_npmrc_path = "{}/{}".format(home_directory, ".npmrc")
-            home_npmrc = parse_npmrc(module_ctx.read(home_npmrc_path))
+            if module_ctx.path(home_npmrc_path).exists:
+                home_npmrc = parse_npmrc(module_ctx.read(home_npmrc_path))
 
-            (registries2, npm_auth2) = npm_translate_lock_helpers.get_npm_auth(home_npmrc, home_npmrc_path, module_ctx)
-            registries.update(registries2)
-            npm_auth.update(npm_auth2)
+                (registries2, npm_auth2) = npm_translate_lock_helpers.get_npm_auth(home_npmrc, home_npmrc_path, module_ctx)
+                registries.update(registries2)
+                npm_auth.update(npm_auth2)
         else:
             # buildifier: disable=print
             print("""


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_js/issues/2068

More detail there but when we want to use `~/.npmrc` for using credentials for private npm repos, bazel build fails with bzlmod even when don't build any JS package because the module extension tries to eagerly read the `~/.npmrc` which may not exist on all machines. This replicates the same behavior that exists with WORKSPACE so that the file is read only if it exists. I used `module_ctx.path` here as it seems to work for absolute system paths too (although it is not documented in bazel docs).

### Test plan

this patch works in our internal repo. I also did manual testing with one of the examples in `e2e`. Before this change and adding `use_home_npmrc` in the module extension
```
npm.npm_translate_lock(
    name = "npm",
    data = ["//:package.json"],
    npmrc = "//:.npmrc",
    pnpm_lock = "//:pnpm-lock.yaml",
    use_home_npmrc = True,
    update_pnpm_lock = True,
    verify_node_modules_ignored = "//:.bazelignore",
)
```

```
npm_translate_lock git:(main) ✗ bazel query //...
INFO: Invocation ID: 905153da-591c-4604-9784-522087e2ed33
ERROR: /home/owner/.cache/bazel/_bazel_owner/ea1866dc89f57aaaf8a3c2a396a9c5d2/external/aspect_rules_js~/npm/extensions.bzl:126:53: Traceback (most recent call last):
        File "/home/owner/.cache/bazel/_bazel_owner/ea1866dc89f57aaaf8a3c2a396a9c5d2/external/aspect_rules_js~/npm/extensions.bzl", line 64, column 39, in _npm_extension_impl
                _npm_translate_lock_bzlmod(module_ctx, attr, exclude_package_contents_config, replace_packages)
        File "/home/owner/.cache/bazel/_bazel_owner/ea1866dc89f57aaaf8a3c2a396a9c5d2/external/aspect_rules_js~/npm/extensions.bzl", line 126, column 53, in _npm_translate_lock_bzlmod
                home_npmrc = parse_npmrc(module_ctx.read(home_npmrc_path))
Error in read: java.io.FileNotFoundException: /home/owner/.npmrc (No such file or directory)
ERROR: Target parsing failed due to unexpected exception: error evaluating module extension npm in @@aspect_rules_js~//npm:extensions.bzl
Loading: 0 packages loaded
    currently loading: 
    Fetching module extension npm in @@aspect_rules_js~//npm:extensions.bzl; Generating starlark for npm dependencies
```

after this change, it successfully runs.
