### PR TITLE
fix: correctly handle an empty chdir argument on js_run_binary

### DIFF
--- a/e2e/js_binary_workspace/BUILD.bazel
+++ b/e2e/js_binary_workspace/BUILD.bazel
@@ -1,10 +1,35 @@
 load("@aspect_rules_js//js:defs.bzl", "js_run_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 js_run_binary(
     name = "run_workspace_bin",
+    chdir = package_name(),
     stdout = "out.txt",
     tool = "@workspace//:bin",
+)
+
+# This generated shell script verifies that the contents of the file passed as
+# the first argument end with the output directory for this package.
+genrule(
+    name = "working_directory_test_sh",
+    outs = ["working_directory_test.sh"],
+    cmd = """cat > $@ << 'EOF'
+#!/usr/bin/env bash
+actual="$$1"
+expected="$(@D)"
+expected_len=$$(printf '%s\\n' "$$expected" | wc -c)
+diff -u <(tail -c "$$expected_len" "$$actual") <(printf '%s\\n' "$$expected")
+EOF""",
+)
+
+# Assert that the js_run_binary target above runs in this package's output
+# directory, overriding the chdir argument on the underlying js_binary.
+sh_test(
+    name = "js_run_binary_chdir_test",
+    srcs = [":working_directory_test.sh"],
+    args = ["$(rootpath :out.txt)"],
+    data = [":out.txt"],
 )
 
 build_test(

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -294,8 +294,8 @@ def js_run_binary(
     }
 
     # Configure working directory to `chdir` is set
-    if chdir:
-        normalized_chdir = chdir
+    if chdir != None:
+        normalized_chdir = "." if chdir == "" else chdir
         repo = native.repo_name()
 
         # Normalize workspace-relative chdir for external repositories so callers can pass


### PR DESCRIPTION
The `js_run_binary` macro has a `chdir` parameter for determining the working directory where the target should run, and this should take precedence over the `chdir` attribute on the underlying `js_binary`.

Currently this does not work correctly if you set `chdir = package_name()` on a `js_run_binary` at the top level of a repo, because in that case `chdir` is the empty string and it is ignored. This change fixes that problem by having the macro make a distinction between `None` and the empty string, and if `chdir` is empty then we replace it with a dot so that it represents the top-level package.

This does for `js_run_binary` what 7d28f8e7 recently did for `js_binary` and `js_test`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

The `js_run_binary` macro now correctly handles an empty string for `chdir`.

### Test plan

- Covered by existing test cases
- New test cases added
