### PR TITLE
test: update e2e/npm_translate_lock_auth to not change lockfile during test

### DIFF
--- a/e2e/npm_translate_lock_auth/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/npm_translate_lock_auth/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,5 +2,5 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "@@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=490827635
-package.json=297721563
-pnpm-lock.yaml=271467844
+package.json=-404196952
+pnpm-lock.yaml=1768813175

--- a/e2e/npm_translate_lock_auth/package.json
+++ b/e2e/npm_translate_lock_auth/package.json
@@ -3,6 +3,9 @@
         "onlyBuiltDependencies": []
     },
     "private": true,
+    "devDependencies": {
+        "@types/node": "22.18.13"
+    },
     "dependencies": {
         "@aspect-build/a": "1.0.0",
         "@aspect-priv-npm/a": "1.0.0"

--- a/e2e/npm_translate_lock_auth/pnpm-lock.yaml
+++ b/e2e/npm_translate_lock_auth/pnpm-lock.yaml
@@ -14,6 +14,10 @@ importers:
       '@aspect-priv-npm/a':
         specifier: 1.0.0
         version: 1.0.0
+    devDependencies:
+      '@types/node':
+        specifier: 22.18.13
+        version: 22.18.13
 
 packages:
 
@@ -25,8 +29,20 @@ packages:
     resolution: {integrity: sha512-M2Bt2VHhbKAtn94EVNtigQncBPo0tHCjM/6k1JV79GOLbVxtFSpwzLEyuivvjc+kyL8b2nAimlfEPhOI3G3OEA==}
     hasBin: true
 
+  '@types/node@22.18.13':
+    resolution: {integrity: sha512-Bo45YKIjnmFtv6I1TuC8AaHBbqXtIo+Om5fE4QiU1Tj8QR/qt+8O3BAtOimG5IFmwaWiPmB3Mv3jtYzBA4Us2A==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
 snapshots:
 
   '@aspect-build/a@1.0.0': {}
 
   '@aspect-priv-npm/a@1.0.0': {}
+
+  '@types/node@22.18.13':
+    dependencies:
+      undici-types: 6.21.0
+
+  undici-types@6.21.0: {}

--- a/e2e/npm_translate_lock_auth/test.sh
+++ b/e2e/npm_translate_lock_auth/test.sh
@@ -14,16 +14,29 @@ _sedi() {
     sed "${sedi[@]}" "$@"
 }
 
+# Move the local .npmrc to ~/ and update MODULE.bazel to use_home_npmrc=True
 cp -f .npmrc ~/.npmrc
 rm .npmrc
-
-# update .aspect/rules/external_repository_action_cache/npm_translate_lock_<HASH>
-unset ASPECT_RULES_JS_FROZEN_PNPM_LOCK
 _sedi 's#npmrc = "//:.npmrc",#use_home_npmrc = True,#' MODULE.bazel
+
+# Have to make another change to package.json to invalidate the repository rule
+_sedi 's#"@types/node": "22.18.13"#"@types/node": "22"#' package.json
+
+# Allow updating the lockfile for this test
+unset ASPECT_RULES_JS_FROZEN_PNPM_LOCK
 
 # Trigger the update of the pnpm lockfile which should exit non-zero
 if bazel run @npm//:sync; then
     echo "ERROR: expected 'update_pnpm_lock' to exit with non-zero exit code on update"
+    exit 1
+fi
+
+if ! git status --porcelain | grep -q "\.aspect/rules/external_repository_action_cache/npm_translate_lock_"; then
+    echo "ERROR: expected .aspect/rules/external_repository_action_cache/npm_translate_lock_* to be updated by sync"
+    exit 1
+fi
+if ! git status --porcelain | grep -q "pnpm-lock.yaml"; then
+    echo "ERROR: expected pnpm-lock.yaml to be updated by sync"
     exit 1
 fi
 

--- a/e2e/update_pnpm_lock/test.sh
+++ b/e2e/update_pnpm_lock/test.sh
@@ -49,7 +49,7 @@ ASPECT_RULES_JS_FROZEN_PNPM_LOCK=
 ASPECT_RULES_JS_DISABLE_UPDATE_PNPM_LOCK=
 
 # Have to make another change to package.json to invalidate the repository rule
-_sedi 's#"@types/node": "20"#"@types/node": "18"#' package.json
+_sedi 's#"@types/node": "22.18.13"#"@types/node": "22"#' package.json
 
 # Trigger the update of the pnpm lockfile which should exit non-zero
 if bazel run @npm//:sync; then


### PR DESCRIPTION
Revert the changes to this test from https://github.com/aspect-build/rules_js/commit/d75c5c86200acf04115ff2d6a0b14a124083e7ea and https://github.com/aspect-build/rules_js/commit/b9a510b4044996704a6baeb1c589b0bd8d334dd0 which were trying to fix the issues caused by github hashes changes (now fixed by https://github.com/aspect-build/rules_js/commit/5329e9275b3dcb0101dfaba4c5ad6811c3abc3e3).

Update the `e2e/npm_translate_lock_auth` test to no longer force `pnpm-lock.yaml` changes while swapping between local and user_home `npmrc`. It asserts the correct npmrc file is used, but also asserts that simply swapping between these 2 npmrc locations does not change the actual lockfile.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
