### PR TITLE
fix: watch pnpm-workspace.yaml

### DIFF
--- a/npm/private/npm_translate_lock_state.bzl
+++ b/npm/private/npm_translate_lock_state.bzl
@@ -141,6 +141,7 @@ def _init_workspace(priv, rctx, is_windows):
     pnpm_lock_label = priv["pnpm_lock_label"]
     pnpm_workspace_label = pnpm_lock_label.same_package_label(PNPM_WORKSPACE_FILENAME)
     pnpm_workspace_path = rctx.path(pnpm_workspace_label)
+    rctx.watch(pnpm_workspace_path)
     if pnpm_workspace_path.exists:
         pnpm_workspace_json, workspace_parse_err = _yaml_to_json(rctx, pnpm_workspace_path, is_windows)
 


### PR DESCRIPTION
Otherwise changes will not (necessarily) trigger extension re-evalution.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no doc update needed.
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no (suggested PR title if anything).

### Test plan

- Covered by existing test cases
- Manual testing:
   1. `echo 9.1.0 > .bazelversion`
   2. `cd e2e/bzlmod`
   3. `bazel build :*` (build passes)
   4. put `@asdf:` in `e2e/bzlmod/pnpm-workspace.yaml` (or some other invalid syntax)
   5. `bazel build :*` (passes on main, fails with this PR as expected).
