### PR TITLE
Revert "fix: produce starlark_doc_extract rules for public API"

### DIFF
--- a/contrib/nextjs/BUILD.bazel
+++ b/contrib/nextjs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -17,4 +17,10 @@ bzl_library(
         "@bazel_lib//lib:copy_to_directory",
         "@bazel_lib//lib:directory_path",
     ],
+)
+
+starlark_doc_extract(
+    name = "defs.doc_extract",
+    src = "defs.bzl",
+    deps = [":defs"],
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -331,7 +331,7 @@ Continuing our example, where we wrote a macro in `tsc.bzl`, we'd write this to 
 
 ```starlark
 load("@bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
     name = "tsc",

--- a/examples/js_library/two/BUILD.bazel
+++ b/examples/js_library/two/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_test")
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":tsc.bzl", "tsc")
 
 tsc(

--- a/examples/macro/BUILD.bazel
+++ b/examples/macro/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//examples/macro:mocha.bzl", "mocha_test")
 

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -1,6 +1,6 @@
 "Public API"
 
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
     glob(["*.bzl"]),

--- a/js/private/BUILD.bazel
+++ b/js/private/BUILD.bazel
@@ -1,6 +1,6 @@
 "Internal implementation details"
 
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,6 +24,12 @@ bzl_library(
     ],
 )
 
+starlark_doc_extract(
+    name = "js_info_files.doc_extract",
+    src = "js_info_files.bzl",
+    deps = [":js_info_files"],
+)
+
 bzl_library(
     name = "js_binary",
     srcs = ["js_binary.bzl"],
@@ -38,6 +44,12 @@ bzl_library(
         "@bazel_skylib//lib:dicts",
         "@bazel_tools//tools/build_defs/repo:cache.bzl",
     ],
+)
+
+starlark_doc_extract(
+    name = "js_binary.doc_extract",
+    src = "js_binary.bzl",
+    deps = [":js_binary"],
 )
 
 bzl_library(
@@ -62,6 +74,12 @@ bzl_library(
     ],
 )
 
+starlark_doc_extract(
+    name = "js_library.doc_extract",
+    src = "js_library.bzl",
+    deps = [":js_library"],
+)
+
 bzl_library(
     name = "js_run_binary",
     srcs = ["js_run_binary.bzl"],
@@ -75,6 +93,12 @@ bzl_library(
     ],
 )
 
+starlark_doc_extract(
+    name = "js_run_binary.doc_extract",
+    src = "js_run_binary.bzl",
+    deps = [":js_run_binary"],
+)
+
 bzl_library(
     name = "js_run_devserver",
     srcs = ["js_run_devserver.bzl"],
@@ -84,6 +108,13 @@ bzl_library(
         "@bazel_skylib//lib:dicts",
         "@bazel_tools//tools/build_defs/repo:cache.bzl",
     ],
+)
+
+starlark_doc_extract(
+    name = "js_run_devserver.doc_extract",
+    src = "js_run_devserver.bzl",
+    symbol_names = ["js_run_devserver"],
+    deps = [":js_run_devserver"],
 )
 
 bzl_library(
@@ -106,4 +137,10 @@ bzl_library(
         "@bazel_tools//tools/build_defs/repo:cache.bzl",
         "@tar.bzl//tar",
     ],
+)
+
+starlark_doc_extract(
+    name = "js_image_layer.doc_extract",
+    src = "js_image_layer.bzl",
+    deps = [":js_image_layer"],
 )

--- a/npm/BUILD.bazel
+++ b/npm/BUILD.bazel
@@ -1,6 +1,6 @@
 "Public API"
 
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
     glob(["*.bzl"]),

--- a/npm/private/BUILD.bazel
+++ b/npm/private/BUILD.bazel
@@ -1,8 +1,8 @@
 "Internal implementation details"
 
 load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_lib//lib:testing.bzl", "assert_contains")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -47,6 +47,12 @@ bzl_library(
     ],
 )
 
+starlark_doc_extract(
+    name = "npm_package.doc_extract",
+    src = "npm_package.bzl",
+    deps = [":npm_package"],
+)
+
 bzl_library(
     name = "npm_link_package",
     srcs = ["npm_link_package.bzl"],
@@ -55,6 +61,12 @@ bzl_library(
         ":npm_package_store",
         ":utils",
     ],
+)
+
+starlark_doc_extract(
+    name = "npm_link_package.doc_extract",
+    src = "npm_link_package.bzl",
+    deps = [":npm_link_package"],
 )
 
 bzl_library(
@@ -101,6 +113,13 @@ bzl_library(
         "@bazel_skylib//lib:dicts",
         "@bazel_tools//tools/build_defs/repo:git_worker.bzl",
     ],
+)
+
+starlark_doc_extract(
+    name = "npm_import.doc_extract",
+    src = "npm_import.bzl",
+    symbol_names = ["npm_import"],
+    deps = [":npm_import"],
 )
 
 bzl_library(
@@ -171,6 +190,16 @@ bzl_library(
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
     ],
+)
+
+starlark_doc_extract(
+    name = "npm_translate_lock.doc_extract",
+    src = "npm_translate_lock.bzl",
+    symbol_names = [
+        "list_patches",
+        "npm_translate_lock",
+    ],
+    deps = [":npm_translate_lock"],
 )
 
 bzl_library(

--- a/platforms/pnpm/BUILD.bazel
+++ b/platforms/pnpm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":index.bzl", "PNPM_ARCHS", "PNPM_PLATFORMS")
 
 # Constraints representing the pnpm [os] and [cpu] fields.


### PR DESCRIPTION
Reverts aspect-build/rules_js#2703

It didn't work because this repo relies on private/ bzl files to give documentation on npm_translate_lock, among others.

Also we don't want the examples to have documentation generated. See https://registry.bazel.build/docs/aspect_rules_js/3.0.0-rc3 which was wrong 😓 