### PR TITLE
fix: fix `js_run_binary` so tools executed with `use_execroot_entry_point` use exec-configuration runfiles

### DIFF
--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -95,12 +95,36 @@ function logf_debug {
     fi
 }
 
+function _normalize_cpu {
+    case "$1" in
+    *aarch64* | *arm64*) echo "arm64" ;;
+    *amd64* | *k8* | *x86_64*) echo "x64" ;;
+    *) echo "$1" ;;
+    esac
+}
+
+function _use_exec_config_entry_point {
+    if [ "$(_normalize_cpu "${BAZEL_TARGET_CPU:-}")" != "$(_normalize_cpu "${JS_BINARY__TARGET_CPU:-}")" ]; then
+        return 0
+    fi
+    case "${BAZEL_BINDIR:-}" in
+    bazel-out/*-ST-* | bazel-out/platform-*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
 function resolve_execroot_bin_path {
     local short_path="$1"
+    local bindir="${BAZEL_BINDIR:-$JS_BINARY__BINDIR}"
+    if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
+        if _use_exec_config_entry_point; then
+            bindir="$JS_BINARY__BINDIR"
+        fi
+    fi
     if [[ "$short_path" == ../* ]]; then
-        echo "$JS_BINARY__EXECROOT/${BAZEL_BINDIR:-$JS_BINARY__BINDIR}/external/${short_path:3}"
+        echo "$JS_BINARY__EXECROOT/$bindir/external/${short_path:3}"
     else
-        echo "$JS_BINARY__EXECROOT/${BAZEL_BINDIR:-$JS_BINARY__BINDIR}/$short_path"
+        echo "$JS_BINARY__EXECROOT/$bindir/$short_path"
     fi
 }
 

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -381,6 +381,16 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
             testonly = kwargs.get("testonly", False),
         )
         extra_srcs.append(":{}".format(js_runfiles_name))
+        js_exec_runfiles_name = "{}_exec_runfiles".format(name)
+        _js_binary_exec_runfiles(
+            name = js_exec_runfiles_name,
+            tool = tool,
+            # Always tag the target manual since we should only build it when the final target is built.
+            tags = kwargs.get("tags", []) + ["manual"],
+            # Always propagate the testonly attribute
+            testonly = kwargs.get("testonly", False),
+        )
+        extra_srcs.append(":{}".format(js_exec_runfiles_name))
 
     if allow_execroot_entry_point_with_no_copy_data_to_bin:
         fixed_env["JS_BINARY__ALLOW_EXECROOT_ENTRY_POINT_WITH_NO_COPY_DATA_TO_BIN"] = "1"
@@ -400,3 +410,24 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
         use_default_shell_env = use_default_shell_env,
         **kwargs
     )
+
+def _js_binary_exec_runfiles_impl(ctx):
+    return DefaultInfo(
+        files = ctx.attr.tool[DefaultInfo].default_runfiles.files,
+    )
+
+_js_binary_exec_runfiles = rule(
+    implementation = _js_binary_exec_runfiles_impl,
+    attrs = {
+        "tool": attr.label(
+            doc = """The js_binary tool whose execution-configuration runfiles should be available as action inputs.
+
+            js_run_binary executes its tool in the execution configuration. When use_execroot_entry_point is enabled,
+            the tool's runfiles must come from the same configuration so native optional npm packages are filtered for
+            the platform that runs the action, not for the target platform being built.
+            """,
+            mandatory = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/js/private/test/image/custom_owner_test_app.listing
+++ b/js/private/test/image/custom_owner_test_app.listing
@@ -2,7 +2,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/
--r-xr-xr-x  0 100    0       xxxxx Jan  1  1970 ./js/private/test/image/bin
+-r-xr-xr-x  0 100    0       25394 Jan  1  1970 ./js/private/test/image/bin
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
@@ -14,7 +14,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image-fixture-d/
 -r-xr-xr-x  0 100    0         128 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image-fixture-d/package.json
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/
--r-xr-xr-x  0 100    0       xxxxx Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/bin
+-r-xr-xr-x  0 100    0       25394 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/bin
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_node_bin/
 -r-xr-xr-x  0 100    0         133 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x  0 100    0          20 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/main.js

--- a/js/private/test/image/default_test_app.listing
+++ b/js/private/test/image/default_test_app.listing
@@ -2,7 +2,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/
--r-xr-xr-x  0 0      0       xxxxx Jan  1  1970 ./js/private/test/image/bin
+-r-xr-xr-x  0 0      0       25394 Jan  1  1970 ./js/private/test/image/bin
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
@@ -14,7 +14,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image-fixture-d/
 -r-xr-xr-x  0 0      0         128 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image-fixture-d/package.json
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/
--r-xr-xr-x  0 0      0       xxxxx Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/bin
+-r-xr-xr-x  0 0      0       25394 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/bin
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_node_bin/
 -r-xr-xr-x  0 0      0         133 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x  0 0      0          20 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/test/image/main.js

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_app.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_app.listing
@@ -4,7 +4,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/
--r-xr-xr-x  0 0      0       xxxxx Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2
+-r-xr-xr-x  0 0      0       25489 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
@@ -14,7 +14,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/
 -r-xr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/ㅑㅕㅣㅇ.ㄴㅅ
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_/
--r-xr-xr-x  0 0      0       xxxxx Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_/bin2
+-r-xr-xr-x  0 0      0       25489 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_/bin2
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_node_bin/
 -r-xr-xr-x  0 0      0         133 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/bin2_node_bin/node
 -r-xr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/test/image/non_ascii/empty empty.ㄴㅅ

--- a/js/private/test/image/regex_edge_cases_test_app.listing
+++ b/js/private/test/image/regex_edge_cases_test_app.listing
@@ -3,7 +3,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/
--r-xr-xr-x  0 0      0       xxxxx Jan  1  1970 ./app/js/private/test/image/bin
+-r-xr-xr-x  0 0      0       25394 Jan  1  1970 ./app/js/private/test/image/bin
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
@@ -15,7 +15,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/test/image-fixture-d/
 -r-xr-xr-x  0 0      0         128 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/test/image-fixture-d/package.json
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/
--r-xr-xr-x  0 0      0       xxxxx Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/bin
+-r-xr-xr-x  0 0      0       25394 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_/bin
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_node_bin/
 -r-xr-xr-x  0 0      0         133 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/test/image/bin_node_bin/node
 -r-xr-xr-x  0 0      0          20 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/test/image/main.js

--- a/js/private/test/js_run_binary_exec_config/BUILD.bazel
+++ b/js/private/test/js_run_binary_exec_config/BUILD.bazel
@@ -1,0 +1,72 @@
+load("@bazel_lib//lib:testing.bzl", "assert_contains")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//js:defs.bzl", "js_binary", "js_run_binary")
+
+config_setting(
+    name = "linux_arm64_target",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+platform(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+write_file(
+    name = "write_tool",
+    out = "tool.mjs",
+    content = [
+        """import { readFileSync } from "node:fs";""",
+        """import { dirname, join } from "node:path";""",
+        """import { fileURLToPath } from "node:url";""",
+        """const here = dirname(fileURLToPath(import.meta.url));""",
+        """console.log(readFileSync(join(here, "exec_config_marker.txt"), "utf8").trim());""",
+    ],
+)
+
+write_file(
+    name = "write_exec_marker",
+    out = "exec_config_marker.txt",
+    content = ["exec-config-data"],
+)
+
+write_file(
+    name = "write_target_marker",
+    out = "target_config_marker.txt",
+    content = ["target-config-data"],
+)
+
+js_binary(
+    name = "tool",
+    data = select({
+        ":linux_arm64_target": [":target_config_marker.txt"],
+        "//conditions:default": [":exec_config_marker.txt"],
+    }),
+    entry_point = "tool.mjs",
+)
+
+js_run_binary(
+    name = "run_tool",
+    stdout = "run_tool.out",
+    tool = ":tool",
+)
+
+platform_transition_filegroup(
+    name = "run_tool_linux_arm64",
+    testonly = True,
+    srcs = [":run_tool"],
+    target_platform = ":linux_arm64",
+)
+
+assert_contains(
+    name = "run_tool_uses_exec_config_runfiles",
+    actual = ":run_tool_linux_arm64",
+    expected = "exec-config-data",
+)

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -106,12 +106,36 @@ function logf_debug {
     fi
 }
 
+function _normalize_cpu {
+    case "$1" in
+    *aarch64* | *arm64*) echo "arm64" ;;
+    *amd64* | *k8* | *x86_64*) echo "x64" ;;
+    *) echo "$1" ;;
+    esac
+}
+
+function _use_exec_config_entry_point {
+    if [ "$(_normalize_cpu "${BAZEL_TARGET_CPU:-}")" != "$(_normalize_cpu "${JS_BINARY__TARGET_CPU:-}")" ]; then
+        return 0
+    fi
+    case "${BAZEL_BINDIR:-}" in
+    bazel-out/*-ST-* | bazel-out/platform-*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
 function resolve_execroot_bin_path {
     local short_path="$1"
+    local bindir="${BAZEL_BINDIR:-$JS_BINARY__BINDIR}"
+    if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ]; then
+        if _use_exec_config_entry_point; then
+            bindir="$JS_BINARY__BINDIR"
+        fi
+    fi
     if [[ "$short_path" == ../* ]]; then
-        echo "$JS_BINARY__EXECROOT/${BAZEL_BINDIR:-$JS_BINARY__BINDIR}/external/${short_path:3}"
+        echo "$JS_BINARY__EXECROOT/$bindir/external/${short_path:3}"
     else
-        echo "$JS_BINARY__EXECROOT/${BAZEL_BINDIR:-$JS_BINARY__BINDIR}/$short_path"
+        echo "$JS_BINARY__EXECROOT/$bindir/$short_path"
     fi
 }
 


### PR DESCRIPTION
`js_run_binary` runs its `tool` in exec config through `bazel-lib` `run_binary`, but previously hoisted the tool runfiles through target-config helper targets. When target and exec platforms differ, this can omit exec-platform files, including native optional npm packages such as `@rolldown/binding-linux-x64-gnu`.

This changes the runfiles hoist to use a helper rule with `cfg = "exec"` on the tool attribute. It also makes the launcher resolve execroot entry points with `JS_BINARY__BINDIR` when `JS_BINARY__USE_EXECROOT_ENTRY_POINT` is set, while preserving `BAZEL_BINDIR` for action context.

Repro repo: https://github.com/longlho/rules-js-exec-platform-repro

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fix `js_run_binary` with `use_execroot_entry_point` under differing target and execution platforms, including native optional npm dependency resolution for JS tools.

### Test plan

- New test cases added
- Manual testing:
  - `npm exec --yes @bazel/bazelisk -- test //js/private/test/js_run_binary_exec_config:run_tool_uses_exec_config_runfiles --test_output=all`
  - `npm exec --yes @bazel/bazelisk -- run //:buildifier.check`
  - `npm exec --yes @bazel/bazelisk -- test //js/private/test/js_binary_sh/... //js/private/test/js_run_binary_exec_config:run_tool_uses_exec_config_runfiles --test_output=errors`