### PR TITLE
fix: declare tar toolchain for package extraction

### DIFF
--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -260,6 +260,7 @@ def _npm_package_store_impl(ctx):
                     execution_requirements = {
                         "supports-path-mapping": "1",
                     },
+                    toolchain = tar_lib.toolchain_type,
 
                     # Always override the locale to give better hermeticity.
                     # See https://github.com/aspect-build/rules_js/issues/2039


### PR DESCRIPTION
Bazel's strict auto-exec-groups mode requires actions that run executables from toolchains to identify the matching action toolchain. npm_package_store already resolves bsdtar from tar.bzl's toolchain, so carry that same toolchain through to ctx.actions.run instead of leaving Bazel to infer where the executable came from.

---

### Test plan

Ran `bazel build --nobuild --incompatible_auto_exec_groups //npm/private/test:node_modules_test`. Additionally in our repo we are working towards enabling incompatible_auto_exec_groups and use this patch.