### PR TITLE
refactor: upgrade bazel_lib to include cac2d78

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,11 +12,14 @@ bazel_dep(name = "tar.bzl", version = "0.6.0")
 bazel_dep(name = "yq.bzl", version = "0.3.2")
 bazel_dep(name = "jq.bzl", version = "0.4.0")
 bazel_dep(name = "aspect_tools_telemetry", version = "0.3.3")
-bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "bazel_features", version = "1.41.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_nodejs", version = "6.7.3")
+
+# Changes ensured by rules_js:
+# 3.2.2: https://github.com/bazel-contrib/bazel-lib/commit/cac2d7855949d1b222fa26888892fbbe1d31015d
+bazel_dep(name = "bazel_lib", version = "3.2.2")
 
 # NB: LOWER BOUND on earliest BCR release of protobuf module, to avoid upgrading the root module by accident
 bazel_dep(name = "protobuf", version = "3.19.6")


### PR DESCRIPTION
I'm still on the fence with this change. The scenario I've seen this multiple times now is `rules_jest` being passed a `bazel_lib` label as a string, and because `rules_jest` still depends on `aspect_bazel_lib` and has no direct dep on `bazel_lib` this no longer works. With rules_js v2 this worked fine because `rules_jest` directly depends on `aspect_bazel_lib` so the string was interpreted correctly.

IMO a better fix would technically be rules_jest declaring this min version, but the `repo_name = None` requires bazel 7.6 which we can't do in rules_jest atm.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

The minimum `bazel_lib` version is now 3.2.2

### Test plan

- Covered by existing test cases
