### PR TITLE
fix: remove invalid repo_name = None from aspect_bazel_lib bazel_dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(name = "protobuf", version = "3.19.6")
 # https://github.com/bazel-contrib/bazel-lib/commit/27a9e7af51c0f806f823425a03283ae487d3a953
 # https://github.com/bazel-contrib/bazel-lib/commit/e56aa707b72364bb1cc6f92580cb12ff88dfc1b4
 # https://github.com/bazel-contrib/bazel-lib/commit/2befef614904d0ebe5161beb271ac31c83e82fd2
-bazel_dep(name = "aspect_bazel_lib", version = "2.22.5", repo_name = None)
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
 tel = use_extension("@aspect_tools_telemetry//:extension.bzl", "telemetry")
 use_repo(tel, "aspect_tools_telemetry_report")


### PR DESCRIPTION
## Problem

`MODULE.bazel` line 33 passes `repo_name = None` to `bazel_dep()`, but `bazel_dep` requires `repo_name` to be a `string`. This causes a build failure for any downstream consumer on Bazel 8+:

```
ERROR: https://bcr.bazel.build/modules/aspect_rules_js/3.0.3/MODULE.bazel:34:10:
Error in bazel_dep: in call to bazel_dep(), parameter 'repo_name'
got value of type 'NoneType', want 'string'

ERROR: Error computing the main repository mapping:
in module dependency chain <root> -> aspect_rules_js@3.0.3:
error executing MODULE.bazel file for aspect_rules_js@3.0.3
```

This was introduced in #2567 to declare a minimum version constraint on `aspect_bazel_lib` without creating a repo alias, and happened to work on older Bazel versions.

## Fix

Remove `repo_name = None`, using the default repo name (the module name). The minimum version constraint still works correctly without it.