### PR TITLE
chore: trigger docs update after publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,8 @@ on:
         secrets:
             BCR_PUBLISH_TOKEN:
                 required: true
+            ASPECT_DOCS_REPO_ACCESS_TOKEN:
+                required: true
     # In case of problems, let release engineers retry by manually dispatching
     # the workflow from the GitHub UI
     workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ on:
         secrets:
             BCR_PUBLISH_TOKEN:
                 required: true
+            ASPECT_DOCS_REPO_ACCESS_TOKEN:
+                required: true
     # Or, developers can manually push a tag from their clone
     push:
         tags:
@@ -32,3 +34,4 @@ jobs:
             tag_name: ${{ inputs.tag_name || github.ref_name }}
         secrets:
             BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+            ASPECT_DOCS_REPO_ACCESS_TOKEN: ${{ secrets.ASPECT_DOCS_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -36,8 +36,7 @@ jobs:
         uses: ./.github/workflows/release.yaml
         with:
             tag_name: ${{ needs.tag.outputs.new-tag-version }}
-        secrets:
-            BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+        secrets: inherit
         if: needs.tag.outputs.new-tag == 'true' && needs.tag.outputs.new-tag-version-type != 'major'
         permissions:
             id-token: write


### PR DESCRIPTION
For https://github.com/aspect-build/docs/issues/140

Based on how bazel-central-registry triggers bcr-ui

Note, a PR is also coming on the docs repo to declare the trigger event type referenced here.