### PR TITLE
refactor: add error message when invalid link_package is specified

### DIFF
--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -269,6 +269,11 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
 
             link_importer_key = package_to_importer.get(link_package)
             link_importer = importers.get(link_importer_key)
+            if link_importer == None:
+                fail("""Npm package '{}' contains invalid link_package '{}' which is not a pnpm workspace project.
+
+Valid pnpm workspace projects: {}
+""".format(_import.package, link_package, package_to_importer.keys()))
 
             # the build file for the package being linked
             build_file = "{}/{}".format(link_package, "BUILD.bazel") if link_package else "BUILD.bazel"


### PR DESCRIPTION
Add a check+`fail` instead of crashing when an invalid `link_package` is specified such as via `npm_translate_lock(public_hoist_packages)`.

Crash introduced in 4d6d35062c8c954329a273abc88a57cdf1953149

Close #2740 

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing: enter a bad `npm_translate_lock(public_hoist_packages)` value and observe new `fail()` instead of crash
