### PR TITLE
refactor: update js_proto_toolchain() to streamline the way output extensions are specified

### DIFF
--- a/examples/protobuf/bufbuild-es/tools/toolchains/BUILD
+++ b/examples/protobuf/bufbuild-es/tools/toolchains/BUILD
@@ -7,10 +7,8 @@ gen_es.protoc_gen_es_binary(
 
 js_proto_toolchain(
     name = "protobuf_es_toolchain",
-    output_file_extensions = [
-        "_pb.js",
-        "_pb.d.ts",
-    ],
+    out_dts_extension = "_pb.d.ts",
+    out_js_extension = "_pb.js",
     plugin_bin = ":protoc_gen_es",
     plugin_name = "es",
     # See https://github.com/connectrpc/connect-es/blob/main/MIGRATING.md#update-plugin-options

--- a/examples/protobuf/google-protobuf/tools/toolchains/BUILD
+++ b/examples/protobuf/google-protobuf/tools/toolchains/BUILD
@@ -2,9 +2,8 @@ load("@aspect_rules_js//js:proto.bzl", "js_proto_toolchain")
 
 js_proto_toolchain(
     name = "google_protobuf_toolchain",
-    output_file_extensions = [
-        "_pb.js",
-    ],
+    out_dts_extension = None,
+    out_js_extension = "_pb.js",
     plugin_bin = "@protobuf-javascript//:protoc-gen-js",
     plugin_name = "js",
     plugin_options = [

--- a/js/private/js_proto_toolchain.bzl
+++ b/js/private/js_proto_toolchain.bzl
@@ -16,7 +16,7 @@ load("//js/private:proto.bzl", "PROTOC_TOOLCHAIN")
 
 JsProtoToolchainInfo = provider(
     doc = "Information on how to invoke the JavaScript or TypeScript protoc plugin.",
-    fields = ["output_file_extensions"],
+    fields = ["out_dts_extension", "out_js_extension"],
 )
 
 def _js_proto_toolchain_impl(ctx):
@@ -51,7 +51,7 @@ def _js_proto_toolchain_impl(ctx):
     )
     return [
         DefaultInfo(files = depset(), runfiles = ctx.runfiles()),
-        platform_common.ToolchainInfo(proto = proto_lang_toolchain_info, js = JsProtoToolchainInfo(output_file_extensions = ctx.attr.output_file_extensions)),
+        platform_common.ToolchainInfo(proto = proto_lang_toolchain_info, js = JsProtoToolchainInfo(out_dts_extension = ctx.attr.out_dts_extension, out_js_extension = ctx.attr.out_js_extension)),
     ]
 
 js_proto_toolchain = rule(
@@ -104,11 +104,16 @@ This is used for .proto files that are already linked into proto runtimes, such 
 <code>any.proto</code>.""",
         ),
         "toolchain_type": attr.label(),
-        "output_file_extensions": attr.string_list(
+        "out_dts_extension": attr.string(
             doc = """
-Indicates the file extensions that the plugin is expected to produce. These are
-interpreted as the suffix that should replace ".proto" from the input file
-name.
+Indicates the .d.ts suffix that the plugin is expected to produce, interpreted
+as the suffix that should replace ".proto" from the input file name.
+""",
+        ),
+        "out_js_extension": attr.string(
+            doc = """
+Indicates the .js suffix that the plugin is expected to produce, interpreted as
+the suffix that should replace ".proto" from the input file name.
 """,
         ),
     },

--- a/js/private/proto.bzl
+++ b/js/private/proto.bzl
@@ -28,13 +28,9 @@ def _js_proto_aspect_impl(target, ctx):
     proto_lang_toolchain_info = ctx.toolchains[LANG_PROTO_TOOLCHAIN].proto
     js_proto_toolchain_info = ctx.toolchains[LANG_PROTO_TOOLCHAIN].js
 
-    js_outputs = []
-    dts_outputs = []
-    for extension in js_proto_toolchain_info.output_file_extensions:
-        if extension.endswith(".d.ts"):
-            dts_outputs.extend(proto_common.declare_generated_files(ctx.actions, proto_info, extension))
-        else:
-            js_outputs.extend(proto_common.declare_generated_files(ctx.actions, proto_info, extension))
+    js_outputs = proto_common.declare_generated_files(ctx.actions, proto_info, js_proto_toolchain_info.out_js_extension)
+    dts_extension = js_proto_toolchain_info.out_dts_extension
+    dts_outputs = proto_common.declare_generated_files(ctx.actions, proto_info, dts_extension) if dts_extension else []
 
     all_outputs = js_outputs + dts_outputs
     output_root = all_outputs[0].root

--- a/js/proto.bzl
+++ b/js/proto.bzl
@@ -47,7 +47,7 @@ The generator you setup earlier will be invoked automatically as an action to ge
 load("//js/private:js_proto_toolchain.bzl", _js_proto_toolchain = "js_proto_toolchain")
 load("//js/private:proto.bzl", "LANG_PROTO_TOOLCHAIN")
 
-def js_proto_toolchain(name, plugin_name, plugin_options, plugin_bin, runtime, output_file_extensions = ["_pb.js", "_pb.d.ts"], target_settings = [], exec_compatible_with = [], target_compatible_with = [], **kwargs):
+def js_proto_toolchain(name, plugin_name, plugin_options, plugin_bin, runtime, out_dts_extension = "_pb.d.ts", out_js_extension = "_pb.js", target_settings = [], exec_compatible_with = [], target_compatible_with = [], **kwargs):
     """Define a proto_lang_toolchain that uses the plugin.
 
     Example:
@@ -55,10 +55,8 @@ def js_proto_toolchain(name, plugin_name, plugin_options, plugin_bin, runtime, o
     ```starlark
     js_proto_toolchain(
         name = "gen_es_toolchain",
-        output_file_extensions = [
-            "_pb.js",
-            "_pb.d.ts",
-        ],
+        out_dts_extension = "_pb.d.ts",
+        out_js_extension = "_pb.js",
         plugin_bin = ":protoc_gen_es",
         plugin_name = "es",
         # See https://github.com/bufbuild/protobuf-es/tree/main/packages/protoc-gen-es#plugin-options
@@ -90,11 +88,10 @@ def js_proto_toolchain(name, plugin_name, plugin_options, plugin_bin, runtime, o
 
             Note that node module resolution requires the runtime to be in a parent folder of any package containing generated code.
 
-        output_file_extensions: The file extensions that the plugin is expected to produce.
+        out_dts_extension: The suffix that should replace ".proto" in determining the .d.ts output file name, or None if the plugin does not produce a type declaration file.
+        out_js_extension: The suffix that should replace ".proto" in determining the .js output file name.
 
-            These are interpreted as the suffix that should replace ".proto"
-            from the input file name. This parameter has a default value for
-            backward compatibility, but should be set explicitly.
+            Each of the two options above has a default value for backward compatibility, but should be set explicitly.
 
         target_settings: List of target config settings the toolchain is compatible with.
         exec_compatible_with: List of constraint_values that the target platform must be compatible with.
@@ -104,16 +101,16 @@ def js_proto_toolchain(name, plugin_name, plugin_options, plugin_bin, runtime, o
     """
     command_line_flags = ["--{}_opt=%s".format(plugin_name) % o for o in plugin_options]
     command_line_flags.append("--{}_out=$(OUT)".format(plugin_name))
-    for extension in output_file_extensions:
-        if extension.endswith(".ts") and not extension.endswith(".d.ts"):
-            fail("Pure-TypeScript protobuf implementations are not currently supported")
+    if out_js_extension.endswith(".ts"):
+        fail("Pure-TypeScript protobuf implementations are not currently supported")
     _js_proto_toolchain(
         name = name,
         command_line = " ".join(command_line_flags),
         plugin_format_flag = "--plugin=protoc-gen-{}=%s".format(plugin_name),
         toolchain_type = LANG_PROTO_TOOLCHAIN,
         plugin = plugin_bin,
-        output_file_extensions = output_file_extensions,
+        out_dts_extension = out_dts_extension,
+        out_js_extension = out_js_extension,
         runtime = runtime,
         **kwargs
     )


### PR DESCRIPTION
Currently, you can set something like `output_file_extensions = ["_pb.js", "_pb.d.ts"]` on a `js_proto_toolchain()` to indicate the outputs you expect the plugin to produce. However, experience has shown that this API is a little bit awkward for us because we end up needing to loop over the list to find the extension we want. In practice there is always a .js file and sometimes a .d.ts file, so this commit provides a parameter for each one.

This is not a breaking change, because the existing API has not made it into a release yet.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
