### PR TITLE
chore: upgrade bazel_lib to 3.3.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Changes ensured by rules_js:
 # 3.2.2: https://github.com/bazel-contrib/bazel-lib/commit/cac2d7855949d1b222fa26888892fbbe1d31015d
-bazel_dep(name = "bazel_lib", version = "3.2.2")
+bazel_dep(name = "bazel_lib", version = "3.3.1")
 
 # NB: LOWER BOUND on earliest BCR release of protobuf module, to avoid upgrading the root module by accident
 bazel_dep(name = "protobuf", version = "3.19.6")


### PR DESCRIPTION
This includes https://github.com/bazel-contrib/bazel-lib/pull/1252, which adds a feature we will likely soon use in `js_run_binary()`.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases