### PR TITLE
chore: support pnpm 11 managed toolchain

### DIFF
--- a/npm/private/versions.bzl
+++ b/npm/private/versions.bzl
@@ -118,4 +118,8 @@ PNPM_VERSIONS = {
     "10.33.0": "sha512-EFaLtKavtYyes2MNqQzJUWQXq+vT+rvmc58K55VyjaFJHp21pUTHatjrdXD1xLs9bGN7LLQb/c20f6gjyGSTGQ==",
     "10.33.1": "sha512-Bbo8HV0cGPaN8GRw10BV5i1B/BEKDGYNsbLfsnhTJ/BM8PaDRdRgm8Ugief6A0PDFZOy+VlOLF1dpCYjCsyYIA==",
     "10.33.2": "sha512-qQ+vb+6rca1sblf5Tg/hoS9dzCLNdU20CulZPraj4LaxLjVAIYuzeuCDQEsfLObbKkEh6XmCm0r/lLmfSdoc+A==",
+    "11.0.0": "sha512-W9GHUA5JzGw9iR2XO0MsArhEpetyCRcskKUXo+9PV57Vwj1Am2meap3EGP97KxiQ5j9tdPHT/EmEjzd3nInITA==",
+    "11.0.1": "sha512-3bHwpT+1ZgPtlrAY28/4P/HF+1EMn5fCrvGa9Rx3bI2Qxn4SwiPDTbeSt1Y0cA4VQZy4c0G6SUei/BUYIvvc8g==",
+    "11.0.2": "sha512-aSbPfNeBKygA46IQVRteyEX3fr66gWQkqVAU3jAh0ZOztVxbS3S6xOuhBpeeeYqgUFZGGBzmckdQcxJTKmYXhw==",
+    "11.0.3": "sha512-EESPKYiTN4fGaZrvaDF0x0H2RyrZG348j+PivaV76KD3yvWJSbi8IuYkV4s9xuV4drpMYxkoobhMwUHhLHm8zQ==",
 }

--- a/npm/private/versions_mirror.sh
+++ b/npm/private/versions_mirror.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 JQ_FILTER='[
     .versions[]
-    | select(.version | test("^(9|10)\\.[0-9.]+$"))
+    | select(.version | test("^(9|10|11)\\.[0-9.]+$"))
     | {key: .version, value: .dist.integrity}
 ] | sort_by(
     .key


### PR DESCRIPTION
Support pnpm v11.x.x

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no (note that /bin/pnpm.cjs exists in the older versions too) 
- Suggested release notes appear below: no

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:
```
cd e2e/pnpm_repo_install
bazel run @pnpm//:pnpm -- --version
11.0.3
```