### PR TITLE
chore: fix broken docs.aspect.build links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ The fastest way to try this in an empty project is to click the green "Use this 
 
 rules_js is just a part Aspect's monorepo developer platform:
 
--   [Aspect Workflows](https://docs.aspect.build/workflows) delivers on Bazel's promises of speed and cost-savings.
+-   [Aspect Workflows](https://docs.aspect.build/aspect-workflows/get-started/overview) delivers on Bazel's promises of speed and cost-savings.
     It provides Continuous Integration and Delivery, including Remote Cache and Remote Build Execution (RBE).
     Best of all, it includes all the expertise that you expect from the team at Aspect!
 -   _Need help?_
     -   Best-effort community support is available on the #javascript channel on [Bazel Slack](https://slack.bazel.build/)
     -   Commercial support as a Slack Connect channel is offered by https://aspect.build/services.
--   See [Aspect's Bazel rules](https://docs.aspect.build/rules), especially those built for rules_js:
-    -   [rules_ts](https://github.com/aspect-build/rules_ts) - Bazel rules for [TypeScript](http://typescriptlang.org)
+-   See Aspect's [Bazel Rules](https://docs.aspect.build/bazel), especially those built for rules_js:
+    -   [rules_ts](https://docs.aspect.build/bazel/javascript/typescript) - Bazel rules for [TypeScript](https://www.typescriptlang.org)
     -   [rules_swc](https://github.com/aspect-build/rules_swc) - Bazel rules for [swc](https://swc.rs)
     -   [rules_jest](https://github.com/aspect-build/rules_jest) - Bazel rules to run tests using [Jest](https://jestjs.io)
     -   [rules_esbuild](https://github.com/aspect-build/rules_esbuild) - Bazel rules for [esbuild](https://esbuild.github.io) JS bundler
@@ -37,7 +37,7 @@ rules_js is just a part Aspect's monorepo developer platform:
     -   [rules_rollup](https://github.com/aspect-build/rules_rollup) - Bazel rules for [Rollup](https://rollupjs.org) - a JavaScript bundler
     -   [rules_jasmine](https://github.com/aspect-build/rules_jasmine) - Bazel rules to run tests using [Jasmine](https://jasmine.github.io/)
     -   [rules_terser](https://github.com/aspect-build/rules_terser) - Bazel rules for [Terser](https://terser.org) - a JavaScript minifier
-    -   [rules_cypress](https://github.com/aspect-build/rules_cypress) - Bazel rules to run tests using [Cypress](https://cypress.io)
+    -   [rules_cypress](https://github.com/aspect-build/rules_cypress) - Bazel rules to run tests using [Cypress](https://www.cypress.io)
     -   [rules_lint](https://github.com/aspect-build/rules_lint) includes [eslint support](https://registry.bazel.build/docs/aspect_rules_lint#lint-eslint-bzl).
 
 ## Known issues
@@ -74,10 +74,10 @@ Larger examples can be found in our [bazel-examples](https://github.com/aspect-b
 ## Relationship to rules_nodejs
 
 rules_js is an alternative to the `build_bazel_rules_nodejs` Bazel module and
-accompanying npm packages hosted in https://github.com/bazelbuild/rules_nodejs,
+accompanying npm packages hosted in https://github.com/bazel-contrib/rules_nodejs,
 which is now unmaintained. All users are recommended to use rules_js instead.
 
-rules_js replaces some parts of [bazelbuild/rules_nodejs](http://github.com/bazelbuild/rules_nodejs) and re-uses other parts:
+rules_js replaces some parts of [bazelbuild/rules_nodejs](https://github.com/bazel-contrib/rules_nodejs) and re-uses other parts:
 
 | Layer                           | Legacy                        | Modern                  |
 | ------------------------------- | ----------------------------- | ----------------------- |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -199,4 +199,4 @@ npm.npm_exclude_package_contents(
 
 #### Jest
 
-See [rules_jest](https://github.com/aspect-build/rules_jest) specific [troubleshooting](https://docs.aspect.build/rulesets/aspect_rules_jest/docs/troubleshooting#performance).
+See [rules_jest](https://github.com/aspect-build/rules_jest) for troubleshooting.

--- a/e2e/pnpm_lockfiles/v101/snapshots/is-odd-v0_resolved.json
+++ b/e2e/pnpm_lockfiles/v101/snapshots/is-odd-v0_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-3RKAybrJxq3zCUC+TJ5Ao0sBsbacAT3OBeNVcCbsQsHUC70qWK2R4JsIvax4OTjeGWnB8FumAWATUtS1jd+KYw==","version":"0.1.0"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-3RKAybrJxq3zCUC+TJ5Ao0sBsbacAT3OBeNVcCbsQsHUC70qWK2R4JsIvax4OTjeGWnB8FumAWATUtS1jd+KYw==","version":"0.1.0"}

--- a/e2e/pnpm_lockfiles/v101/snapshots/is-odd_resolved.json
+++ b/e2e/pnpm_lockfiles/v101/snapshots/is-odd_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}

--- a/e2e/pnpm_lockfiles/v101/snapshots/lodash_resolved.json
+++ b/e2e/pnpm_lockfiles/v101/snapshots/lodash_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==","version":"file:../vendored/lodash-4.17.21.tgz"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==","version":"file:../vendored/lodash-4.17.21.tgz"}

--- a/e2e/pnpm_lockfiles/v110/snapshots/is-odd-v0_resolved.json
+++ b/e2e/pnpm_lockfiles/v110/snapshots/is-odd-v0_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-3RKAybrJxq3zCUC+TJ5Ao0sBsbacAT3OBeNVcCbsQsHUC70qWK2R4JsIvax4OTjeGWnB8FumAWATUtS1jd+KYw==","version":"0.1.0"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-3RKAybrJxq3zCUC+TJ5Ao0sBsbacAT3OBeNVcCbsQsHUC70qWK2R4JsIvax4OTjeGWnB8FumAWATUtS1jd+KYw==","version":"0.1.0"}

--- a/e2e/pnpm_lockfiles/v110/snapshots/is-odd_resolved.json
+++ b/e2e/pnpm_lockfiles/v110/snapshots/is-odd_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}

--- a/e2e/pnpm_lockfiles/v110/snapshots/lodash_resolved.json
+++ b/e2e/pnpm_lockfiles/v110/snapshots/lodash_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==","version":"file:../vendored/lodash-4.17.21.tgz"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==","version":"file:../vendored/lodash-4.17.21.tgz"}

--- a/e2e/pnpm_lockfiles/v90/snapshots/is-odd-v0_resolved.json
+++ b/e2e/pnpm_lockfiles/v90/snapshots/is-odd-v0_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-3RKAybrJxq3zCUC+TJ5Ao0sBsbacAT3OBeNVcCbsQsHUC70qWK2R4JsIvax4OTjeGWnB8FumAWATUtS1jd+KYw==","version":"0.1.0"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-3RKAybrJxq3zCUC+TJ5Ao0sBsbacAT3OBeNVcCbsQsHUC70qWK2R4JsIvax4OTjeGWnB8FumAWATUtS1jd+KYw==","version":"0.1.0"}

--- a/e2e/pnpm_lockfiles/v90/snapshots/is-odd_resolved.json
+++ b/e2e/pnpm_lockfiles/v90/snapshots/is-odd_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJ<LOCKVERSION>yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJ<LOCKVERSION>yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","version":"3.0.1"}

--- a/e2e/pnpm_lockfiles/v90/snapshots/lodash_resolved.json
+++ b/e2e/pnpm_lockfiles/v90/snapshots/lodash_resolved.json
@@ -1,1 +1,1 @@
-{"$schema":"https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock","integrity":"sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==","version":"file:../vendored/lodash-4.17.21.tgz"}
+{"$schema":"https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock","integrity":"sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==","version":"file:../vendored/lodash-4.17.21.tgz"}

--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -75,7 +75,7 @@ def js_binary(**kwargs):
     The following environment variables are made available to the Node.js runtime based the runtime environment:
 
     * JS_BINARY__NODE_BINARY: the Node.js binary path run by the `js_binary` target
-    * JS_BINARY__NPM_BINARY: the npm binary path; this is available when [`include_npm`](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary#include_npm) is `True` on the `js_binary` target
+    * JS_BINARY__NPM_BINARY: the npm binary path; this is available when `include_npm` is `True` on the `js_binary` target
     * JS_BINARY__NODE_WRAPPER: the Node.js wrapper script used to run Node.js which is available as `node` on the `PATH` at runtime
     * JS_BINARY__RUNFILES: the absolute path to the Bazel runfiles directory
     * JS_BINARY__EXECROOT: the absolute path to the root of the execution root for the action; if in the sandbox, this path absolute path to the root of the execution root within the sandbox

--- a/js/private/js_helpers.bzl
+++ b/js/private/js_helpers.bzl
@@ -83,7 +83,7 @@ Expected to find source file {file_basename} in '{this_package}', but instead it
 All source and data files that are not in the Bazel output tree must be in the same package as the
 target so that they can be copied to the output tree in an action.
 
-See https://docs.aspect.build/rules/aspect_rules_js/docs/#javascript for more context on why this is required.
+See https://docs.aspect.build/bazel/javascript/rules_js for more context on why this is required.
 
 Either move {file_basename} to '{this_package}', or add a 'js_library'
 target in {file_basename}'s package and add that target to the deps of {this_target}:

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -241,9 +241,9 @@ def js_run_binary(
 
     # Friendly fail if user has specified invalid parameters
     if "data" in kwargs.keys():
-        fail("Use srcs instead of data in js_run_binary: https://docs.aspect.build/rules/aspect_rules_js/docs/js_run_binary#srcs")
+        fail("Use srcs instead of data in js_run_binary: https://docs.aspect.build/bazel/javascript/aspect_rules_js/js_defs#function-js_run_binary")
     if "deps" in kwargs.keys():
-        fail("Use srcs instead of deps in js_run_binary: https://docs.aspect.build/rules/aspect_rules_js/docs/js_run_binary#srcs")
+        fail("Use srcs instead of deps in js_run_binary: https://docs.aspect.build/bazel/javascript/aspect_rules_js/js_defs#function-js_run_binary")
 
     extra_srcs = []
 

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -253,7 +253,7 @@ def js_run_devserver(
 
             `entry_point` is set implicitly by `js_run_devserver` and cannot be overridden.
 
-            See https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary
+            See https://docs.aspect.build/bazel/javascript/aspect_rules_js/js_defs
     """
     if kwargs.get("entry_point", None):
         fail("`entry_point` is set implicitly by `js_run_devserver` and cannot be overridden.")

--- a/js/private/test/js_run_devserver/js_run_devserver_test.bzl
+++ b/js/private/test/js_run_devserver/js_run_devserver_test.bzl
@@ -27,7 +27,7 @@ def js_run_devserver_test(
 
         **kwargs: All other args for `js_run_devserver`.
 
-            See https://docs.aspect.build/rules/aspect_rules_js/docs/js_run_devserver
+            See https://docs.aspect.build/bazel/javascript/aspect_rules_js/js_defs#function-js_run_devserver
     """
     js_run_devserver(
         name,

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -178,7 +178,7 @@ def npm_package(
     for more information on supported globbing patterns.
 
     `npm_package` makes use of `copy_to_directory`
-    (https://docs.aspect.build/rules/bazel_lib/docs/copy_to_directory) under the hood,
+    (https://docs.aspect.build/bazel/utility/bazel_lib/lib_copy_to_directory) under the hood,
     adopting its API and its copy action using composition. However, unlike `copy_to_directory`,
     `npm_package` includes direct and transitive sources and types files from `JsInfo` providers in srcs
     by default. The behavior of including sources and types from `JsInfo` can be configured
@@ -474,12 +474,12 @@ def stamped_package_json(name, stamp_var, **kwargs):
     In unstamped builds (typically those without `--stamp`) the version will be set to `0.0.0`.
     This ensures that actions which use the package.json file can get cache hits.
 
-    For more information on stamping, read https://docs.aspect.build/rules/bazel_lib/docs/stamping.
+    For more information on stamping, read https://docs.aspect.build/bazel/utility/bazel_lib/lib_stamping.
 
     Args:
         name: name of the resulting `jq` target, must be "package"
         stamp_var: a key from the bazel-out/stable-status.txt or bazel-out/volatile-status.txt files
-        **kwargs: additional attributes passed to the jq rule, see https://docs.aspect.build/rules/bazel_lib/docs/jq
+        **kwargs: additional attributes passed to the jq rule
     """
     if name != "package":
         fail("""stamped_package_json should always be named "package" so that the default output is named "package.json".

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -315,7 +315,7 @@ Valid pnpm workspace projects: {}
 
                 final_rctx_files[resolved_json_file_path] = json.encode({
                     # Allow consumers to auto-detect this filetype
-                    "$schema": "https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock",
+                    "$schema": "https://docs.aspect.build/bazel/javascript/aspect_rules_js/npm_extensions#tag-npm_translate_lock",
                     "version": _import.version,
                     "integrity": _import.integrity,
                 })


### PR DESCRIPTION

Addresses broken links mentioned in https://github.com/aspect-build/rules_js/pull/2711#issuecomment-3880030786.

Update all links using the old `/rules/` and `/rulesets/` URL patterns to the new `/bazel/` path structure on `docs.aspect.build`.

The old URL patterns (e.g. `docs.aspect.build/rules/aspect_rules_js/...`) now redirect to a broken `rules-redirect` page. This updates all occurrences across `.bzl` files, docs, and e2e test snapshots to the new URL structure.

Two cases had no direct replacement:
- **`jq` rule docs** (`npm/private/npm_package.bzl`): The `jq` rule was removed from `bazel_lib` entirely, so the link was removed. The docstring still references the jq rule by name.
- **`rules_jest` troubleshooting page** (`docs/troubleshooting.md`): The troubleshooting page for `rules_jest` no longer exists at the new URL structure. The broken link was removed; the text now points to the `rules_jest` GitHub repo instead.

---
### Changes are visible to end-users: no

### Test plan
- Checked links