### PR TITLE
refactor: simplify launcher script logic for `chdir`

### DIFF
--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -328,10 +328,7 @@ fi
 # Change directory to user specified package if set
 if [ "${JS_BINARY__CHDIR:-}" ]; then
     logf_debug "changing directory to user specified package %s" "$JS_BINARY__CHDIR"
-    case "$JS_BINARY__CHDIR" in
-    external/*) cd "$(resolve_execroot_bin_path "$JS_BINARY__CHDIR")" ;;
-    *) cd "$JS_BINARY__CHDIR" ;;
-    esac
+    cd "$JS_BINARY__EXECROOT/${BAZEL_BINDIR:-$JS_BINARY__BINDIR}/$JS_BINARY__CHDIR"
 fi
 
 # Gather node options

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -448,10 +448,7 @@ fi
 # Change directory to user specified package if set
 if [ "${JS_BINARY__CHDIR:-}" ]; then
     logf_debug "changing directory to user specified package %s" "$JS_BINARY__CHDIR"
-    case "$JS_BINARY__CHDIR" in
-    external/*) cd "$(resolve_execroot_bin_path "$JS_BINARY__CHDIR")" ;;
-    *) cd "$JS_BINARY__CHDIR" ;;
-    esac
+    cd "$JS_BINARY__EXECROOT/${BAZEL_BINDIR:-$JS_BINARY__BINDIR}/$JS_BINARY__CHDIR"
 fi
 
 # Gather node options


### PR DESCRIPTION
The `js_binary()` and `js_run_binary()` rules provide a `chdir` option that you can use to indicate a directory to cd to before the main entry point is invoked. This turns into a `JS_BINARY__CHDIR` environment variable that the launcher script looks at to decide where to cd.

The logic has a special case for when `JS_BINARY__CHDIR` begins with `external/`, in which case we call `resolve_execroot_bin_path` to canonicalize the path. This special casing seems to be unnecessary, and `resolve_execroot_bin_path` also contains more logic than we need. I therefore replaced all this with a one-liner that cds to the correct absolute path.

The motivation for this is that in another PR I am going to change the behavior of `resolve_execroot_bin_path` so that it always refers to the exec platform bin directory, but this is not something we want to affect `chdir`.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases