### PR TITLE
fix: handle missing packages in _collect_dep_constraints

### DIFF
--- a/e2e/pnpm_lockfiles/.bazelignore
+++ b/e2e/pnpm_lockfiles/.bazelignore
@@ -2,6 +2,8 @@ node_modules/
 cases/versionless-patch-v9/node_modules
 cases/docusaurus-direct-peer-v9/node_modules
 cases/nested-peer-v9/node_modules
+cases/workspace-peer-v9/node_modules
+cases/workspace-peer-v9/libs/chokidar/node_modules
 cases/isaacs-cliui-v90/node_modules
 cases/override-with-alias-url-v9/node_modules
 projects/a/node_modules

--- a/e2e/pnpm_lockfiles/MODULE.bazel
+++ b/e2e/pnpm_lockfiles/MODULE.bazel
@@ -17,6 +17,7 @@ PNPM_LOCK_TEST_CASES = [
     "docusaurus-direct-peer-v9",
     "versionless-patch-v9",
     "nested-peer-v9",
+    "workspace-peer-v9",
 ]
 
 bazel_dep(name = "bazel_lib", version = "3.0.0")

--- a/e2e/pnpm_lockfiles/cases/workspace-peer-v9/BUILD.bazel
+++ b/e2e/pnpm_lockfiles/cases/workspace-peer-v9/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@workspace-peer-v9//:defs.bzl", "npm_link_all_packages")
+
+exports_files(["pnpm-lock.yaml"])
+
+npm_link_all_packages()
+
+build_test(
+    name = "optional_peers_targets",
+    targets = [
+        ":node_modules",
+        ":node_modules/chokidar",
+    ],
+)

--- a/e2e/pnpm_lockfiles/cases/workspace-peer-v9/libs/chokidar/BUILD.bazel
+++ b/e2e/pnpm_lockfiles/cases/workspace-peer-v9/libs/chokidar/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+
+js_library(
+    name = "pkg",
+    srcs = ["package.json"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/pnpm_lockfiles/cases/workspace-peer-v9/libs/chokidar/package.json
+++ b/e2e/pnpm_lockfiles/cases/workspace-peer-v9/libs/chokidar/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "chokidar"
+}

--- a/e2e/pnpm_lockfiles/cases/workspace-peer-v9/package.json
+++ b/e2e/pnpm_lockfiles/cases/workspace-peer-v9/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "workspace-peer",
+    "private": true,
+    "pnpm": {
+        "onlyBuiltDependencies": []
+    },
+    "devDependencies": {
+        "@angular-devkit/core": "21.2.1",
+        "chokidar": "workspace:*"
+    }
+}

--- a/e2e/pnpm_lockfiles/cases/workspace-peer-v9/pnpm-lock.yaml
+++ b/e2e/pnpm_lockfiles/cases/workspace-peer-v9/pnpm-lock.yaml
@@ -1,0 +1,109 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@angular-devkit/core':
+        specifier: 21.2.1
+        version: 21.2.1(chokidar@libs+chokidar)
+      chokidar:
+        specifier: workspace:*
+        version: link:libs/chokidar
+
+  libs/chokidar: {}
+
+packages:
+
+  '@angular-devkit/core@21.2.1':
+    resolution: {integrity: sha512-TpXGjERqVPN8EPt7LdmWAwh0oNQ/6uWFutzGZiXhJy81n1zb1O1XrqhRAmvP1cAo5O+na6IV2JkkCmxL6F8GUg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+    peerDependencies:
+      chokidar: ^5.0.0
+    peerDependenciesMeta:
+      chokidar:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+snapshots:
+
+  '@angular-devkit/core@21.2.1(chokidar@libs+chokidar)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.3
+      rxjs: 7.8.2
+      source-map: 0.7.6
+    optionalDependencies:
+      chokidar: link:libs/chokidar
+
+  ajv-formats@3.0.1:
+    dependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  jsonc-parser@3.3.1: {}
+
+  picomatch@4.0.3: {}
+
+  require-from-string@2.0.2: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  source-map@0.7.6: {}
+
+  tslib@2.8.1: {}

--- a/e2e/pnpm_lockfiles/cases/workspace-peer-v9/pnpm-workspace.yaml
+++ b/e2e/pnpm_lockfiles/cases/workspace-peer-v9/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+    - '.'
+    - 'libs/*'

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -555,6 +555,9 @@ def _collect_dep_constraints(packages, package_info):
 
     optional_keys = package_info["optional_dependencies"].values() + package_info.get("transitive_optional_closure", {}).keys()
     for dep_key in optional_keys:
+        if dep_key.startswith("link:"):
+            continue
+
         dep = packages[dep_key]
         if dep["os"]:
             constraints_os[dep_key] = dep["os"]


### PR DESCRIPTION
When an optional dependency is a "link:" dependency or otherwise not present in the `packages` dictionary, `npm_translate_lock` would fail with a "key not found" error such as: `Error: key "link:@angular/core|packages/core" not found in dictionary`

This occurs because `_collect_dep_constraints` iterates over optional dependencies but assumes they all exist in the `packages` dictionary. Link dependencies are often not represented in the lockfile as standard packages, leading to this missing key.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
