### PR TITLE
fix(nextjs): add allow_overwrites to standalone copy_to_directory for…

### DIFF
--- a/contrib/nextjs/defs.bzl
+++ b/contrib/nextjs/defs.bzl
@@ -406,6 +406,7 @@ def nextjs_standalone_server(name, app, pkg = None, data = [], **kwargs):
             "public": "standalone/{}/public".format(pkg),
         },
         out = standalone_outdir,
+        allow_overwrites = True,
         visibility = ["//visibility:private"],
         tags = ["manual"],
     )


### PR DESCRIPTION
● Fix duplicate output file error in `nextjs_standalone_server` when using Next.js 16+.

  Starting with Next.js 16, the standalone build already embeds `.next/static`
  inside `.next/standalone/{pkg}/.next/static`. The `copy_to_directory` rule in
  `nextjs_standalone_server` also copies `.next/static` separately and maps it to
  the same destination path via `replace_prefixes`, causing Bazel to fail with:

  duplicate output file 'standalone/.../.next/static/...' configured from source files
  '.../.next/standalone/.../.next/static/...' and '.../.next/static/...';
  set 'allow_overwrites' to True to allow this

  Both sources produce identical file content — Next.js copies static assets into
  the standalone directory for exactly this reason — so `allow_overwrites = True`
  is safe.

  ---

  ### Changes are visible to end-users: yes

  - Searched for relevant documentation and updated as needed: no
  - Breaking change (forces users to change their own code or config): no
  - Suggested release notes appear below: yes

  > `nextjs_standalone_server`: fix duplicate output file error when building with Next.js 16+, which now embeds `.next/static` inside the standalone
  directory.

  ### Test plan

  - Manual testing: upgrade a Next.js project to v16, run `nextjs_standalone_server`, confirm the build succeeds without the duplicate output file error.
  With Next.js ≤15 the `allow_overwrites` flag is a no-op since no duplicate paths exist.