### PR TITLE
Take out outputFileTracingRoot

### DIFF
--- a/examples/nextjs/next.standalone.mjs
+++ b/examples/nextjs/next.standalone.mjs
@@ -1,20 +1,9 @@
-import { join } from 'node:path'
-
-// Must include the parent .aspect_rules_js package store when tracing for standalone output
-const outputFileTracingRoot = join(import.meta.dirname, '../')
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
 
     // Bundle everything into a standalone output
     output: 'standalone',
-    outputFileTracingRoot,
-
-    // If you're using NextJS 14, replace outputFileTracingRoot with:
-    // experimental: {
-    //   outputFileTracingRoot,
-    // },
 }
 
 export default nextConfig


### PR DESCRIPTION
With this change, everything still builds, but when you try to run the standalone build you get:

```
$ bazel run //nextjs:server       
[...]
FATAL: aspect_rules_js[js_binary]: the entry_point '/private/var/tmp/_bazel_tyler.breisacher/4730c514413039494267447997766965/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/nextjs/server_/server.runfiles/_main/nextjs/server/standalone/nextjs/server.js' not found
```

It looks like the server.js gets placed at a different place than it should be.

On main:

```
$ bazel build //nextjs:standalone && tree bazel-bin/nextjs/.next/standalone
[...]
bazel-bin/nextjs/.next/standalone
└── nextjs
    ├── server.js
    └── src
        └── pages
            ├── _app.js
            └── _document.js
```

On this branch:

```
$ bazel build //nextjs:standalone && tree bazel-bin/nextjs/.next/standalone
[...]
bazel-bin/nextjs/.next/standalone
├── server.js
└── src
    └── pages
        ├── _app.js
        └── _document.js
```