### PR TITLE
perf: avoid AST depth depending on pnpm workspace size

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -44,6 +44,9 @@ buildifier = format.alias(
             "**/*.bzl",
             "**/*.star",
         ],
+        "exclude_patterns": [
+            "**/snapshots/**",
+        ],
     },
     summary = "Format Starlark files using buildifier.",
 )

--- a/e2e/npm_translate_lock_disable_hooks/snapshots/defs.bzl
+++ b/e2e/npm_translate_lock_disable_hooks/snapshots/defs.bzl
@@ -7,6 +7,16 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 _IMPORTER_PACKAGES = [""]
 
+def _link_pkg_0():
+    link_0()
+    return [":node_modules/@aspect-test/c"], {
+        "@aspect-test": [":node_modules/@aspect-test/c"],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "": _link_pkg_0,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -29,12 +39,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "":
-            link_0()
-            link_targets = [":node_modules/@aspect-test/c"]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/c"],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -64,6 +71,12 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "": {
+        "prod": [":node_modules/@aspect-test/c"],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -73,9 +86,10 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "":
-        if prod:
-            link_targets.extend([":node_modules/@aspect-test/c"])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]

--- a/e2e/npm_translate_lock_empty/snapshots/npm_defs.bzl
+++ b/e2e/npm_translate_lock_empty/snapshots/npm_defs.bzl
@@ -59,6 +59,8 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -68,6 +70,10 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]

--- a/e2e/npm_translate_lock_replace_packages/snapshots/npm_defs.bzl
+++ b/e2e/npm_translate_lock_replace_packages/snapshots/npm_defs.bzl
@@ -8,6 +8,18 @@ load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
 
 _IMPORTER_PACKAGES = [""]
 
+def _link_pkg_0():
+    link_0()
+    link_1()
+    return [
+        ":node_modules/chalk",
+        ":node_modules/lodash",
+    ], None
+
+_LINK_PACKAGE_FNS = {
+    "": _link_pkg_0,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -31,13 +43,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "":
-            link_0()
-            link_1()
-            link_targets = [
-                ":node_modules/chalk",
-                ":node_modules/lodash",
-            ]
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -67,6 +75,15 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "": {
+        "prod": [
+            ":node_modules/chalk",
+            ":node_modules/lodash",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -76,12 +93,10 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "":
-        if prod:
-            link_targets.extend([
-                ":node_modules/chalk",
-                ":node_modules/lodash",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]

--- a/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v101/snapshots/defs.bzl
@@ -175,6 +175,248 @@ load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_s
 
 _IMPORTER_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/alts", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
+def _link_pkg_0():
+    link_0("@aspect-test-a-bad-scope")
+    link_0("@aspect-test-custom-scope/a")
+    link_0()
+    link_0("@aspect-test/a2")
+    link_0("aspect-test-a-no-scope")
+    link_0("aspect-test-a/no-at")
+    link_1(dev=True)
+    link_2()
+    link_8()
+    link_9("@aspect-test/h-is-only-optional")
+    link_37("jsonify")
+    link_38()
+    link_53("rollup-plugin-with-peers")
+    link_55(dev=True)
+    link_59(dev=True)
+    link_59("alias-types-node", dev=True)
+    link_60("alias-only-sizzle", dev=True)
+    link_70()
+    link_79()
+    link_87()
+    link_93("highlightjs-git-https-notar")
+    link_99("is-odd-v0")
+    link_100("is-odd-v1")
+    link_101("is-odd-v2")
+    link_102("is-odd-v3")
+    link_103()
+    link_103("is-odd-alias")
+    link_104("jquery-git-ssh-399b201")
+    link_105("jquery-github")
+    link_106("jquery-git-https-763ade6")
+    link_107("jquery-git-ssh-e61fccb")
+    link_108("jquery-http-git-f85d521")
+    link_113()
+    link_114()
+    link_123()
+    link_124("rollup3")
+    link_145(dev=True)
+    link_156()
+    link_157()
+    link_159()
+    _fp_link_0()
+    _fp_link_2()
+    _fp_link_2("alias-project-a")
+    _fp_link_3()
+    _fp_link_3("scoped/bad")
+    _fp_link_4()
+    _fp_link_5()
+    _fp_link_6()
+    _fp_link_7()
+    _fp_link_8()
+    return [
+        ":node_modules/@aspect-test-a-bad-scope",
+        ":node_modules/@aspect-test-custom-scope/a",
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/a2",
+        ":node_modules/aspect-test-a-no-scope",
+        ":node_modules/aspect-test-a/no-at",
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/e",
+        ":node_modules/@aspect-test/h-is-only-optional",
+        ":node_modules/jsonify",
+        ":node_modules/@isaacs/cliui",
+        ":node_modules/rollup-plugin-with-peers",
+        ":node_modules/@vscode/vsce-sign",
+        ":node_modules/debug",
+        ":node_modules/esbuild",
+        ":node_modules/highlightjs-git-https-notar",
+        ":node_modules/is-odd-v0",
+        ":node_modules/is-odd-v1",
+        ":node_modules/is-odd-v2",
+        ":node_modules/is-odd-v3",
+        ":node_modules/is-odd",
+        ":node_modules/is-odd-alias",
+        ":node_modules/jquery-git-ssh-399b201",
+        ":node_modules/jquery-github",
+        ":node_modules/jquery-git-https-763ade6",
+        ":node_modules/jquery-git-ssh-e61fccb",
+        ":node_modules/jquery-http-git-f85d521",
+        ":node_modules/lodash",
+        ":node_modules/meaning-of-life",
+        ":node_modules/rollup",
+        ":node_modules/rollup3",
+        ":node_modules/tslib",
+        ":node_modules/typescript",
+        ":node_modules/uvu",
+        ":node_modules/@scoped/c",
+        ":node_modules/@scoped/a",
+        ":node_modules/alias-project-a",
+        ":node_modules/@scoped/b",
+        ":node_modules/scoped/bad",
+        ":node_modules/@scoped/d",
+        ":node_modules/alternate-versions",
+        ":node_modules/test-c200-d200",
+        ":node_modules/test-c201-d200",
+        ":node_modules/test-peer-types",
+        ":node_modules/@aspect-test/b",
+        ":node_modules/@types/archiver",
+        ":node_modules/@types/node",
+        ":node_modules/alias-types-node",
+        ":node_modules/alias-only-sizzle",
+        ":node_modules/sass-embedded",
+    ], {
+        "@aspect-test-a-bad-scop": [":node_modules/@aspect-test-a-bad-scope"],
+        "@aspect-test-custom-scope": [":node_modules/@aspect-test-custom-scope/a"],
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/a2",
+            ":node_modules/@aspect-test/b",
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/e",
+            ":node_modules/@aspect-test/h-is-only-optional",
+        ],
+        "@isaacs": [":node_modules/@isaacs/cliui"],
+        "@types": [
+            ":node_modules/@types/archiver",
+            ":node_modules/@types/node",
+        ],
+        "@vscode": [":node_modules/@vscode/vsce-sign"],
+        "@scoped": [
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+            ":node_modules/@scoped/d",
+        ],
+    }
+
+def _link_pkg_1():
+    link_2()
+    link_5()
+    return [
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/d",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    }
+
+def _link_pkg_2():
+    link_3()
+    link_6()
+    return [
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/d",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    }
+
+def _link_pkg_3():
+    link_37("jsonify", dev=True)
+    _fp_link_0()
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/jsonify",
+        ":node_modules/@scoped/c",
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+def _link_pkg_4():
+    link_59()
+    return [":node_modules/@types/node"], {
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_5():
+    link_59(dev=True)
+    _fp_link_2()
+    _fp_link_9()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@types/node",
+        ":node_modules/a-types",
+    ], {
+        "@types": [":node_modules/@types/node"],
+        "@scoped": [":node_modules/@scoped/a"],
+    }
+
+def _link_pkg_6():
+    link_110()
+    link_111("lodash-4.17.20")
+    link_112("lodash-4.17.21")
+    link_113("lodash-4.17.21-file")
+    return [
+        ":node_modules/lodash",
+        ":node_modules/lodash-4.17.20",
+        ":node_modules/lodash-4.17.21",
+        ":node_modules/lodash-4.17.21-file",
+    ], None
+
+def _link_pkg_7():
+    _fp_link_2()
+    _fp_link_3()
+    _fp_link_9()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+        ":node_modules/a-types",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+def _link_pkg_8():
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "<LOCKVERSION>": _link_pkg_0,
+    "projects/peers-combo-2": _link_pkg_1,
+    "projects/peers-combo-1": _link_pkg_2,
+    "projects/peer-types": _link_pkg_3,
+    "projects/a-types": _link_pkg_4,
+    "projects/b": _link_pkg_5,
+    "projects/alts": _link_pkg_6,
+    "projects/c": _link_pkg_7,
+    "projects/d": _link_pkg_8,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -470,235 +712,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "<LOCKVERSION>":
-            link_0("@aspect-test-a-bad-scope")
-            link_0("@aspect-test-custom-scope/a")
-            link_0()
-            link_0("@aspect-test/a2")
-            link_0("aspect-test-a-no-scope")
-            link_0("aspect-test-a/no-at")
-            link_1(dev=True)
-            link_2()
-            link_8()
-            link_9("@aspect-test/h-is-only-optional")
-            link_37("jsonify")
-            link_38()
-            link_53("rollup-plugin-with-peers")
-            link_55(dev=True)
-            link_59(dev=True)
-            link_59("alias-types-node", dev=True)
-            link_60("alias-only-sizzle", dev=True)
-            link_70()
-            link_79()
-            link_87()
-            link_93("highlightjs-git-https-notar")
-            link_99("is-odd-v0")
-            link_100("is-odd-v1")
-            link_101("is-odd-v2")
-            link_102("is-odd-v3")
-            link_103()
-            link_103("is-odd-alias")
-            link_104("jquery-git-ssh-399b201")
-            link_105("jquery-github")
-            link_106("jquery-git-https-763ade6")
-            link_107("jquery-git-ssh-e61fccb")
-            link_108("jquery-http-git-f85d521")
-            link_113()
-            link_114()
-            link_123()
-            link_124("rollup3")
-            link_145(dev=True)
-            link_156()
-            link_157()
-            link_159()
-            _fp_link_0()
-            _fp_link_2()
-            _fp_link_2("alias-project-a")
-            _fp_link_3()
-            _fp_link_3("scoped/bad")
-            _fp_link_4()
-            _fp_link_5()
-            _fp_link_6()
-            _fp_link_7()
-            _fp_link_8()
-            link_targets = [
-                ":node_modules/@aspect-test-a-bad-scope",
-                ":node_modules/@aspect-test-custom-scope/a",
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/a2",
-                ":node_modules/aspect-test-a-no-scope",
-                ":node_modules/aspect-test-a/no-at",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/e",
-                ":node_modules/@aspect-test/h-is-only-optional",
-                ":node_modules/jsonify",
-                ":node_modules/@isaacs/cliui",
-                ":node_modules/rollup-plugin-with-peers",
-                ":node_modules/@vscode/vsce-sign",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/highlightjs-git-https-notar",
-                ":node_modules/is-odd-v0",
-                ":node_modules/is-odd-v1",
-                ":node_modules/is-odd-v2",
-                ":node_modules/is-odd-v3",
-                ":node_modules/is-odd",
-                ":node_modules/is-odd-alias",
-                ":node_modules/jquery-git-ssh-399b201",
-                ":node_modules/jquery-github",
-                ":node_modules/jquery-git-https-763ade6",
-                ":node_modules/jquery-git-ssh-e61fccb",
-                ":node_modules/jquery-http-git-f85d521",
-                ":node_modules/lodash",
-                ":node_modules/meaning-of-life",
-                ":node_modules/rollup",
-                ":node_modules/rollup3",
-                ":node_modules/tslib",
-                ":node_modules/typescript",
-                ":node_modules/uvu",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/alias-project-a",
-                ":node_modules/@scoped/b",
-                ":node_modules/scoped/bad",
-                ":node_modules/@scoped/d",
-                ":node_modules/alternate-versions",
-                ":node_modules/test-c200-d200",
-                ":node_modules/test-c201-d200",
-                ":node_modules/test-peer-types",
-                ":node_modules/@aspect-test/b",
-                ":node_modules/@types/archiver",
-                ":node_modules/@types/node",
-                ":node_modules/alias-types-node",
-                ":node_modules/alias-only-sizzle",
-                ":node_modules/sass-embedded",
-            ]
-            scope_targets = {
-                "@aspect-test-a-bad-scop": [":node_modules/@aspect-test-a-bad-scope"],
-                "@aspect-test-custom-scope": [":node_modules/@aspect-test-custom-scope/a"],
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/a2",
-                    ":node_modules/@aspect-test/b",
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/e",
-                    ":node_modules/@aspect-test/h-is-only-optional",
-                ],
-                "@isaacs": [":node_modules/@isaacs/cliui"],
-                "@types": [
-                    ":node_modules/@types/archiver",
-                    ":node_modules/@types/node",
-                ],
-                "@vscode": [":node_modules/@vscode/vsce-sign"],
-                "@scoped": [
-                    ":node_modules/@scoped/c",
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                    ":node_modules/@scoped/d",
-                ],
-            }
-        elif bazel_package == "projects/peers-combo-2":
-            link_2()
-            link_5()
-            link_targets = [
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/d",
-                ],
-            }
-        elif bazel_package == "projects/peers-combo-1":
-            link_3()
-            link_6()
-            link_targets = [
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/d",
-                ],
-            }
-        elif bazel_package == "projects/peer-types":
-            link_37("jsonify", dev=True)
-            _fp_link_0()
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/jsonify",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/c",
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
-        elif bazel_package == "projects/a-types":
-            link_59()
-            link_targets = [":node_modules/@types/node"]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "projects/b":
-            link_59(dev=True)
-            _fp_link_2()
-            _fp_link_9()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@types/node",
-                ":node_modules/a-types",
-            ]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-                "@scoped": [":node_modules/@scoped/a"],
-            }
-        elif bazel_package == "projects/alts":
-            link_110()
-            link_111("lodash-4.17.20")
-            link_112("lodash-4.17.21")
-            link_113("lodash-4.17.21-file")
-            link_targets = [
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.20",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-file",
-            ]
-        elif bazel_package == "projects/c":
-            _fp_link_2()
-            _fp_link_3()
-            _fp_link_9()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-                ":node_modules/a-types",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
-        elif bazel_package == "projects/d":
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -728,6 +744,116 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "<LOCKVERSION>": {
+        "prod": [
+            ":node_modules/@aspect-test-a-bad-scope",
+            ":node_modules/@aspect-test-custom-scope/a",
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/a2",
+            ":node_modules/aspect-test-a-no-scope",
+            ":node_modules/aspect-test-a/no-at",
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/e",
+            ":node_modules/@aspect-test/h-is-only-optional",
+            ":node_modules/jsonify",
+            ":node_modules/@isaacs/cliui",
+            ":node_modules/rollup-plugin-with-peers",
+            ":node_modules/@vscode/vsce-sign",
+            ":node_modules/debug",
+            ":node_modules/esbuild",
+            ":node_modules/highlightjs-git-https-notar",
+            ":node_modules/is-odd-v0",
+            ":node_modules/is-odd-v1",
+            ":node_modules/is-odd-v2",
+            ":node_modules/is-odd-v3",
+            ":node_modules/is-odd",
+            ":node_modules/is-odd-alias",
+            ":node_modules/jquery-git-ssh-399b201",
+            ":node_modules/jquery-github",
+            ":node_modules/jquery-git-https-763ade6",
+            ":node_modules/jquery-git-ssh-e61fccb",
+            ":node_modules/jquery-http-git-f85d521",
+            ":node_modules/lodash",
+            ":node_modules/meaning-of-life",
+            ":node_modules/rollup",
+            ":node_modules/rollup3",
+            ":node_modules/tslib",
+            ":node_modules/typescript",
+            ":node_modules/uvu",
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/alias-project-a",
+            ":node_modules/@scoped/b",
+            ":node_modules/scoped/bad",
+            ":node_modules/@scoped/d",
+            ":node_modules/alternate-versions",
+            ":node_modules/test-c200-d200",
+            ":node_modules/test-c201-d200",
+            ":node_modules/test-peer-types",
+        ],
+        "dev": [
+            ":node_modules/@aspect-test/b",
+            ":node_modules/@types/archiver",
+            ":node_modules/@types/node",
+            ":node_modules/alias-types-node",
+            ":node_modules/alias-only-sizzle",
+            ":node_modules/sass-embedded",
+        ],
+    },
+    "projects/peers-combo-2": {
+        "prod": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    },
+    "projects/peers-combo-1": {
+        "prod": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    },
+    "projects/peer-types": {
+        "dev": [
+            ":node_modules/jsonify",
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    },
+    "projects/a-types": {
+        "prod": [":node_modules/@types/node"],
+    },
+    "projects/b": {
+        "prod": [":node_modules/@scoped/a"],
+        "dev": [
+            ":node_modules/@types/node",
+            ":node_modules/a-types",
+        ],
+    },
+    "projects/alts": {
+        "prod": [
+            ":node_modules/lodash",
+            ":node_modules/lodash-4.17.20",
+            ":node_modules/lodash-4.17.21",
+            ":node_modules/lodash-4.17.21-file",
+        ],
+    },
+    "projects/c": {
+        "prod": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+        "dev": [":node_modules/a-types"],
+    },
+    "projects/d": {
+        "prod": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -737,118 +863,12 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "<LOCKVERSION>":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test-a-bad-scope",
-                ":node_modules/@aspect-test-custom-scope/a",
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/a2",
-                ":node_modules/aspect-test-a-no-scope",
-                ":node_modules/aspect-test-a/no-at",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/e",
-                ":node_modules/@aspect-test/h-is-only-optional",
-                ":node_modules/jsonify",
-                ":node_modules/@isaacs/cliui",
-                ":node_modules/rollup-plugin-with-peers",
-                ":node_modules/@vscode/vsce-sign",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/highlightjs-git-https-notar",
-                ":node_modules/is-odd-v0",
-                ":node_modules/is-odd-v1",
-                ":node_modules/is-odd-v2",
-                ":node_modules/is-odd-v3",
-                ":node_modules/is-odd",
-                ":node_modules/is-odd-alias",
-                ":node_modules/jquery-git-ssh-399b201",
-                ":node_modules/jquery-github",
-                ":node_modules/jquery-git-https-763ade6",
-                ":node_modules/jquery-git-ssh-e61fccb",
-                ":node_modules/jquery-http-git-f85d521",
-                ":node_modules/lodash",
-                ":node_modules/meaning-of-life",
-                ":node_modules/rollup",
-                ":node_modules/rollup3",
-                ":node_modules/tslib",
-                ":node_modules/typescript",
-                ":node_modules/uvu",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/alias-project-a",
-                ":node_modules/@scoped/b",
-                ":node_modules/scoped/bad",
-                ":node_modules/@scoped/d",
-                ":node_modules/alternate-versions",
-                ":node_modules/test-c200-d200",
-                ":node_modules/test-c201-d200",
-                ":node_modules/test-peer-types",
-            ])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@aspect-test/b",
-                ":node_modules/@types/archiver",
-                ":node_modules/@types/node",
-                ":node_modules/alias-types-node",
-                ":node_modules/alias-only-sizzle",
-                ":node_modules/sass-embedded",
-            ])
-    elif bazel_package == "projects/peers-combo-2":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ])
-    elif bazel_package == "projects/peers-combo-1":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ])
-    elif bazel_package == "projects/peer-types":
-        if dev:
-            link_targets.extend([
-                ":node_modules/jsonify",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
-    elif bazel_package == "projects/a-types":
-        if prod:
-            link_targets.extend([":node_modules/@types/node"])
-    elif bazel_package == "projects/b":
-        if prod:
-            link_targets.extend([":node_modules/@scoped/a"])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@types/node",
-                ":node_modules/a-types",
-            ])
-    elif bazel_package == "projects/alts":
-        if prod:
-            link_targets.extend([
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.20",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-file",
-            ])
-    elif bazel_package == "projects/c":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
-        if dev:
-            link_targets.extend([":node_modules/a-types"])
-    elif bazel_package == "projects/d":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package

--- a/e2e/pnpm_lockfiles/v110/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v110/snapshots/defs.bzl
@@ -175,6 +175,248 @@ load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_s
 
 _IMPORTER_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/alts", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
+def _link_pkg_0():
+    link_0("@aspect-test-a-bad-scope")
+    link_0("@aspect-test-custom-scope/a")
+    link_0()
+    link_0("@aspect-test/a2")
+    link_0("aspect-test-a-no-scope")
+    link_0("aspect-test-a/no-at")
+    link_1(dev=True)
+    link_2()
+    link_8()
+    link_9("@aspect-test/h-is-only-optional")
+    link_37("jsonify")
+    link_38()
+    link_53("rollup-plugin-with-peers")
+    link_55(dev=True)
+    link_59(dev=True)
+    link_59("alias-types-node", dev=True)
+    link_60("alias-only-sizzle", dev=True)
+    link_70()
+    link_79()
+    link_87()
+    link_93("highlightjs-git-https-notar")
+    link_99("is-odd-v0")
+    link_100("is-odd-v1")
+    link_101("is-odd-v2")
+    link_102("is-odd-v3")
+    link_103()
+    link_103("is-odd-alias")
+    link_104("jquery-git-https-763ade6")
+    link_105("jquery-git-ssh-399b201")
+    link_106("jquery-github")
+    link_107("jquery-git-ssh-e61fccb")
+    link_108("jquery-http-git-f85d521")
+    link_113()
+    link_114()
+    link_123()
+    link_124("rollup3")
+    link_145(dev=True)
+    link_156()
+    link_157()
+    link_159()
+    _fp_link_0()
+    _fp_link_2()
+    _fp_link_2("alias-project-a")
+    _fp_link_3()
+    _fp_link_3("scoped/bad")
+    _fp_link_4()
+    _fp_link_5()
+    _fp_link_6()
+    _fp_link_7()
+    _fp_link_8()
+    return [
+        ":node_modules/@aspect-test-a-bad-scope",
+        ":node_modules/@aspect-test-custom-scope/a",
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/a2",
+        ":node_modules/aspect-test-a-no-scope",
+        ":node_modules/aspect-test-a/no-at",
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/e",
+        ":node_modules/@aspect-test/h-is-only-optional",
+        ":node_modules/jsonify",
+        ":node_modules/@isaacs/cliui",
+        ":node_modules/rollup-plugin-with-peers",
+        ":node_modules/@vscode/vsce-sign",
+        ":node_modules/debug",
+        ":node_modules/esbuild",
+        ":node_modules/highlightjs-git-https-notar",
+        ":node_modules/is-odd-v0",
+        ":node_modules/is-odd-v1",
+        ":node_modules/is-odd-v2",
+        ":node_modules/is-odd-v3",
+        ":node_modules/is-odd",
+        ":node_modules/is-odd-alias",
+        ":node_modules/jquery-git-https-763ade6",
+        ":node_modules/jquery-git-ssh-399b201",
+        ":node_modules/jquery-github",
+        ":node_modules/jquery-git-ssh-e61fccb",
+        ":node_modules/jquery-http-git-f85d521",
+        ":node_modules/lodash",
+        ":node_modules/meaning-of-life",
+        ":node_modules/rollup",
+        ":node_modules/rollup3",
+        ":node_modules/tslib",
+        ":node_modules/typescript",
+        ":node_modules/uvu",
+        ":node_modules/@scoped/c",
+        ":node_modules/@scoped/a",
+        ":node_modules/alias-project-a",
+        ":node_modules/@scoped/b",
+        ":node_modules/scoped/bad",
+        ":node_modules/@scoped/d",
+        ":node_modules/alternate-versions",
+        ":node_modules/test-c200-d200",
+        ":node_modules/test-c201-d200",
+        ":node_modules/test-peer-types",
+        ":node_modules/@aspect-test/b",
+        ":node_modules/@types/archiver",
+        ":node_modules/@types/node",
+        ":node_modules/alias-types-node",
+        ":node_modules/alias-only-sizzle",
+        ":node_modules/sass-embedded",
+    ], {
+        "@aspect-test-a-bad-scop": [":node_modules/@aspect-test-a-bad-scope"],
+        "@aspect-test-custom-scope": [":node_modules/@aspect-test-custom-scope/a"],
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/a2",
+            ":node_modules/@aspect-test/b",
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/e",
+            ":node_modules/@aspect-test/h-is-only-optional",
+        ],
+        "@isaacs": [":node_modules/@isaacs/cliui"],
+        "@types": [
+            ":node_modules/@types/archiver",
+            ":node_modules/@types/node",
+        ],
+        "@vscode": [":node_modules/@vscode/vsce-sign"],
+        "@scoped": [
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+            ":node_modules/@scoped/d",
+        ],
+    }
+
+def _link_pkg_1():
+    link_2()
+    link_5()
+    return [
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/d",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    }
+
+def _link_pkg_2():
+    link_3()
+    link_6()
+    return [
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/d",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    }
+
+def _link_pkg_3():
+    link_37("jsonify", dev=True)
+    _fp_link_0()
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/jsonify",
+        ":node_modules/@scoped/c",
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+def _link_pkg_4():
+    link_59()
+    return [":node_modules/@types/node"], {
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_5():
+    link_59(dev=True)
+    _fp_link_2()
+    _fp_link_9()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@types/node",
+        ":node_modules/a-types",
+    ], {
+        "@types": [":node_modules/@types/node"],
+        "@scoped": [":node_modules/@scoped/a"],
+    }
+
+def _link_pkg_6():
+    link_110()
+    link_111("lodash-4.17.20")
+    link_112("lodash-4.17.21")
+    link_113("lodash-4.17.21-file")
+    return [
+        ":node_modules/lodash",
+        ":node_modules/lodash-4.17.20",
+        ":node_modules/lodash-4.17.21",
+        ":node_modules/lodash-4.17.21-file",
+    ], None
+
+def _link_pkg_7():
+    _fp_link_2()
+    _fp_link_3()
+    _fp_link_9()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+        ":node_modules/a-types",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+def _link_pkg_8():
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "<LOCKVERSION>": _link_pkg_0,
+    "projects/peers-combo-2": _link_pkg_1,
+    "projects/peers-combo-1": _link_pkg_2,
+    "projects/peer-types": _link_pkg_3,
+    "projects/a-types": _link_pkg_4,
+    "projects/b": _link_pkg_5,
+    "projects/alts": _link_pkg_6,
+    "projects/c": _link_pkg_7,
+    "projects/d": _link_pkg_8,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -470,235 +712,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "<LOCKVERSION>":
-            link_0("@aspect-test-a-bad-scope")
-            link_0("@aspect-test-custom-scope/a")
-            link_0()
-            link_0("@aspect-test/a2")
-            link_0("aspect-test-a-no-scope")
-            link_0("aspect-test-a/no-at")
-            link_1(dev=True)
-            link_2()
-            link_8()
-            link_9("@aspect-test/h-is-only-optional")
-            link_37("jsonify")
-            link_38()
-            link_53("rollup-plugin-with-peers")
-            link_55(dev=True)
-            link_59(dev=True)
-            link_59("alias-types-node", dev=True)
-            link_60("alias-only-sizzle", dev=True)
-            link_70()
-            link_79()
-            link_87()
-            link_93("highlightjs-git-https-notar")
-            link_99("is-odd-v0")
-            link_100("is-odd-v1")
-            link_101("is-odd-v2")
-            link_102("is-odd-v3")
-            link_103()
-            link_103("is-odd-alias")
-            link_104("jquery-git-https-763ade6")
-            link_105("jquery-git-ssh-399b201")
-            link_106("jquery-github")
-            link_107("jquery-git-ssh-e61fccb")
-            link_108("jquery-http-git-f85d521")
-            link_113()
-            link_114()
-            link_123()
-            link_124("rollup3")
-            link_145(dev=True)
-            link_156()
-            link_157()
-            link_159()
-            _fp_link_0()
-            _fp_link_2()
-            _fp_link_2("alias-project-a")
-            _fp_link_3()
-            _fp_link_3("scoped/bad")
-            _fp_link_4()
-            _fp_link_5()
-            _fp_link_6()
-            _fp_link_7()
-            _fp_link_8()
-            link_targets = [
-                ":node_modules/@aspect-test-a-bad-scope",
-                ":node_modules/@aspect-test-custom-scope/a",
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/a2",
-                ":node_modules/aspect-test-a-no-scope",
-                ":node_modules/aspect-test-a/no-at",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/e",
-                ":node_modules/@aspect-test/h-is-only-optional",
-                ":node_modules/jsonify",
-                ":node_modules/@isaacs/cliui",
-                ":node_modules/rollup-plugin-with-peers",
-                ":node_modules/@vscode/vsce-sign",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/highlightjs-git-https-notar",
-                ":node_modules/is-odd-v0",
-                ":node_modules/is-odd-v1",
-                ":node_modules/is-odd-v2",
-                ":node_modules/is-odd-v3",
-                ":node_modules/is-odd",
-                ":node_modules/is-odd-alias",
-                ":node_modules/jquery-git-https-763ade6",
-                ":node_modules/jquery-git-ssh-399b201",
-                ":node_modules/jquery-github",
-                ":node_modules/jquery-git-ssh-e61fccb",
-                ":node_modules/jquery-http-git-f85d521",
-                ":node_modules/lodash",
-                ":node_modules/meaning-of-life",
-                ":node_modules/rollup",
-                ":node_modules/rollup3",
-                ":node_modules/tslib",
-                ":node_modules/typescript",
-                ":node_modules/uvu",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/alias-project-a",
-                ":node_modules/@scoped/b",
-                ":node_modules/scoped/bad",
-                ":node_modules/@scoped/d",
-                ":node_modules/alternate-versions",
-                ":node_modules/test-c200-d200",
-                ":node_modules/test-c201-d200",
-                ":node_modules/test-peer-types",
-                ":node_modules/@aspect-test/b",
-                ":node_modules/@types/archiver",
-                ":node_modules/@types/node",
-                ":node_modules/alias-types-node",
-                ":node_modules/alias-only-sizzle",
-                ":node_modules/sass-embedded",
-            ]
-            scope_targets = {
-                "@aspect-test-a-bad-scop": [":node_modules/@aspect-test-a-bad-scope"],
-                "@aspect-test-custom-scope": [":node_modules/@aspect-test-custom-scope/a"],
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/a2",
-                    ":node_modules/@aspect-test/b",
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/e",
-                    ":node_modules/@aspect-test/h-is-only-optional",
-                ],
-                "@isaacs": [":node_modules/@isaacs/cliui"],
-                "@types": [
-                    ":node_modules/@types/archiver",
-                    ":node_modules/@types/node",
-                ],
-                "@vscode": [":node_modules/@vscode/vsce-sign"],
-                "@scoped": [
-                    ":node_modules/@scoped/c",
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                    ":node_modules/@scoped/d",
-                ],
-            }
-        elif bazel_package == "projects/peers-combo-2":
-            link_2()
-            link_5()
-            link_targets = [
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/d",
-                ],
-            }
-        elif bazel_package == "projects/peers-combo-1":
-            link_3()
-            link_6()
-            link_targets = [
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/d",
-                ],
-            }
-        elif bazel_package == "projects/peer-types":
-            link_37("jsonify", dev=True)
-            _fp_link_0()
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/jsonify",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/c",
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
-        elif bazel_package == "projects/a-types":
-            link_59()
-            link_targets = [":node_modules/@types/node"]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "projects/b":
-            link_59(dev=True)
-            _fp_link_2()
-            _fp_link_9()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@types/node",
-                ":node_modules/a-types",
-            ]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-                "@scoped": [":node_modules/@scoped/a"],
-            }
-        elif bazel_package == "projects/alts":
-            link_110()
-            link_111("lodash-4.17.20")
-            link_112("lodash-4.17.21")
-            link_113("lodash-4.17.21-file")
-            link_targets = [
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.20",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-file",
-            ]
-        elif bazel_package == "projects/c":
-            _fp_link_2()
-            _fp_link_3()
-            _fp_link_9()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-                ":node_modules/a-types",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
-        elif bazel_package == "projects/d":
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -728,6 +744,116 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "<LOCKVERSION>": {
+        "prod": [
+            ":node_modules/@aspect-test-a-bad-scope",
+            ":node_modules/@aspect-test-custom-scope/a",
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/a2",
+            ":node_modules/aspect-test-a-no-scope",
+            ":node_modules/aspect-test-a/no-at",
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/e",
+            ":node_modules/@aspect-test/h-is-only-optional",
+            ":node_modules/jsonify",
+            ":node_modules/@isaacs/cliui",
+            ":node_modules/rollup-plugin-with-peers",
+            ":node_modules/@vscode/vsce-sign",
+            ":node_modules/debug",
+            ":node_modules/esbuild",
+            ":node_modules/highlightjs-git-https-notar",
+            ":node_modules/is-odd-v0",
+            ":node_modules/is-odd-v1",
+            ":node_modules/is-odd-v2",
+            ":node_modules/is-odd-v3",
+            ":node_modules/is-odd",
+            ":node_modules/is-odd-alias",
+            ":node_modules/jquery-git-https-763ade6",
+            ":node_modules/jquery-git-ssh-399b201",
+            ":node_modules/jquery-github",
+            ":node_modules/jquery-git-ssh-e61fccb",
+            ":node_modules/jquery-http-git-f85d521",
+            ":node_modules/lodash",
+            ":node_modules/meaning-of-life",
+            ":node_modules/rollup",
+            ":node_modules/rollup3",
+            ":node_modules/tslib",
+            ":node_modules/typescript",
+            ":node_modules/uvu",
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/alias-project-a",
+            ":node_modules/@scoped/b",
+            ":node_modules/scoped/bad",
+            ":node_modules/@scoped/d",
+            ":node_modules/alternate-versions",
+            ":node_modules/test-c200-d200",
+            ":node_modules/test-c201-d200",
+            ":node_modules/test-peer-types",
+        ],
+        "dev": [
+            ":node_modules/@aspect-test/b",
+            ":node_modules/@types/archiver",
+            ":node_modules/@types/node",
+            ":node_modules/alias-types-node",
+            ":node_modules/alias-only-sizzle",
+            ":node_modules/sass-embedded",
+        ],
+    },
+    "projects/peers-combo-2": {
+        "prod": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    },
+    "projects/peers-combo-1": {
+        "prod": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    },
+    "projects/peer-types": {
+        "dev": [
+            ":node_modules/jsonify",
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    },
+    "projects/a-types": {
+        "prod": [":node_modules/@types/node"],
+    },
+    "projects/b": {
+        "prod": [":node_modules/@scoped/a"],
+        "dev": [
+            ":node_modules/@types/node",
+            ":node_modules/a-types",
+        ],
+    },
+    "projects/alts": {
+        "prod": [
+            ":node_modules/lodash",
+            ":node_modules/lodash-4.17.20",
+            ":node_modules/lodash-4.17.21",
+            ":node_modules/lodash-4.17.21-file",
+        ],
+    },
+    "projects/c": {
+        "prod": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+        "dev": [":node_modules/a-types"],
+    },
+    "projects/d": {
+        "prod": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -737,118 +863,12 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "<LOCKVERSION>":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test-a-bad-scope",
-                ":node_modules/@aspect-test-custom-scope/a",
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/a2",
-                ":node_modules/aspect-test-a-no-scope",
-                ":node_modules/aspect-test-a/no-at",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/e",
-                ":node_modules/@aspect-test/h-is-only-optional",
-                ":node_modules/jsonify",
-                ":node_modules/@isaacs/cliui",
-                ":node_modules/rollup-plugin-with-peers",
-                ":node_modules/@vscode/vsce-sign",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/highlightjs-git-https-notar",
-                ":node_modules/is-odd-v0",
-                ":node_modules/is-odd-v1",
-                ":node_modules/is-odd-v2",
-                ":node_modules/is-odd-v3",
-                ":node_modules/is-odd",
-                ":node_modules/is-odd-alias",
-                ":node_modules/jquery-git-https-763ade6",
-                ":node_modules/jquery-git-ssh-399b201",
-                ":node_modules/jquery-github",
-                ":node_modules/jquery-git-ssh-e61fccb",
-                ":node_modules/jquery-http-git-f85d521",
-                ":node_modules/lodash",
-                ":node_modules/meaning-of-life",
-                ":node_modules/rollup",
-                ":node_modules/rollup3",
-                ":node_modules/tslib",
-                ":node_modules/typescript",
-                ":node_modules/uvu",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/alias-project-a",
-                ":node_modules/@scoped/b",
-                ":node_modules/scoped/bad",
-                ":node_modules/@scoped/d",
-                ":node_modules/alternate-versions",
-                ":node_modules/test-c200-d200",
-                ":node_modules/test-c201-d200",
-                ":node_modules/test-peer-types",
-            ])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@aspect-test/b",
-                ":node_modules/@types/archiver",
-                ":node_modules/@types/node",
-                ":node_modules/alias-types-node",
-                ":node_modules/alias-only-sizzle",
-                ":node_modules/sass-embedded",
-            ])
-    elif bazel_package == "projects/peers-combo-2":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ])
-    elif bazel_package == "projects/peers-combo-1":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ])
-    elif bazel_package == "projects/peer-types":
-        if dev:
-            link_targets.extend([
-                ":node_modules/jsonify",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
-    elif bazel_package == "projects/a-types":
-        if prod:
-            link_targets.extend([":node_modules/@types/node"])
-    elif bazel_package == "projects/b":
-        if prod:
-            link_targets.extend([":node_modules/@scoped/a"])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@types/node",
-                ":node_modules/a-types",
-            ])
-    elif bazel_package == "projects/alts":
-        if prod:
-            link_targets.extend([
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.20",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-file",
-            ])
-    elif bazel_package == "projects/c":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
-        if dev:
-            link_targets.extend([":node_modules/a-types"])
-    elif bazel_package == "projects/d":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package

--- a/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
+++ b/e2e/pnpm_lockfiles/v90/snapshots/defs.bzl
@@ -175,6 +175,248 @@ load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_s
 
 _IMPORTER_PACKAGES = ["<LOCKVERSION>", "projects/a", "projects/a-types", "projects/alts", "projects/b", "projects/c", "projects/d", "projects/peer-types", "projects/peers-combo-1", "projects/peers-combo-2", "vendored/is-number"]
 
+def _link_pkg_0():
+    link_0("@aspect-test-a-bad-scope")
+    link_0("@aspect-test-custom-scope/a")
+    link_0()
+    link_0("@aspect-test/a2")
+    link_0("aspect-test-a-no-scope")
+    link_0("aspect-test-a/no-at")
+    link_1(dev=True)
+    link_2()
+    link_8()
+    link_9("@aspect-test/h-is-only-optional")
+    link_37("jsonify")
+    link_38()
+    link_53("rollup-plugin-with-peers")
+    link_55(dev=True)
+    link_59(dev=True)
+    link_59("alias-types-node", dev=True)
+    link_60("alias-only-sizzle", dev=True)
+    link_70()
+    link_79()
+    link_87()
+    link_93("highlightjs-git-https-notar")
+    link_99("is-odd-v0")
+    link_100("is-odd-v1")
+    link_101("is-odd-v2")
+    link_102("is-odd-v3")
+    link_103()
+    link_103("is-odd-alias")
+    link_104("jquery-git-ssh-399b201")
+    link_105("jquery-github")
+    link_106("jquery-git-https-763ade6")
+    link_107("jquery-git-ssh-e61fccb")
+    link_108("jquery-http-git-f85d521")
+    link_113()
+    link_114()
+    link_123()
+    link_124("rollup3")
+    link_145(dev=True)
+    link_156()
+    link_157()
+    link_159()
+    _fp_link_0()
+    _fp_link_2()
+    _fp_link_2("alias-project-a")
+    _fp_link_3()
+    _fp_link_3("scoped/bad")
+    _fp_link_4()
+    _fp_link_5()
+    _fp_link_6()
+    _fp_link_7()
+    _fp_link_8()
+    return [
+        ":node_modules/@aspect-test-a-bad-scope",
+        ":node_modules/@aspect-test-custom-scope/a",
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/a2",
+        ":node_modules/aspect-test-a-no-scope",
+        ":node_modules/aspect-test-a/no-at",
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/e",
+        ":node_modules/@aspect-test/h-is-only-optional",
+        ":node_modules/jsonify",
+        ":node_modules/@isaacs/cliui",
+        ":node_modules/rollup-plugin-with-peers",
+        ":node_modules/@vscode/vsce-sign",
+        ":node_modules/debug",
+        ":node_modules/esbuild",
+        ":node_modules/highlightjs-git-https-notar",
+        ":node_modules/is-odd-v0",
+        ":node_modules/is-odd-v1",
+        ":node_modules/is-odd-v2",
+        ":node_modules/is-odd-v3",
+        ":node_modules/is-odd",
+        ":node_modules/is-odd-alias",
+        ":node_modules/jquery-git-ssh-399b201",
+        ":node_modules/jquery-github",
+        ":node_modules/jquery-git-https-763ade6",
+        ":node_modules/jquery-git-ssh-e61fccb",
+        ":node_modules/jquery-http-git-f85d521",
+        ":node_modules/lodash",
+        ":node_modules/meaning-of-life",
+        ":node_modules/rollup",
+        ":node_modules/rollup3",
+        ":node_modules/tslib",
+        ":node_modules/typescript",
+        ":node_modules/uvu",
+        ":node_modules/@scoped/c",
+        ":node_modules/@scoped/a",
+        ":node_modules/alias-project-a",
+        ":node_modules/@scoped/b",
+        ":node_modules/scoped/bad",
+        ":node_modules/@scoped/d",
+        ":node_modules/alternate-versions",
+        ":node_modules/test-c200-d200",
+        ":node_modules/test-c201-d200",
+        ":node_modules/test-peer-types",
+        ":node_modules/@aspect-test/b",
+        ":node_modules/@types/archiver",
+        ":node_modules/@types/node",
+        ":node_modules/alias-types-node",
+        ":node_modules/alias-only-sizzle",
+        ":node_modules/sass-embedded",
+    ], {
+        "@aspect-test-a-bad-scop": [":node_modules/@aspect-test-a-bad-scope"],
+        "@aspect-test-custom-scope": [":node_modules/@aspect-test-custom-scope/a"],
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/a2",
+            ":node_modules/@aspect-test/b",
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/e",
+            ":node_modules/@aspect-test/h-is-only-optional",
+        ],
+        "@isaacs": [":node_modules/@isaacs/cliui"],
+        "@types": [
+            ":node_modules/@types/archiver",
+            ":node_modules/@types/node",
+        ],
+        "@vscode": [":node_modules/@vscode/vsce-sign"],
+        "@scoped": [
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+            ":node_modules/@scoped/d",
+        ],
+    }
+
+def _link_pkg_1():
+    link_2()
+    link_5()
+    return [
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/d",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    }
+
+def _link_pkg_2():
+    link_3()
+    link_6()
+    return [
+        ":node_modules/@aspect-test/c",
+        ":node_modules/@aspect-test/d",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    }
+
+def _link_pkg_3():
+    link_37("jsonify", dev=True)
+    _fp_link_0()
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/jsonify",
+        ":node_modules/@scoped/c",
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+def _link_pkg_4():
+    link_59()
+    return [":node_modules/@types/node"], {
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_5():
+    link_59(dev=True)
+    _fp_link_2()
+    _fp_link_9()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@types/node",
+        ":node_modules/a-types",
+    ], {
+        "@types": [":node_modules/@types/node"],
+        "@scoped": [":node_modules/@scoped/a"],
+    }
+
+def _link_pkg_6():
+    link_110()
+    link_111("lodash-4.17.20")
+    link_112("lodash-4.17.21")
+    link_113("lodash-4.17.21-file")
+    return [
+        ":node_modules/lodash",
+        ":node_modules/lodash-4.17.20",
+        ":node_modules/lodash-4.17.21",
+        ":node_modules/lodash-4.17.21-file",
+    ], None
+
+def _link_pkg_7():
+    _fp_link_2()
+    _fp_link_3()
+    _fp_link_9()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+        ":node_modules/a-types",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+def _link_pkg_8():
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/@scoped/a",
+        ":node_modules/@scoped/b",
+    ], {
+        "@scoped": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "<LOCKVERSION>": _link_pkg_0,
+    "projects/peers-combo-2": _link_pkg_1,
+    "projects/peers-combo-1": _link_pkg_2,
+    "projects/peer-types": _link_pkg_3,
+    "projects/a-types": _link_pkg_4,
+    "projects/b": _link_pkg_5,
+    "projects/alts": _link_pkg_6,
+    "projects/c": _link_pkg_7,
+    "projects/d": _link_pkg_8,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -470,235 +712,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "<LOCKVERSION>":
-            link_0("@aspect-test-a-bad-scope")
-            link_0("@aspect-test-custom-scope/a")
-            link_0()
-            link_0("@aspect-test/a2")
-            link_0("aspect-test-a-no-scope")
-            link_0("aspect-test-a/no-at")
-            link_1(dev=True)
-            link_2()
-            link_8()
-            link_9("@aspect-test/h-is-only-optional")
-            link_37("jsonify")
-            link_38()
-            link_53("rollup-plugin-with-peers")
-            link_55(dev=True)
-            link_59(dev=True)
-            link_59("alias-types-node", dev=True)
-            link_60("alias-only-sizzle", dev=True)
-            link_70()
-            link_79()
-            link_87()
-            link_93("highlightjs-git-https-notar")
-            link_99("is-odd-v0")
-            link_100("is-odd-v1")
-            link_101("is-odd-v2")
-            link_102("is-odd-v3")
-            link_103()
-            link_103("is-odd-alias")
-            link_104("jquery-git-ssh-399b201")
-            link_105("jquery-github")
-            link_106("jquery-git-https-763ade6")
-            link_107("jquery-git-ssh-e61fccb")
-            link_108("jquery-http-git-f85d521")
-            link_113()
-            link_114()
-            link_123()
-            link_124("rollup3")
-            link_145(dev=True)
-            link_156()
-            link_157()
-            link_159()
-            _fp_link_0()
-            _fp_link_2()
-            _fp_link_2("alias-project-a")
-            _fp_link_3()
-            _fp_link_3("scoped/bad")
-            _fp_link_4()
-            _fp_link_5()
-            _fp_link_6()
-            _fp_link_7()
-            _fp_link_8()
-            link_targets = [
-                ":node_modules/@aspect-test-a-bad-scope",
-                ":node_modules/@aspect-test-custom-scope/a",
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/a2",
-                ":node_modules/aspect-test-a-no-scope",
-                ":node_modules/aspect-test-a/no-at",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/e",
-                ":node_modules/@aspect-test/h-is-only-optional",
-                ":node_modules/jsonify",
-                ":node_modules/@isaacs/cliui",
-                ":node_modules/rollup-plugin-with-peers",
-                ":node_modules/@vscode/vsce-sign",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/highlightjs-git-https-notar",
-                ":node_modules/is-odd-v0",
-                ":node_modules/is-odd-v1",
-                ":node_modules/is-odd-v2",
-                ":node_modules/is-odd-v3",
-                ":node_modules/is-odd",
-                ":node_modules/is-odd-alias",
-                ":node_modules/jquery-git-ssh-399b201",
-                ":node_modules/jquery-github",
-                ":node_modules/jquery-git-https-763ade6",
-                ":node_modules/jquery-git-ssh-e61fccb",
-                ":node_modules/jquery-http-git-f85d521",
-                ":node_modules/lodash",
-                ":node_modules/meaning-of-life",
-                ":node_modules/rollup",
-                ":node_modules/rollup3",
-                ":node_modules/tslib",
-                ":node_modules/typescript",
-                ":node_modules/uvu",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/alias-project-a",
-                ":node_modules/@scoped/b",
-                ":node_modules/scoped/bad",
-                ":node_modules/@scoped/d",
-                ":node_modules/alternate-versions",
-                ":node_modules/test-c200-d200",
-                ":node_modules/test-c201-d200",
-                ":node_modules/test-peer-types",
-                ":node_modules/@aspect-test/b",
-                ":node_modules/@types/archiver",
-                ":node_modules/@types/node",
-                ":node_modules/alias-types-node",
-                ":node_modules/alias-only-sizzle",
-                ":node_modules/sass-embedded",
-            ]
-            scope_targets = {
-                "@aspect-test-a-bad-scop": [":node_modules/@aspect-test-a-bad-scope"],
-                "@aspect-test-custom-scope": [":node_modules/@aspect-test-custom-scope/a"],
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/a2",
-                    ":node_modules/@aspect-test/b",
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/e",
-                    ":node_modules/@aspect-test/h-is-only-optional",
-                ],
-                "@isaacs": [":node_modules/@isaacs/cliui"],
-                "@types": [
-                    ":node_modules/@types/archiver",
-                    ":node_modules/@types/node",
-                ],
-                "@vscode": [":node_modules/@vscode/vsce-sign"],
-                "@scoped": [
-                    ":node_modules/@scoped/c",
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                    ":node_modules/@scoped/d",
-                ],
-            }
-        elif bazel_package == "projects/peers-combo-2":
-            link_2()
-            link_5()
-            link_targets = [
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/d",
-                ],
-            }
-        elif bazel_package == "projects/peers-combo-1":
-            link_3()
-            link_6()
-            link_targets = [
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/c",
-                    ":node_modules/@aspect-test/d",
-                ],
-            }
-        elif bazel_package == "projects/peer-types":
-            link_37("jsonify", dev=True)
-            _fp_link_0()
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/jsonify",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/c",
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
-        elif bazel_package == "projects/a-types":
-            link_59()
-            link_targets = [":node_modules/@types/node"]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "projects/b":
-            link_59(dev=True)
-            _fp_link_2()
-            _fp_link_9()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@types/node",
-                ":node_modules/a-types",
-            ]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-                "@scoped": [":node_modules/@scoped/a"],
-            }
-        elif bazel_package == "projects/alts":
-            link_110()
-            link_111("lodash-4.17.20")
-            link_112("lodash-4.17.21")
-            link_113("lodash-4.17.21-file")
-            link_targets = [
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.20",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-file",
-            ]
-        elif bazel_package == "projects/c":
-            _fp_link_2()
-            _fp_link_3()
-            _fp_link_9()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-                ":node_modules/a-types",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
-        elif bazel_package == "projects/d":
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ]
-            scope_targets = {
-                "@scoped": [
-                    ":node_modules/@scoped/a",
-                    ":node_modules/@scoped/b",
-                ],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -728,6 +744,116 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "<LOCKVERSION>": {
+        "prod": [
+            ":node_modules/@aspect-test-a-bad-scope",
+            ":node_modules/@aspect-test-custom-scope/a",
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/a2",
+            ":node_modules/aspect-test-a-no-scope",
+            ":node_modules/aspect-test-a/no-at",
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/e",
+            ":node_modules/@aspect-test/h-is-only-optional",
+            ":node_modules/jsonify",
+            ":node_modules/@isaacs/cliui",
+            ":node_modules/rollup-plugin-with-peers",
+            ":node_modules/@vscode/vsce-sign",
+            ":node_modules/debug",
+            ":node_modules/esbuild",
+            ":node_modules/highlightjs-git-https-notar",
+            ":node_modules/is-odd-v0",
+            ":node_modules/is-odd-v1",
+            ":node_modules/is-odd-v2",
+            ":node_modules/is-odd-v3",
+            ":node_modules/is-odd",
+            ":node_modules/is-odd-alias",
+            ":node_modules/jquery-git-ssh-399b201",
+            ":node_modules/jquery-github",
+            ":node_modules/jquery-git-https-763ade6",
+            ":node_modules/jquery-git-ssh-e61fccb",
+            ":node_modules/jquery-http-git-f85d521",
+            ":node_modules/lodash",
+            ":node_modules/meaning-of-life",
+            ":node_modules/rollup",
+            ":node_modules/rollup3",
+            ":node_modules/tslib",
+            ":node_modules/typescript",
+            ":node_modules/uvu",
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/alias-project-a",
+            ":node_modules/@scoped/b",
+            ":node_modules/scoped/bad",
+            ":node_modules/@scoped/d",
+            ":node_modules/alternate-versions",
+            ":node_modules/test-c200-d200",
+            ":node_modules/test-c201-d200",
+            ":node_modules/test-peer-types",
+        ],
+        "dev": [
+            ":node_modules/@aspect-test/b",
+            ":node_modules/@types/archiver",
+            ":node_modules/@types/node",
+            ":node_modules/alias-types-node",
+            ":node_modules/alias-only-sizzle",
+            ":node_modules/sass-embedded",
+        ],
+    },
+    "projects/peers-combo-2": {
+        "prod": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    },
+    "projects/peers-combo-1": {
+        "prod": [
+            ":node_modules/@aspect-test/c",
+            ":node_modules/@aspect-test/d",
+        ],
+    },
+    "projects/peer-types": {
+        "dev": [
+            ":node_modules/jsonify",
+            ":node_modules/@scoped/c",
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    },
+    "projects/a-types": {
+        "prod": [":node_modules/@types/node"],
+    },
+    "projects/b": {
+        "prod": [":node_modules/@scoped/a"],
+        "dev": [
+            ":node_modules/@types/node",
+            ":node_modules/a-types",
+        ],
+    },
+    "projects/alts": {
+        "prod": [
+            ":node_modules/lodash",
+            ":node_modules/lodash-4.17.20",
+            ":node_modules/lodash-4.17.21",
+            ":node_modules/lodash-4.17.21-file",
+        ],
+    },
+    "projects/c": {
+        "prod": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+        "dev": [":node_modules/a-types"],
+    },
+    "projects/d": {
+        "prod": [
+            ":node_modules/@scoped/a",
+            ":node_modules/@scoped/b",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -737,118 +863,12 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "<LOCKVERSION>":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test-a-bad-scope",
-                ":node_modules/@aspect-test-custom-scope/a",
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/a2",
-                ":node_modules/aspect-test-a-no-scope",
-                ":node_modules/aspect-test-a/no-at",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/e",
-                ":node_modules/@aspect-test/h-is-only-optional",
-                ":node_modules/jsonify",
-                ":node_modules/@isaacs/cliui",
-                ":node_modules/rollup-plugin-with-peers",
-                ":node_modules/@vscode/vsce-sign",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/highlightjs-git-https-notar",
-                ":node_modules/is-odd-v0",
-                ":node_modules/is-odd-v1",
-                ":node_modules/is-odd-v2",
-                ":node_modules/is-odd-v3",
-                ":node_modules/is-odd",
-                ":node_modules/is-odd-alias",
-                ":node_modules/jquery-git-ssh-399b201",
-                ":node_modules/jquery-github",
-                ":node_modules/jquery-git-https-763ade6",
-                ":node_modules/jquery-git-ssh-e61fccb",
-                ":node_modules/jquery-http-git-f85d521",
-                ":node_modules/lodash",
-                ":node_modules/meaning-of-life",
-                ":node_modules/rollup",
-                ":node_modules/rollup3",
-                ":node_modules/tslib",
-                ":node_modules/typescript",
-                ":node_modules/uvu",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/alias-project-a",
-                ":node_modules/@scoped/b",
-                ":node_modules/scoped/bad",
-                ":node_modules/@scoped/d",
-                ":node_modules/alternate-versions",
-                ":node_modules/test-c200-d200",
-                ":node_modules/test-c201-d200",
-                ":node_modules/test-peer-types",
-            ])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@aspect-test/b",
-                ":node_modules/@types/archiver",
-                ":node_modules/@types/node",
-                ":node_modules/alias-types-node",
-                ":node_modules/alias-only-sizzle",
-                ":node_modules/sass-embedded",
-            ])
-    elif bazel_package == "projects/peers-combo-2":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ])
-    elif bazel_package == "projects/peers-combo-1":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/c",
-                ":node_modules/@aspect-test/d",
-            ])
-    elif bazel_package == "projects/peer-types":
-        if dev:
-            link_targets.extend([
-                ":node_modules/jsonify",
-                ":node_modules/@scoped/c",
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
-    elif bazel_package == "projects/a-types":
-        if prod:
-            link_targets.extend([":node_modules/@types/node"])
-    elif bazel_package == "projects/b":
-        if prod:
-            link_targets.extend([":node_modules/@scoped/a"])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@types/node",
-                ":node_modules/a-types",
-            ])
-    elif bazel_package == "projects/alts":
-        if prod:
-            link_targets.extend([
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.20",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-file",
-            ])
-    elif bazel_package == "projects/c":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
-        if dev:
-            link_targets.extend([":node_modules/a-types"])
-    elif bazel_package == "projects/d":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@scoped/a",
-                ":node_modules/@scoped/b",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@scoped/c" package

--- a/e2e/pnpm_workspace/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace/snapshots/defs.bzl
@@ -25,6 +25,146 @@ load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_s
 
 _IMPORTER_PACKAGES = ["", "app/a", "app/b", "app/c", "app/d", "lib/a", "lib/b", "lib/c", "lib/d", "lib/d/e", "lib/d/f"]
 
+def _link_pkg_0():
+    link_0()
+    link_1(dev=True)
+    link_2()
+    link_10()
+    link_11()
+    return [
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/c",
+        ":node_modules/lodash",
+        ":node_modules/typescript",
+        ":node_modules/@aspect-test/b",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/b",
+            ":node_modules/@aspect-test/c",
+        ],
+    }
+
+def _link_pkg_1():
+    link_0()
+    link_6()
+    _fp_link_2()
+    return [
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/g",
+        ":node_modules/@lib/a",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/g",
+        ],
+        "@lib": [":node_modules/@lib/a"],
+    }
+
+def _link_pkg_2():
+    link_0()
+    link_6()
+    _fp_link_4()
+    return [
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/g",
+        ":node_modules/@lib/c",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/g",
+        ],
+        "@lib": [":node_modules/@lib/c"],
+    }
+
+def _link_pkg_3():
+    link_3()
+    link_8("alias-2")
+    _fp_link_6()
+    _fp_link_7()
+    return [
+        ":node_modules/@aspect-test/d",
+        ":node_modules/alias-2",
+        ":node_modules/@lib/e",
+        ":node_modules/@lib/f",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/d"],
+        "@lib": [
+            ":node_modules/@lib/e",
+            ":node_modules/@lib/f",
+        ],
+    }
+
+def _link_pkg_4():
+    link_4()
+    _fp_link_0()
+    _fp_link_1()
+    _fp_link_3()
+    return [
+        ":node_modules/@aspect-test/e",
+        ":node_modules/vendored-a",
+        ":node_modules/vendored-b",
+        ":node_modules/@lib/b",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/e"],
+        "@lib": [":node_modules/@lib/b"],
+    }
+
+def _link_pkg_5():
+    link_5()
+    link_9("alias-1")
+    return [
+        ":node_modules/@aspect-test/f",
+        ":node_modules/alias-1",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/f"],
+    }
+
+def _link_pkg_6():
+    link_5()
+    return [":node_modules/@aspect-test/f"], {
+        "@aspect-test": [":node_modules/@aspect-test/f"],
+    }
+
+def _link_pkg_7():
+    link_6()
+    _fp_link_5()
+    return [
+        ":node_modules/@aspect-test/g",
+        ":node_modules/@lib/d",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/g"],
+        "@lib": [":node_modules/@lib/d"],
+    }
+
+def _link_pkg_8():
+    link_7()
+    _fp_link_3()
+    _fp_link_3("@lib/b_alias")
+    return [
+        ":node_modules/@aspect-test/h",
+        ":node_modules/@lib/b",
+        ":node_modules/@lib/b_alias",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/h"],
+        "@lib": [
+            ":node_modules/@lib/b",
+            ":node_modules/@lib/b_alias",
+        ],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "": _link_pkg_0,
+    "app/a": _link_pkg_1,
+    "app/c": _link_pkg_2,
+    "lib/d": _link_pkg_3,
+    "lib/a": _link_pkg_4,
+    "lib/b": _link_pkg_5,
+    "lib/c": _link_pkg_6,
+    "app/d": _link_pkg_7,
+    "app/b": _link_pkg_8,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -150,134 +290,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "":
-            link_0()
-            link_1(dev=True)
-            link_2()
-            link_10()
-            link_11()
-            link_targets = [
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/lodash",
-                ":node_modules/typescript",
-                ":node_modules/@aspect-test/b",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/b",
-                    ":node_modules/@aspect-test/c",
-                ],
-            }
-        elif bazel_package == "app/a":
-            link_0()
-            link_6()
-            _fp_link_2()
-            link_targets = [
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/a",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/g",
-                ],
-                "@lib": [":node_modules/@lib/a"],
-            }
-        elif bazel_package == "app/c":
-            link_0()
-            link_6()
-            _fp_link_4()
-            link_targets = [
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/c",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/g",
-                ],
-                "@lib": [":node_modules/@lib/c"],
-            }
-        elif bazel_package == "lib/d":
-            link_3()
-            link_8("alias-2")
-            _fp_link_6()
-            _fp_link_7()
-            link_targets = [
-                ":node_modules/@aspect-test/d",
-                ":node_modules/alias-2",
-                ":node_modules/@lib/e",
-                ":node_modules/@lib/f",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/d"],
-                "@lib": [
-                    ":node_modules/@lib/e",
-                    ":node_modules/@lib/f",
-                ],
-            }
-        elif bazel_package == "lib/a":
-            link_4()
-            _fp_link_0()
-            _fp_link_1()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/@aspect-test/e",
-                ":node_modules/vendored-a",
-                ":node_modules/vendored-b",
-                ":node_modules/@lib/b",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/e"],
-                "@lib": [":node_modules/@lib/b"],
-            }
-        elif bazel_package == "lib/b":
-            link_5()
-            link_9("alias-1")
-            link_targets = [
-                ":node_modules/@aspect-test/f",
-                ":node_modules/alias-1",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/f"],
-            }
-        elif bazel_package == "lib/c":
-            link_5()
-            link_targets = [":node_modules/@aspect-test/f"]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/f"],
-            }
-        elif bazel_package == "app/d":
-            link_6()
-            _fp_link_5()
-            link_targets = [
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/d",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/g"],
-                "@lib": [":node_modules/@lib/d"],
-            }
-        elif bazel_package == "app/b":
-            link_7()
-            _fp_link_3()
-            _fp_link_3("@lib/b_alias")
-            link_targets = [
-                ":node_modules/@aspect-test/h",
-                ":node_modules/@lib/b",
-                ":node_modules/@lib/b_alias",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/h"],
-                "@lib": [
-                    ":node_modules/@lib/b",
-                    ":node_modules/@lib/b_alias",
-                ],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -307,6 +322,70 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "": {
+        "prod": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/c",
+            ":node_modules/lodash",
+            ":node_modules/typescript",
+        ],
+        "dev": [":node_modules/@aspect-test/b"],
+    },
+    "app/a": {
+        "prod": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/g",
+            ":node_modules/@lib/a",
+        ],
+    },
+    "app/c": {
+        "prod": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/g",
+            ":node_modules/@lib/c",
+        ],
+    },
+    "lib/d": {
+        "prod": [
+            ":node_modules/@aspect-test/d",
+            ":node_modules/alias-2",
+            ":node_modules/@lib/e",
+            ":node_modules/@lib/f",
+        ],
+    },
+    "lib/a": {
+        "prod": [
+            ":node_modules/@aspect-test/e",
+            ":node_modules/vendored-a",
+            ":node_modules/vendored-b",
+            ":node_modules/@lib/b",
+        ],
+    },
+    "lib/b": {
+        "prod": [
+            ":node_modules/@aspect-test/f",
+            ":node_modules/alias-1",
+        ],
+    },
+    "lib/c": {
+        "prod": [":node_modules/@aspect-test/f"],
+    },
+    "app/d": {
+        "prod": [
+            ":node_modules/@aspect-test/g",
+            ":node_modules/@lib/d",
+        ],
+    },
+    "app/b": {
+        "prod": [
+            ":node_modules/@aspect-test/h",
+            ":node_modules/@lib/b",
+            ":node_modules/@lib/b_alias",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -316,70 +395,12 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/lodash",
-                ":node_modules/typescript",
-            ])
-        if dev:
-            link_targets.extend([":node_modules/@aspect-test/b"])
-    elif bazel_package == "app/a":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/a",
-            ])
-    elif bazel_package == "app/c":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/c",
-            ])
-    elif bazel_package == "lib/d":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/d",
-                ":node_modules/alias-2",
-                ":node_modules/@lib/e",
-                ":node_modules/@lib/f",
-            ])
-    elif bazel_package == "lib/a":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/e",
-                ":node_modules/vendored-a",
-                ":node_modules/vendored-b",
-                ":node_modules/@lib/b",
-            ])
-    elif bazel_package == "lib/b":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/f",
-                ":node_modules/alias-1",
-            ])
-    elif bazel_package == "lib/c":
-        if prod:
-            link_targets.extend([":node_modules/@aspect-test/f"])
-    elif bazel_package == "app/d":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/d",
-            ])
-    elif bazel_package == "app/b":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/h",
-                ":node_modules/@lib/b",
-                ":node_modules/@lib/b_alias",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package

--- a/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
+++ b/e2e/pnpm_workspace_rerooted/snapshots/defs.bzl
@@ -25,6 +25,146 @@ load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_s
 
 _IMPORTER_PACKAGES = ["root", "", "app/a", "app/b", "app/c", "app/d", "lib/a", "lib/b", "lib/c", "lib/d", "lib/d/e", "lib/d/f"]
 
+def _link_pkg_0():
+    link_0()
+    link_1(dev=True)
+    link_2()
+    link_10()
+    link_11()
+    return [
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/c",
+        ":node_modules/lodash",
+        ":node_modules/typescript",
+        ":node_modules/@aspect-test/b",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/b",
+            ":node_modules/@aspect-test/c",
+        ],
+    }
+
+def _link_pkg_1():
+    link_0()
+    link_6()
+    _fp_link_2()
+    return [
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/g",
+        ":node_modules/@lib/a",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/g",
+        ],
+        "@lib": [":node_modules/@lib/a"],
+    }
+
+def _link_pkg_2():
+    link_0()
+    link_6()
+    _fp_link_4()
+    return [
+        ":node_modules/@aspect-test/a",
+        ":node_modules/@aspect-test/g",
+        ":node_modules/@lib/c",
+    ], {
+        "@aspect-test": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/g",
+        ],
+        "@lib": [":node_modules/@lib/c"],
+    }
+
+def _link_pkg_3():
+    link_3()
+    link_8("alias-2")
+    _fp_link_6()
+    _fp_link_7()
+    return [
+        ":node_modules/@aspect-test/d",
+        ":node_modules/alias-2",
+        ":node_modules/@lib/e",
+        ":node_modules/@lib/f",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/d"],
+        "@lib": [
+            ":node_modules/@lib/e",
+            ":node_modules/@lib/f",
+        ],
+    }
+
+def _link_pkg_4():
+    link_4()
+    _fp_link_0()
+    _fp_link_1()
+    _fp_link_3()
+    return [
+        ":node_modules/@aspect-test/e",
+        ":node_modules/vendored-a",
+        ":node_modules/vendored-b",
+        ":node_modules/@lib/b",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/e"],
+        "@lib": [":node_modules/@lib/b"],
+    }
+
+def _link_pkg_5():
+    link_5()
+    link_9("alias-1")
+    return [
+        ":node_modules/@aspect-test/f",
+        ":node_modules/alias-1",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/f"],
+    }
+
+def _link_pkg_6():
+    link_5()
+    return [":node_modules/@aspect-test/f"], {
+        "@aspect-test": [":node_modules/@aspect-test/f"],
+    }
+
+def _link_pkg_7():
+    link_6()
+    _fp_link_5()
+    return [
+        ":node_modules/@aspect-test/g",
+        ":node_modules/@lib/d",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/g"],
+        "@lib": [":node_modules/@lib/d"],
+    }
+
+def _link_pkg_8():
+    link_7()
+    _fp_link_3()
+    _fp_link_3("@lib/b_alias")
+    return [
+        ":node_modules/@aspect-test/h",
+        ":node_modules/@lib/b",
+        ":node_modules/@lib/b_alias",
+    ], {
+        "@aspect-test": [":node_modules/@aspect-test/h"],
+        "@lib": [
+            ":node_modules/@lib/b",
+            ":node_modules/@lib/b_alias",
+        ],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "": _link_pkg_0,
+    "app/a": _link_pkg_1,
+    "app/c": _link_pkg_2,
+    "lib/d": _link_pkg_3,
+    "lib/a": _link_pkg_4,
+    "lib/b": _link_pkg_5,
+    "lib/c": _link_pkg_6,
+    "app/d": _link_pkg_7,
+    "app/b": _link_pkg_8,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -150,134 +290,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "":
-            link_0()
-            link_1(dev=True)
-            link_2()
-            link_10()
-            link_11()
-            link_targets = [
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/lodash",
-                ":node_modules/typescript",
-                ":node_modules/@aspect-test/b",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/b",
-                    ":node_modules/@aspect-test/c",
-                ],
-            }
-        elif bazel_package == "app/a":
-            link_0()
-            link_6()
-            _fp_link_2()
-            link_targets = [
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/a",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/g",
-                ],
-                "@lib": [":node_modules/@lib/a"],
-            }
-        elif bazel_package == "app/c":
-            link_0()
-            link_6()
-            _fp_link_4()
-            link_targets = [
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/c",
-            ]
-            scope_targets = {
-                "@aspect-test": [
-                    ":node_modules/@aspect-test/a",
-                    ":node_modules/@aspect-test/g",
-                ],
-                "@lib": [":node_modules/@lib/c"],
-            }
-        elif bazel_package == "lib/d":
-            link_3()
-            link_8("alias-2")
-            _fp_link_6()
-            _fp_link_7()
-            link_targets = [
-                ":node_modules/@aspect-test/d",
-                ":node_modules/alias-2",
-                ":node_modules/@lib/e",
-                ":node_modules/@lib/f",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/d"],
-                "@lib": [
-                    ":node_modules/@lib/e",
-                    ":node_modules/@lib/f",
-                ],
-            }
-        elif bazel_package == "lib/a":
-            link_4()
-            _fp_link_0()
-            _fp_link_1()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/@aspect-test/e",
-                ":node_modules/vendored-a",
-                ":node_modules/vendored-b",
-                ":node_modules/@lib/b",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/e"],
-                "@lib": [":node_modules/@lib/b"],
-            }
-        elif bazel_package == "lib/b":
-            link_5()
-            link_9("alias-1")
-            link_targets = [
-                ":node_modules/@aspect-test/f",
-                ":node_modules/alias-1",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/f"],
-            }
-        elif bazel_package == "lib/c":
-            link_5()
-            link_targets = [":node_modules/@aspect-test/f"]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/f"],
-            }
-        elif bazel_package == "app/d":
-            link_6()
-            _fp_link_5()
-            link_targets = [
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/d",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/g"],
-                "@lib": [":node_modules/@lib/d"],
-            }
-        elif bazel_package == "app/b":
-            link_7()
-            _fp_link_3()
-            _fp_link_3("@lib/b_alias")
-            link_targets = [
-                ":node_modules/@aspect-test/h",
-                ":node_modules/@lib/b",
-                ":node_modules/@lib/b_alias",
-            ]
-            scope_targets = {
-                "@aspect-test": [":node_modules/@aspect-test/h"],
-                "@lib": [
-                    ":node_modules/@lib/b",
-                    ":node_modules/@lib/b_alias",
-                ],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -307,6 +322,70 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "": {
+        "prod": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/c",
+            ":node_modules/lodash",
+            ":node_modules/typescript",
+        ],
+        "dev": [":node_modules/@aspect-test/b"],
+    },
+    "app/a": {
+        "prod": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/g",
+            ":node_modules/@lib/a",
+        ],
+    },
+    "app/c": {
+        "prod": [
+            ":node_modules/@aspect-test/a",
+            ":node_modules/@aspect-test/g",
+            ":node_modules/@lib/c",
+        ],
+    },
+    "lib/d": {
+        "prod": [
+            ":node_modules/@aspect-test/d",
+            ":node_modules/alias-2",
+            ":node_modules/@lib/e",
+            ":node_modules/@lib/f",
+        ],
+    },
+    "lib/a": {
+        "prod": [
+            ":node_modules/@aspect-test/e",
+            ":node_modules/vendored-a",
+            ":node_modules/vendored-b",
+            ":node_modules/@lib/b",
+        ],
+    },
+    "lib/b": {
+        "prod": [
+            ":node_modules/@aspect-test/f",
+            ":node_modules/alias-1",
+        ],
+    },
+    "lib/c": {
+        "prod": [":node_modules/@aspect-test/f"],
+    },
+    "app/d": {
+        "prod": [
+            ":node_modules/@aspect-test/g",
+            ":node_modules/@lib/d",
+        ],
+    },
+    "app/b": {
+        "prod": [
+            ":node_modules/@aspect-test/h",
+            ":node_modules/@lib/b",
+            ":node_modules/@lib/b_alias",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -316,70 +395,12 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/c",
-                ":node_modules/lodash",
-                ":node_modules/typescript",
-            ])
-        if dev:
-            link_targets.extend([":node_modules/@aspect-test/b"])
-    elif bazel_package == "app/a":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/a",
-            ])
-    elif bazel_package == "app/c":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/a",
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/c",
-            ])
-    elif bazel_package == "lib/d":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/d",
-                ":node_modules/alias-2",
-                ":node_modules/@lib/e",
-                ":node_modules/@lib/f",
-            ])
-    elif bazel_package == "lib/a":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/e",
-                ":node_modules/vendored-a",
-                ":node_modules/vendored-b",
-                ":node_modules/@lib/b",
-            ])
-    elif bazel_package == "lib/b":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/f",
-                ":node_modules/alias-1",
-            ])
-    elif bazel_package == "lib/c":
-        if prod:
-            link_targets.extend([":node_modules/@aspect-test/f"])
-    elif bazel_package == "app/d":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/g",
-                ":node_modules/@lib/d",
-            ])
-    elif bazel_package == "app/b":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@aspect-test/h",
-                ":node_modules/@lib/b",
-                ":node_modules/@lib/b_alias",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "vendored-a" package

--- a/npm/private/npm_translate_lock_generate.bzl
+++ b/npm/private/npm_translate_lock_generate.bzl
@@ -292,7 +292,7 @@ Valid pnpm workspace projects: {}
                 is_alias = link_alias != _import.package
                 is_dev = link_alias not in link_importer["dependencies"] and link_alias not in link_importer["optional_dependencies"]
 
-                links_pkg_bzl[link_package].append("""            link_{i}({maybe_alias}{maybe_dev})""".format(
+                links_pkg_bzl[link_package].append("""    link_{i}({maybe_alias}{maybe_dev})""".format(
                     i = i,
                     maybe_alias = '"{}"'.format(link_alias) if is_alias else "",
                     maybe_dev = (", " if is_alias else "") + "dev=True" if is_dev else "",
@@ -410,13 +410,40 @@ Valid pnpm workspace projects: {}
                 links_pkg_bzl[link_package] = []
             for alias in aliases.keys():
                 if alias == fp_package:
-                    links_pkg_bzl[link_package].append("""            _fp_link_{i}()""".format(i = i))
+                    links_pkg_bzl[link_package].append("""    _fp_link_{i}()""".format(i = i))
                 else:
-                    links_pkg_bzl[link_package].append("""            _fp_link_{i}("{alias}")""".format(i = i, alias = alias))
+                    links_pkg_bzl[link_package].append("""    _fp_link_{i}("{alias}")""".format(i = i, alias = alias))
 
     if stores_bzl:
         npm_link_all_packages_bzl.append("""    if is_root:""")
         npm_link_all_packages_bzl.extend(stores_bzl)
+
+    # Generate one function per pnpm workspace project that performs the linking
+    # for that project and returns its (link_targets, scope_targets), collected
+    # into the `_LINK_PACKAGE_FNS` dict for dispatch by package name.
+    link_pkg_fns_bzl = []
+    link_pkg_dispatch = {}
+    for i, (link_package, bzl) in enumerate(links_pkg_bzl.items()):
+        fn_name = "_link_pkg_%d" % i
+        link_pkg_dispatch[link_package] = fn_name
+
+        if link_package in links_targets and (links_targets[link_package]["prod"] or links_targets[link_package]["dev"]):
+            link_targets_repr = starlark_codegen_utils.to_list_attr(links_targets[link_package]["prod"] + links_targets[link_package]["dev"], 1, 4, quote_value = False)
+        else:
+            link_targets_repr = "None"
+
+        if links_scope_targets.get(link_package):
+            scope_targets_repr = starlark_codegen_utils.to_dict_list_attr(links_scope_targets[link_package], 1, 4, quote_list_value = False)
+        else:
+            scope_targets_repr = "None"
+
+        fn_lines = ["""def {fn_name}():""".format(fn_name = fn_name)]
+        fn_lines.extend(bzl)
+        fn_lines.append("""    return {link_targets}, {scope_targets}""".format(
+            link_targets = link_targets_repr,
+            scope_targets = scope_targets_repr,
+        ))
+        link_pkg_fns_bzl.append("\n".join(fn_lines))
 
     # Start with empty link and scope targets
     npm_link_all_packages_bzl.append("""
@@ -424,28 +451,12 @@ Valid pnpm workspace projects: {}
     scope_targets = None
 """)
 
-    # Invoke and collect link targets based on package
-    if links_pkg_bzl:
-        npm_link_all_packages_bzl.append("""    if is_importer:""")
-        first_link = True
-        for link_package, bzl in links_pkg_bzl.items():
-            npm_link_all_packages_bzl.append("""        {els}if bazel_package == "{pkg}":""".format(
-                els = "" if first_link else "el",
-                pkg = link_package,
-            ))
-            npm_link_all_packages_bzl.extend(bzl)
-
-            if link_package in links_targets and (links_targets[link_package]["prod"] or links_targets[link_package]["dev"]):
-                npm_link_all_packages_bzl.append("""            link_targets = {targets}""".format(
-                    targets = starlark_codegen_utils.to_list_attr(links_targets[link_package]["prod"] + links_targets[link_package]["dev"], 3, 4, quote_value = False),
-                ))
-
-            if links_scope_targets.get(link_package):
-                npm_link_all_packages_bzl.append("""            scope_targets = {targets}""".format(
-                    targets = starlark_codegen_utils.to_dict_list_attr(links_scope_targets[link_package], 3, 4, quote_list_value = False),
-                ))
-
-            first_link = False
+    # Dispatch to this importer's link function, if any.
+    if link_pkg_dispatch:
+        npm_link_all_packages_bzl.append("""    if is_importer:
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()""")
 
     # Invoke and collect link targets from the `imported_links` param
     npm_link_all_packages_bzl.append("""\
@@ -480,7 +491,7 @@ Valid pnpm workspace projects: {}
             visibility = ["//visibility:public"],
         )""")
 
-    npm_link_targets_bzl = _generate_npm_link_targets(links_targets)
+    npm_link_targets_const, npm_link_targets_bzl = _generate_npm_link_targets(links_targets)
 
     defs_bzl_header.append("")
     defs_bzl_header.append("# buildifier: disable=bzl-visibility")
@@ -510,11 +521,25 @@ Valid pnpm workspace projects: {}
     defs_bzl_contents.extend(["", npm_visibility_config] if npm_visibility_config else [])
     defs_bzl_contents.extend(["", npm_package_locations] if npm_package_locations else [])
 
+    # Per-package link functions + dispatch dict, emitted before npm_link_all_packages
+    # which references _LINK_PACKAGE_FNS.
+    if link_pkg_fns_bzl:
+        defs_bzl_contents.extend([
+            "",
+            "\n\n".join(link_pkg_fns_bzl),
+            "",
+            "_LINK_PACKAGE_FNS = {dispatch}".format(
+                dispatch = starlark_codegen_utils.to_dict_attr(link_pkg_dispatch, 0, 4, quote_value = False),
+            ),
+        ])
+
     defs_bzl_contents.extend([
         "",
         "\n".join(npm_link_all_packages_bzl),
         "",
-        "\n".join(npm_link_targets_bzl),
+        npm_link_targets_const,
+        "",
+        npm_link_targets_bzl,
         "",
         "\n\n".join(link_factories_bzl),
     ])
@@ -527,9 +552,37 @@ Valid pnpm workspace projects: {}
     }
 
 def _generate_npm_link_targets(links_targets):
-    """Generate the npm_link_targets() macro given the links_targets struct"""
-    npm_link_targets_bzl = [
-        """\
+    """Generate the npm_link_targets() macro and its `_LINK_TARGETS` data table.
+
+    The per-package prod/dev targets are stored in the `_LINK_TARGETS` dict and
+    looked up at runtime by package name.
+
+    Returns:
+        A (link_targets_const, npm_link_targets_bzl) tuple of source strings, where
+        link_targets_const is the `_LINK_TARGETS = {...}` table and
+        npm_link_targets_bzl is the npm_link_targets() macro definition.
+    """
+    link_targets_const_lines = []
+    for link_package, lists in links_targets.items():
+        if not lists["prod"] and not lists["dev"]:
+            continue
+        link_targets_const_lines.append("""    "{pkg}": {{""".format(pkg = link_package))
+        if lists["prod"]:
+            link_targets_const_lines.append("""        "prod": {targets},""".format(
+                targets = starlark_codegen_utils.to_list_attr(lists["prod"], 2, 4, quote_value = False),
+            ))
+        if lists["dev"]:
+            link_targets_const_lines.append("""        "dev": {targets},""".format(
+                targets = starlark_codegen_utils.to_list_attr(lists["dev"], 2, 4, quote_value = False),
+            ))
+        link_targets_const_lines.append("    },")
+
+    if link_targets_const_lines:
+        link_targets_const = "_LINK_TARGETS = {\n" + "\n".join(link_targets_const_lines) + "\n}"
+    else:
+        link_targets_const = "_LINK_TARGETS = {}"
+
+    npm_link_targets_bzl = """\
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -539,29 +592,15 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-""",
-    ]
-    first_link = True
-    for link_package, lists in links_targets.items():
-        npm_link_targets_bzl.append("""    {els}if bazel_package == "{pkg}":""".format(
-            els = "" if first_link else "el",
-            pkg = link_package,
-        ))
-        if lists["prod"]:
-            npm_link_targets_bzl.append("""        if prod:""")
-            npm_link_targets_bzl.append("""            link_targets.extend({targets})""".format(
-                targets = starlark_codegen_utils.to_list_attr(lists["prod"], 3, 4, quote_value = False),
-            ))
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
+    return ["//%s%s" % (bazel_package, target) for target in link_targets]"""
 
-        if lists["dev"]:
-            npm_link_targets_bzl.append("""        if dev:""")
-            npm_link_targets_bzl.append("""            link_targets.extend({targets})""".format(
-                targets = starlark_codegen_utils.to_list_attr(lists["dev"], 3, 4, quote_value = False),
-            ))
-        first_link = False
-    npm_link_targets_bzl.append("""    return ["//%s%s" % (bazel_package, target) for target in link_targets]""")
-    return npm_link_targets_bzl
+    return link_targets_const, npm_link_targets_bzl
 
 def _generate_npm_visibility_config(package_visibility_attr):
     """Generate visibility configuration for npm packages"""

--- a/npm/private/test/snapshots/npm_defs-no_dev.bzl
+++ b/npm/private/test/snapshots/npm_defs-no_dev.bzl
@@ -918,6 +918,130 @@ load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_s
 
 _IMPORTER_PACKAGES = ["", "js/private/coverage/bundle", "js/private/devserver/src", "js/private/test/image", "js/private/test/image-fixture-a", "js/private/test/image-fixture-d", "js/private/test/image/platform_deps", "js/private/test/js_run_devserver", "js/private/test/node-patches", "js/private/worker/src", "npm/private/lifecycle", "npm/private/test", "npm/private/test/npm_package", "npm/private/test/npm_package_publish", "npm/private/test/subs"]
 
+def _link_pkg_0():
+    link_117()
+    link_119()
+    link_125()
+    return [
+        ":node_modules/@pnpm/lifecycle",
+        ":node_modules/@pnpm/logger",
+        ":node_modules/@pnpm/read-package-json",
+    ], {
+        "@pnpm": [
+            ":node_modules/@pnpm/lifecycle",
+            ":node_modules/@pnpm/logger",
+            ":node_modules/@pnpm/read-package-json",
+        ],
+    }
+
+def _link_pkg_1():
+    link_178()
+    link_179()
+    return [
+        ":node_modules/@rspack/cli",
+        ":node_modules/@rspack/core",
+    ], {
+        "@rspack": [
+            ":node_modules/@rspack/cli",
+            ":node_modules/@rspack/core",
+        ],
+    }
+
+def _link_pkg_2():
+    link_196()
+    link_545()
+    return [
+        ":node_modules/@types/node",
+        ":node_modules/jasmine",
+    ], {
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_3():
+    link_205()
+    link_206()
+    link_749()
+    return [
+        ":node_modules/@vscode/vsce-sign-alpine-arm64",
+        ":node_modules/@vscode/vsce-sign-alpine-x64",
+        ":node_modules/sass-embedded-all-unknown",
+    ], {
+        "@vscode": [
+            ":node_modules/@vscode/vsce-sign-alpine-arm64",
+            ":node_modules/@vscode/vsce-sign-alpine-x64",
+        ],
+    }
+
+def _link_pkg_4():
+    link_218()
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/acorn",
+        ":node_modules/@image-test/a",
+        ":node_modules/@image-test/d",
+    ], {
+        "@image-test": [
+            ":node_modules/@image-test/a",
+            ":node_modules/@image-test/d",
+        ],
+    }
+
+def _link_pkg_5():
+    link_268()
+    return [":node_modules/c8"], None
+
+def _link_pkg_6():
+    link_279()
+    link_280("chalk-alt")
+    return [
+        ":node_modules/chalk",
+        ":node_modules/chalk-alt",
+    ], None
+
+def _link_pkg_7():
+    link_471()
+    link_842()
+    return [
+        ":node_modules/google-protobuf",
+        ":node_modules/tslib",
+    ], None
+
+def _link_pkg_8():
+    link_868()
+    return [":node_modules/uuid"], None
+
+def _link_pkg_9():
+    link_868()
+    return [":node_modules/uuid"], None
+
+def _link_pkg_10():
+    _fp_link_4()
+    _fp_link_5()
+    return [
+        ":node_modules/@subs/a",
+        ":node_modules/@subs/b",
+    ], {
+        "@subs": [
+            ":node_modules/@subs/a",
+            ":node_modules/@subs/b",
+        ],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "npm/private/lifecycle": _link_pkg_0,
+    "js/private/test/image/platform_deps": _link_pkg_1,
+    "js/private/test/js_run_devserver": _link_pkg_2,
+    "npm/private/test": _link_pkg_3,
+    "js/private/test/image": _link_pkg_4,
+    "js/private/coverage/bundle": _link_pkg_5,
+    "npm/private/test/npm_package": _link_pkg_6,
+    "js/private/worker/src": _link_pkg_7,
+    "js/private/test/image-fixture-a": _link_pkg_8,
+    "js/private/test/image-fixture-d": _link_pkg_9,
+    "npm/private/test/subs": _link_pkg_10,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -1908,111 +2032,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "npm/private/lifecycle":
-            link_117()
-            link_119()
-            link_125()
-            link_targets = [
-                ":node_modules/@pnpm/lifecycle",
-                ":node_modules/@pnpm/logger",
-                ":node_modules/@pnpm/read-package-json",
-            ]
-            scope_targets = {
-                "@pnpm": [
-                    ":node_modules/@pnpm/lifecycle",
-                    ":node_modules/@pnpm/logger",
-                    ":node_modules/@pnpm/read-package-json",
-                ],
-            }
-        elif bazel_package == "js/private/test/image/platform_deps":
-            link_178()
-            link_179()
-            link_targets = [
-                ":node_modules/@rspack/cli",
-                ":node_modules/@rspack/core",
-            ]
-            scope_targets = {
-                "@rspack": [
-                    ":node_modules/@rspack/cli",
-                    ":node_modules/@rspack/core",
-                ],
-            }
-        elif bazel_package == "js/private/test/js_run_devserver":
-            link_196()
-            link_545()
-            link_targets = [
-                ":node_modules/@types/node",
-                ":node_modules/jasmine",
-            ]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "npm/private/test":
-            link_205()
-            link_206()
-            link_749()
-            link_targets = [
-                ":node_modules/@vscode/vsce-sign-alpine-arm64",
-                ":node_modules/@vscode/vsce-sign-alpine-x64",
-                ":node_modules/sass-embedded-all-unknown",
-            ]
-            scope_targets = {
-                "@vscode": [
-                    ":node_modules/@vscode/vsce-sign-alpine-arm64",
-                    ":node_modules/@vscode/vsce-sign-alpine-x64",
-                ],
-            }
-        elif bazel_package == "js/private/test/image":
-            link_218()
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/acorn",
-                ":node_modules/@image-test/a",
-                ":node_modules/@image-test/d",
-            ]
-            scope_targets = {
-                "@image-test": [
-                    ":node_modules/@image-test/a",
-                    ":node_modules/@image-test/d",
-                ],
-            }
-        elif bazel_package == "js/private/coverage/bundle":
-            link_268()
-            link_targets = [":node_modules/c8"]
-        elif bazel_package == "npm/private/test/npm_package":
-            link_279()
-            link_280("chalk-alt")
-            link_targets = [
-                ":node_modules/chalk",
-                ":node_modules/chalk-alt",
-            ]
-        elif bazel_package == "js/private/worker/src":
-            link_471()
-            link_842()
-            link_targets = [
-                ":node_modules/google-protobuf",
-                ":node_modules/tslib",
-            ]
-        elif bazel_package == "js/private/test/image-fixture-a":
-            link_868()
-            link_targets = [":node_modules/uuid"]
-        elif bazel_package == "js/private/test/image-fixture-d":
-            link_868()
-            link_targets = [":node_modules/uuid"]
-        elif bazel_package == "npm/private/test/subs":
-            _fp_link_4()
-            _fp_link_5()
-            link_targets = [
-                ":node_modules/@subs/a",
-                ":node_modules/@subs/b",
-            ]
-            scope_targets = {
-                "@subs": [
-                    ":node_modules/@subs/a",
-                    ":node_modules/@subs/b",
-                ],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -2042,6 +2064,69 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "npm/private/lifecycle": {
+        "prod": [
+            ":node_modules/@pnpm/lifecycle",
+            ":node_modules/@pnpm/logger",
+            ":node_modules/@pnpm/read-package-json",
+        ],
+    },
+    "js/private/test/image/platform_deps": {
+        "prod": [
+            ":node_modules/@rspack/cli",
+            ":node_modules/@rspack/core",
+        ],
+    },
+    "js/private/test/js_run_devserver": {
+        "prod": [
+            ":node_modules/@types/node",
+            ":node_modules/jasmine",
+        ],
+    },
+    "npm/private/test": {
+        "prod": [
+            ":node_modules/@vscode/vsce-sign-alpine-arm64",
+            ":node_modules/@vscode/vsce-sign-alpine-x64",
+            ":node_modules/sass-embedded-all-unknown",
+        ],
+    },
+    "js/private/test/image": {
+        "prod": [
+            ":node_modules/acorn",
+            ":node_modules/@image-test/a",
+            ":node_modules/@image-test/d",
+        ],
+    },
+    "js/private/coverage/bundle": {
+        "prod": [":node_modules/c8"],
+    },
+    "npm/private/test/npm_package": {
+        "prod": [
+            ":node_modules/chalk",
+            ":node_modules/chalk-alt",
+        ],
+    },
+    "js/private/worker/src": {
+        "prod": [
+            ":node_modules/google-protobuf",
+            ":node_modules/tslib",
+        ],
+    },
+    "js/private/test/image-fixture-a": {
+        "prod": [":node_modules/uuid"],
+    },
+    "js/private/test/image-fixture-d": {
+        "prod": [":node_modules/uuid"],
+    },
+    "npm/private/test/subs": {
+        "prod": [
+            ":node_modules/@subs/a",
+            ":node_modules/@subs/b",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -2051,68 +2136,12 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "npm/private/lifecycle":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@pnpm/lifecycle",
-                ":node_modules/@pnpm/logger",
-                ":node_modules/@pnpm/read-package-json",
-            ])
-    elif bazel_package == "js/private/test/image/platform_deps":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@rspack/cli",
-                ":node_modules/@rspack/core",
-            ])
-    elif bazel_package == "js/private/test/js_run_devserver":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@types/node",
-                ":node_modules/jasmine",
-            ])
-    elif bazel_package == "npm/private/test":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@vscode/vsce-sign-alpine-arm64",
-                ":node_modules/@vscode/vsce-sign-alpine-x64",
-                ":node_modules/sass-embedded-all-unknown",
-            ])
-    elif bazel_package == "js/private/test/image":
-        if prod:
-            link_targets.extend([
-                ":node_modules/acorn",
-                ":node_modules/@image-test/a",
-                ":node_modules/@image-test/d",
-            ])
-    elif bazel_package == "js/private/coverage/bundle":
-        if prod:
-            link_targets.extend([":node_modules/c8"])
-    elif bazel_package == "npm/private/test/npm_package":
-        if prod:
-            link_targets.extend([
-                ":node_modules/chalk",
-                ":node_modules/chalk-alt",
-            ])
-    elif bazel_package == "js/private/worker/src":
-        if prod:
-            link_targets.extend([
-                ":node_modules/google-protobuf",
-                ":node_modules/tslib",
-            ])
-    elif bazel_package == "js/private/test/image-fixture-a":
-        if prod:
-            link_targets.extend([":node_modules/uuid"])
-    elif bazel_package == "js/private/test/image-fixture-d":
-        if prod:
-            link_targets.extend([":node_modules/uuid"])
-    elif bazel_package == "npm/private/test/subs":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@subs/a",
-                ":node_modules/@subs/b",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@image-test/a" package

--- a/npm/private/test/snapshots/npm_defs-no_optional.bzl
+++ b/npm/private/test/snapshots/npm_defs-no_optional.bzl
@@ -809,6 +809,295 @@ load("@aspect_rules_js//npm/private:npm_package_store.bzl", _npm_local_package_s
 
 _IMPORTER_PACKAGES = ["", "js/private/coverage/bundle", "js/private/devserver/src", "js/private/test/image", "js/private/test/image-fixture-a", "js/private/test/image-fixture-d", "js/private/test/image/platform_deps", "js/private/test/js_run_devserver", "js/private/test/node-patches", "js/private/worker/src", "npm/private/lifecycle", "npm/private/test", "npm/private/test/npm_package", "npm/private/test/npm_package_publish", "npm/private/test/subs"]
 
+def _link_pkg_0():
+    link_1(dev=True)
+    link_5(dev=True)
+    link_17(dev=True)
+    link_407(dev=True)
+    return [
+        ":node_modules/@babel/cli",
+        ":node_modules/@babel/core",
+        ":node_modules/@babel/plugin-transform-modules-commonjs",
+        ":node_modules/inline-fixtures",
+    ], {
+        "@babel": [
+            ":node_modules/@babel/cli",
+            ":node_modules/@babel/core",
+            ":node_modules/@babel/plugin-transform-modules-commonjs",
+        ],
+    }
+
+def _link_pkg_1():
+    link_21(dev=True)
+    link_116(dev=True)
+    link_190(dev=True)
+    link_290("circles", dev=True)
+    link_372(dev=True)
+    link_456(dev=True)
+    link_742(dev=True)
+    return [
+        ":node_modules/@bazel/runfiles",
+        ":node_modules/@types/node",
+        ":node_modules/chalk",
+        ":node_modules/circles",
+        ":node_modules/google-closure-compiler",
+        ":node_modules/jsonpath-plus",
+        ":node_modules/typescript",
+    ], {
+        "@bazel": [":node_modules/@bazel/runfiles"],
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_2():
+    link_24(dev=True)
+    link_25(dev=True)
+    link_40(dev=True)
+    link_63(dev=True)
+    link_63("regl", dev=True)
+    link_177(dev=True)
+    link_258(dev=True)
+    link_294(dev=True)
+    link_387("handlebars-helpers/helper-date", dev=True)
+    link_389(dev=True)
+    link_408(dev=True)
+    link_452(dev=True)
+    link_465(dev=True)
+    link_466("lodash-4.17.21", dev=True)
+    link_467("lodash-4.17.21-tar", dev=True)
+    link_537(dev=True)
+    link_587(dev=True)
+    link_588(dev=True)
+    link_598(dev=True)
+    link_603(dev=True)
+    link_645(dev=True)
+    link_646(dev=True)
+    link_705(dev=True)
+    link_742(dev=True)
+    link_755(dev=True)
+    link_768(dev=True)
+    _fp_link_4()
+    return [
+        ":node_modules/@fastify/send",
+        ":node_modules/@figma/nodegit",
+        ":node_modules/@kubernetes/client-node",
+        ":node_modules/@plotly/regl",
+        ":node_modules/regl",
+        ":node_modules/bufferutil",
+        ":node_modules/debug",
+        ":node_modules/esbuild",
+        ":node_modules/handlebars-helpers/helper-date",
+        ":node_modules/hot-shots",
+        ":node_modules/inline-fixtures",
+        ":node_modules/json-stable-stringify",
+        ":node_modules/lodash",
+        ":node_modules/lodash-4.17.21",
+        ":node_modules/lodash-4.17.21-tar",
+        ":node_modules/node-gyp",
+        ":node_modules/plotly.js",
+        ":node_modules/pngjs",
+        ":node_modules/protoc-gen-grpc",
+        ":node_modules/puppeteer",
+        ":node_modules/segfault-handler",
+        ":node_modules/semver-first-satisfied",
+        ":node_modules/syncpack",
+        ":node_modules/typescript",
+        ":node_modules/unused",
+        ":node_modules/webpack-bundle-analyzer",
+        ":node_modules/test-npm_package",
+    ], {
+        "@fastify": [":node_modules/@fastify/send"],
+        "@figma": [":node_modules/@figma/nodegit"],
+        "@kubernetes": [":node_modules/@kubernetes/client-node"],
+        "@plotly": [":node_modules/@plotly/regl"],
+    }
+
+def _link_pkg_3():
+    link_73()
+    link_75()
+    link_81()
+    link_91(dev=True)
+    link_92(dev=True)
+    link_93(dev=True)
+    link_94(dev=True)
+    link_95(dev=True)
+    link_637(dev=True)
+    return [
+        ":node_modules/@pnpm/lifecycle",
+        ":node_modules/@pnpm/logger",
+        ":node_modules/@pnpm/read-package-json",
+        ":node_modules/@rollup/plugin-commonjs",
+        ":node_modules/@rollup/plugin-json",
+        ":node_modules/@rollup/plugin-node-resolve",
+        ":node_modules/@rollup/plugin-replace",
+        ":node_modules/@rollup/plugin-terser",
+        ":node_modules/rollup",
+    ], {
+        "@pnpm": [
+            ":node_modules/@pnpm/lifecycle",
+            ":node_modules/@pnpm/logger",
+            ":node_modules/@pnpm/read-package-json",
+        ],
+        "@rollup": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@rollup/plugin-replace",
+            ":node_modules/@rollup/plugin-terser",
+        ],
+    }
+
+def _link_pkg_4():
+    link_91(dev=True)
+    link_92(dev=True)
+    link_93(dev=True)
+    link_178()
+    link_637(dev=True)
+    return [
+        ":node_modules/c8",
+        ":node_modules/@rollup/plugin-commonjs",
+        ":node_modules/@rollup/plugin-json",
+        ":node_modules/@rollup/plugin-node-resolve",
+        ":node_modules/rollup",
+    ], {
+        "@rollup": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+        ],
+    }
+
+def _link_pkg_5():
+    link_91(dev=True)
+    link_92(dev=True)
+    link_93(dev=True)
+    link_96(dev=True)
+    link_110(dev=True)
+    link_116(dev=True)
+    link_373()
+    link_637(dev=True)
+    link_734()
+    link_742(dev=True)
+    return [
+        ":node_modules/google-protobuf",
+        ":node_modules/tslib",
+        ":node_modules/@rollup/plugin-commonjs",
+        ":node_modules/@rollup/plugin-json",
+        ":node_modules/@rollup/plugin-node-resolve",
+        ":node_modules/@rollup/plugin-typescript",
+        ":node_modules/@types/google-protobuf",
+        ":node_modules/@types/node",
+        ":node_modules/rollup",
+        ":node_modules/typescript",
+    ], {
+        "@rollup": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@rollup/plugin-typescript",
+        ],
+        "@types": [
+            ":node_modules/@types/google-protobuf",
+            ":node_modules/@types/node",
+        ],
+    }
+
+def _link_pkg_6():
+    link_93(dev=True)
+    link_116(dev=True)
+    link_637(dev=True)
+    return [
+        ":node_modules/@rollup/plugin-node-resolve",
+        ":node_modules/@types/node",
+        ":node_modules/rollup",
+    ], {
+        "@rollup": [":node_modules/@rollup/plugin-node-resolve"],
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_7():
+    link_99()
+    link_100()
+    return [
+        ":node_modules/@rspack/cli",
+        ":node_modules/@rspack/core",
+    ], {
+        "@rspack": [
+            ":node_modules/@rspack/cli",
+            ":node_modules/@rspack/core",
+        ],
+    }
+
+def _link_pkg_8():
+    link_116()
+    link_443()
+    return [
+        ":node_modules/@types/node",
+        ":node_modules/jasmine",
+    ], {
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_9():
+    link_135()
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/acorn",
+        ":node_modules/@image-test/a",
+        ":node_modules/@image-test/d",
+    ], {
+        "@image-test": [
+            ":node_modules/@image-test/a",
+            ":node_modules/@image-test/d",
+        ],
+    }
+
+def _link_pkg_10():
+    link_189()
+    link_190("chalk-alt")
+    return [
+        ":node_modules/chalk",
+        ":node_modules/chalk-alt",
+    ], None
+
+def _link_pkg_11():
+    link_759()
+    return [":node_modules/uuid"], None
+
+def _link_pkg_12():
+    link_759()
+    return [":node_modules/uuid"], None
+
+def _link_pkg_13():
+    _fp_link_5()
+    _fp_link_6()
+    return [
+        ":node_modules/@subs/a",
+        ":node_modules/@subs/b",
+    ], {
+        "@subs": [
+            ":node_modules/@subs/a",
+            ":node_modules/@subs/b",
+        ],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "js/private/test/node-patches": _link_pkg_0,
+    "": _link_pkg_1,
+    "npm/private/test": _link_pkg_2,
+    "npm/private/lifecycle": _link_pkg_3,
+    "js/private/coverage/bundle": _link_pkg_4,
+    "js/private/worker/src": _link_pkg_5,
+    "js/private/devserver/src": _link_pkg_6,
+    "js/private/test/image/platform_deps": _link_pkg_7,
+    "js/private/test/js_run_devserver": _link_pkg_8,
+    "js/private/test/image": _link_pkg_9,
+    "npm/private/test/npm_package": _link_pkg_10,
+    "js/private/test/image-fixture-a": _link_pkg_11,
+    "js/private/test/image-fixture-d": _link_pkg_12,
+    "npm/private/test/subs": _link_pkg_13,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -1702,275 +1991,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "js/private/test/node-patches":
-            link_1(dev=True)
-            link_5(dev=True)
-            link_17(dev=True)
-            link_407(dev=True)
-            link_targets = [
-                ":node_modules/@babel/cli",
-                ":node_modules/@babel/core",
-                ":node_modules/@babel/plugin-transform-modules-commonjs",
-                ":node_modules/inline-fixtures",
-            ]
-            scope_targets = {
-                "@babel": [
-                    ":node_modules/@babel/cli",
-                    ":node_modules/@babel/core",
-                    ":node_modules/@babel/plugin-transform-modules-commonjs",
-                ],
-            }
-        elif bazel_package == "":
-            link_21(dev=True)
-            link_116(dev=True)
-            link_190(dev=True)
-            link_290("circles", dev=True)
-            link_372(dev=True)
-            link_456(dev=True)
-            link_742(dev=True)
-            link_targets = [
-                ":node_modules/@bazel/runfiles",
-                ":node_modules/@types/node",
-                ":node_modules/chalk",
-                ":node_modules/circles",
-                ":node_modules/google-closure-compiler",
-                ":node_modules/jsonpath-plus",
-                ":node_modules/typescript",
-            ]
-            scope_targets = {
-                "@bazel": [":node_modules/@bazel/runfiles"],
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "npm/private/test":
-            link_24(dev=True)
-            link_25(dev=True)
-            link_40(dev=True)
-            link_63(dev=True)
-            link_63("regl", dev=True)
-            link_177(dev=True)
-            link_258(dev=True)
-            link_294(dev=True)
-            link_387("handlebars-helpers/helper-date", dev=True)
-            link_389(dev=True)
-            link_408(dev=True)
-            link_452(dev=True)
-            link_465(dev=True)
-            link_466("lodash-4.17.21", dev=True)
-            link_467("lodash-4.17.21-tar", dev=True)
-            link_537(dev=True)
-            link_587(dev=True)
-            link_588(dev=True)
-            link_598(dev=True)
-            link_603(dev=True)
-            link_645(dev=True)
-            link_646(dev=True)
-            link_705(dev=True)
-            link_742(dev=True)
-            link_755(dev=True)
-            link_768(dev=True)
-            _fp_link_4()
-            link_targets = [
-                ":node_modules/@fastify/send",
-                ":node_modules/@figma/nodegit",
-                ":node_modules/@kubernetes/client-node",
-                ":node_modules/@plotly/regl",
-                ":node_modules/regl",
-                ":node_modules/bufferutil",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/handlebars-helpers/helper-date",
-                ":node_modules/hot-shots",
-                ":node_modules/inline-fixtures",
-                ":node_modules/json-stable-stringify",
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-tar",
-                ":node_modules/node-gyp",
-                ":node_modules/plotly.js",
-                ":node_modules/pngjs",
-                ":node_modules/protoc-gen-grpc",
-                ":node_modules/puppeteer",
-                ":node_modules/segfault-handler",
-                ":node_modules/semver-first-satisfied",
-                ":node_modules/syncpack",
-                ":node_modules/typescript",
-                ":node_modules/unused",
-                ":node_modules/webpack-bundle-analyzer",
-                ":node_modules/test-npm_package",
-            ]
-            scope_targets = {
-                "@fastify": [":node_modules/@fastify/send"],
-                "@figma": [":node_modules/@figma/nodegit"],
-                "@kubernetes": [":node_modules/@kubernetes/client-node"],
-                "@plotly": [":node_modules/@plotly/regl"],
-            }
-        elif bazel_package == "npm/private/lifecycle":
-            link_73()
-            link_75()
-            link_81()
-            link_91(dev=True)
-            link_92(dev=True)
-            link_93(dev=True)
-            link_94(dev=True)
-            link_95(dev=True)
-            link_637(dev=True)
-            link_targets = [
-                ":node_modules/@pnpm/lifecycle",
-                ":node_modules/@pnpm/logger",
-                ":node_modules/@pnpm/read-package-json",
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@rollup/plugin-replace",
-                ":node_modules/@rollup/plugin-terser",
-                ":node_modules/rollup",
-            ]
-            scope_targets = {
-                "@pnpm": [
-                    ":node_modules/@pnpm/lifecycle",
-                    ":node_modules/@pnpm/logger",
-                    ":node_modules/@pnpm/read-package-json",
-                ],
-                "@rollup": [
-                    ":node_modules/@rollup/plugin-commonjs",
-                    ":node_modules/@rollup/plugin-json",
-                    ":node_modules/@rollup/plugin-node-resolve",
-                    ":node_modules/@rollup/plugin-replace",
-                    ":node_modules/@rollup/plugin-terser",
-                ],
-            }
-        elif bazel_package == "js/private/coverage/bundle":
-            link_91(dev=True)
-            link_92(dev=True)
-            link_93(dev=True)
-            link_178()
-            link_637(dev=True)
-            link_targets = [
-                ":node_modules/c8",
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/rollup",
-            ]
-            scope_targets = {
-                "@rollup": [
-                    ":node_modules/@rollup/plugin-commonjs",
-                    ":node_modules/@rollup/plugin-json",
-                    ":node_modules/@rollup/plugin-node-resolve",
-                ],
-            }
-        elif bazel_package == "js/private/worker/src":
-            link_91(dev=True)
-            link_92(dev=True)
-            link_93(dev=True)
-            link_96(dev=True)
-            link_110(dev=True)
-            link_116(dev=True)
-            link_373()
-            link_637(dev=True)
-            link_734()
-            link_742(dev=True)
-            link_targets = [
-                ":node_modules/google-protobuf",
-                ":node_modules/tslib",
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@rollup/plugin-typescript",
-                ":node_modules/@types/google-protobuf",
-                ":node_modules/@types/node",
-                ":node_modules/rollup",
-                ":node_modules/typescript",
-            ]
-            scope_targets = {
-                "@rollup": [
-                    ":node_modules/@rollup/plugin-commonjs",
-                    ":node_modules/@rollup/plugin-json",
-                    ":node_modules/@rollup/plugin-node-resolve",
-                    ":node_modules/@rollup/plugin-typescript",
-                ],
-                "@types": [
-                    ":node_modules/@types/google-protobuf",
-                    ":node_modules/@types/node",
-                ],
-            }
-        elif bazel_package == "js/private/devserver/src":
-            link_93(dev=True)
-            link_116(dev=True)
-            link_637(dev=True)
-            link_targets = [
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@types/node",
-                ":node_modules/rollup",
-            ]
-            scope_targets = {
-                "@rollup": [":node_modules/@rollup/plugin-node-resolve"],
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "js/private/test/image/platform_deps":
-            link_99()
-            link_100()
-            link_targets = [
-                ":node_modules/@rspack/cli",
-                ":node_modules/@rspack/core",
-            ]
-            scope_targets = {
-                "@rspack": [
-                    ":node_modules/@rspack/cli",
-                    ":node_modules/@rspack/core",
-                ],
-            }
-        elif bazel_package == "js/private/test/js_run_devserver":
-            link_116()
-            link_443()
-            link_targets = [
-                ":node_modules/@types/node",
-                ":node_modules/jasmine",
-            ]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "js/private/test/image":
-            link_135()
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/acorn",
-                ":node_modules/@image-test/a",
-                ":node_modules/@image-test/d",
-            ]
-            scope_targets = {
-                "@image-test": [
-                    ":node_modules/@image-test/a",
-                    ":node_modules/@image-test/d",
-                ],
-            }
-        elif bazel_package == "npm/private/test/npm_package":
-            link_189()
-            link_190("chalk-alt")
-            link_targets = [
-                ":node_modules/chalk",
-                ":node_modules/chalk-alt",
-            ]
-        elif bazel_package == "js/private/test/image-fixture-a":
-            link_759()
-            link_targets = [":node_modules/uuid"]
-        elif bazel_package == "js/private/test/image-fixture-d":
-            link_759()
-            link_targets = [":node_modules/uuid"]
-        elif bazel_package == "npm/private/test/subs":
-            _fp_link_5()
-            _fp_link_6()
-            link_targets = [
-                ":node_modules/@subs/a",
-                ":node_modules/@subs/b",
-            ]
-            scope_targets = {
-                "@subs": [
-                    ":node_modules/@subs/a",
-                    ":node_modules/@subs/b",
-                ],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -2000,6 +2023,143 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "js/private/test/node-patches": {
+        "dev": [
+            ":node_modules/@babel/cli",
+            ":node_modules/@babel/core",
+            ":node_modules/@babel/plugin-transform-modules-commonjs",
+            ":node_modules/inline-fixtures",
+        ],
+    },
+    "": {
+        "dev": [
+            ":node_modules/@bazel/runfiles",
+            ":node_modules/@types/node",
+            ":node_modules/chalk",
+            ":node_modules/circles",
+            ":node_modules/google-closure-compiler",
+            ":node_modules/jsonpath-plus",
+            ":node_modules/typescript",
+        ],
+    },
+    "npm/private/test": {
+        "dev": [
+            ":node_modules/@fastify/send",
+            ":node_modules/@figma/nodegit",
+            ":node_modules/@kubernetes/client-node",
+            ":node_modules/@plotly/regl",
+            ":node_modules/regl",
+            ":node_modules/bufferutil",
+            ":node_modules/debug",
+            ":node_modules/esbuild",
+            ":node_modules/handlebars-helpers/helper-date",
+            ":node_modules/hot-shots",
+            ":node_modules/inline-fixtures",
+            ":node_modules/json-stable-stringify",
+            ":node_modules/lodash",
+            ":node_modules/lodash-4.17.21",
+            ":node_modules/lodash-4.17.21-tar",
+            ":node_modules/node-gyp",
+            ":node_modules/plotly.js",
+            ":node_modules/pngjs",
+            ":node_modules/protoc-gen-grpc",
+            ":node_modules/puppeteer",
+            ":node_modules/segfault-handler",
+            ":node_modules/semver-first-satisfied",
+            ":node_modules/syncpack",
+            ":node_modules/typescript",
+            ":node_modules/unused",
+            ":node_modules/webpack-bundle-analyzer",
+            ":node_modules/test-npm_package",
+        ],
+    },
+    "npm/private/lifecycle": {
+        "prod": [
+            ":node_modules/@pnpm/lifecycle",
+            ":node_modules/@pnpm/logger",
+            ":node_modules/@pnpm/read-package-json",
+        ],
+        "dev": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@rollup/plugin-replace",
+            ":node_modules/@rollup/plugin-terser",
+            ":node_modules/rollup",
+        ],
+    },
+    "js/private/coverage/bundle": {
+        "prod": [":node_modules/c8"],
+        "dev": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/rollup",
+        ],
+    },
+    "js/private/worker/src": {
+        "prod": [
+            ":node_modules/google-protobuf",
+            ":node_modules/tslib",
+        ],
+        "dev": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@rollup/plugin-typescript",
+            ":node_modules/@types/google-protobuf",
+            ":node_modules/@types/node",
+            ":node_modules/rollup",
+            ":node_modules/typescript",
+        ],
+    },
+    "js/private/devserver/src": {
+        "dev": [
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@types/node",
+            ":node_modules/rollup",
+        ],
+    },
+    "js/private/test/image/platform_deps": {
+        "prod": [
+            ":node_modules/@rspack/cli",
+            ":node_modules/@rspack/core",
+        ],
+    },
+    "js/private/test/js_run_devserver": {
+        "prod": [
+            ":node_modules/@types/node",
+            ":node_modules/jasmine",
+        ],
+    },
+    "js/private/test/image": {
+        "prod": [
+            ":node_modules/acorn",
+            ":node_modules/@image-test/a",
+            ":node_modules/@image-test/d",
+        ],
+    },
+    "npm/private/test/npm_package": {
+        "prod": [
+            ":node_modules/chalk",
+            ":node_modules/chalk-alt",
+        ],
+    },
+    "js/private/test/image-fixture-a": {
+        "prod": [":node_modules/uuid"],
+    },
+    "js/private/test/image-fixture-d": {
+        "prod": [":node_modules/uuid"],
+    },
+    "npm/private/test/subs": {
+        "prod": [
+            ":node_modules/@subs/a",
+            ":node_modules/@subs/b",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -2009,145 +2169,12 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "js/private/test/node-patches":
-        if dev:
-            link_targets.extend([
-                ":node_modules/@babel/cli",
-                ":node_modules/@babel/core",
-                ":node_modules/@babel/plugin-transform-modules-commonjs",
-                ":node_modules/inline-fixtures",
-            ])
-    elif bazel_package == "":
-        if dev:
-            link_targets.extend([
-                ":node_modules/@bazel/runfiles",
-                ":node_modules/@types/node",
-                ":node_modules/chalk",
-                ":node_modules/circles",
-                ":node_modules/google-closure-compiler",
-                ":node_modules/jsonpath-plus",
-                ":node_modules/typescript",
-            ])
-    elif bazel_package == "npm/private/test":
-        if dev:
-            link_targets.extend([
-                ":node_modules/@fastify/send",
-                ":node_modules/@figma/nodegit",
-                ":node_modules/@kubernetes/client-node",
-                ":node_modules/@plotly/regl",
-                ":node_modules/regl",
-                ":node_modules/bufferutil",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/handlebars-helpers/helper-date",
-                ":node_modules/hot-shots",
-                ":node_modules/inline-fixtures",
-                ":node_modules/json-stable-stringify",
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-tar",
-                ":node_modules/node-gyp",
-                ":node_modules/plotly.js",
-                ":node_modules/pngjs",
-                ":node_modules/protoc-gen-grpc",
-                ":node_modules/puppeteer",
-                ":node_modules/segfault-handler",
-                ":node_modules/semver-first-satisfied",
-                ":node_modules/syncpack",
-                ":node_modules/typescript",
-                ":node_modules/unused",
-                ":node_modules/webpack-bundle-analyzer",
-                ":node_modules/test-npm_package",
-            ])
-    elif bazel_package == "npm/private/lifecycle":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@pnpm/lifecycle",
-                ":node_modules/@pnpm/logger",
-                ":node_modules/@pnpm/read-package-json",
-            ])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@rollup/plugin-replace",
-                ":node_modules/@rollup/plugin-terser",
-                ":node_modules/rollup",
-            ])
-    elif bazel_package == "js/private/coverage/bundle":
-        if prod:
-            link_targets.extend([":node_modules/c8"])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/rollup",
-            ])
-    elif bazel_package == "js/private/worker/src":
-        if prod:
-            link_targets.extend([
-                ":node_modules/google-protobuf",
-                ":node_modules/tslib",
-            ])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@rollup/plugin-typescript",
-                ":node_modules/@types/google-protobuf",
-                ":node_modules/@types/node",
-                ":node_modules/rollup",
-                ":node_modules/typescript",
-            ])
-    elif bazel_package == "js/private/devserver/src":
-        if dev:
-            link_targets.extend([
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@types/node",
-                ":node_modules/rollup",
-            ])
-    elif bazel_package == "js/private/test/image/platform_deps":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@rspack/cli",
-                ":node_modules/@rspack/core",
-            ])
-    elif bazel_package == "js/private/test/js_run_devserver":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@types/node",
-                ":node_modules/jasmine",
-            ])
-    elif bazel_package == "js/private/test/image":
-        if prod:
-            link_targets.extend([
-                ":node_modules/acorn",
-                ":node_modules/@image-test/a",
-                ":node_modules/@image-test/d",
-            ])
-    elif bazel_package == "npm/private/test/npm_package":
-        if prod:
-            link_targets.extend([
-                ":node_modules/chalk",
-                ":node_modules/chalk-alt",
-            ])
-    elif bazel_package == "js/private/test/image-fixture-a":
-        if prod:
-            link_targets.extend([":node_modules/uuid"])
-    elif bazel_package == "js/private/test/image-fixture-d":
-        if prod:
-            link_targets.extend([":node_modules/uuid"])
-    elif bazel_package == "npm/private/test/subs":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@subs/a",
-                ":node_modules/@subs/b",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@image-test/a" package

--- a/npm/private/test/snapshots/npm_defs.bzl
+++ b/npm/private/test/snapshots/npm_defs.bzl
@@ -942,6 +942,304 @@ _NPM_PACKAGE_LOCATIONS = {
     "js/private/test/image-fixture-d": ["uuid"],
 }
 
+def _link_pkg_0():
+    link_1(dev=True)
+    link_5(dev=True)
+    link_17(dev=True)
+    link_508(dev=True)
+    return [
+        ":node_modules/@babel/cli",
+        ":node_modules/@babel/core",
+        ":node_modules/@babel/plugin-transform-modules-commonjs",
+        ":node_modules/inline-fixtures",
+    ], {
+        "@babel": [
+            ":node_modules/@babel/cli",
+            ":node_modules/@babel/core",
+            ":node_modules/@babel/plugin-transform-modules-commonjs",
+        ],
+    }
+
+def _link_pkg_1():
+    link_21(dev=True)
+    link_196(dev=True)
+    link_280(dev=True)
+    link_383("circles", dev=True)
+    link_470(dev=True)
+    link_558(dev=True)
+    link_850(dev=True)
+    return [
+        ":node_modules/@bazel/runfiles",
+        ":node_modules/@types/node",
+        ":node_modules/chalk",
+        ":node_modules/circles",
+        ":node_modules/google-closure-compiler",
+        ":node_modules/jsonpath-plus",
+        ":node_modules/typescript",
+    ], {
+        "@bazel": [":node_modules/@bazel/runfiles"],
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_2():
+    link_51(dev=True)
+    link_52(dev=True)
+    link_67(dev=True)
+    link_107(dev=True)
+    link_107("regl", dev=True)
+    link_205()
+    link_206()
+    link_267(dev=True)
+    link_350(dev=True)
+    link_387(dev=True)
+    link_485("handlebars-helpers/helper-date", dev=True)
+    link_487(dev=True)
+    link_509(dev=True)
+    link_554(dev=True)
+    link_567(dev=True)
+    link_568("lodash-4.17.21", dev=True)
+    link_569("lodash-4.17.21-tar", dev=True)
+    link_640(dev=True)
+    link_690(dev=True)
+    link_691(dev=True)
+    link_701(dev=True)
+    link_706(dev=True)
+    link_749()
+    link_752(dev=True)
+    link_753(dev=True)
+    link_813(dev=True)
+    link_850(dev=True)
+    link_864(dev=True)
+    link_877(dev=True)
+    _fp_link_4()
+    return [
+        ":node_modules/@vscode/vsce-sign-alpine-arm64",
+        ":node_modules/@vscode/vsce-sign-alpine-x64",
+        ":node_modules/sass-embedded-all-unknown",
+        ":node_modules/@fastify/send",
+        ":node_modules/@figma/nodegit",
+        ":node_modules/@kubernetes/client-node",
+        ":node_modules/@plotly/regl",
+        ":node_modules/regl",
+        ":node_modules/bufferutil",
+        ":node_modules/debug",
+        ":node_modules/esbuild",
+        ":node_modules/handlebars-helpers/helper-date",
+        ":node_modules/hot-shots",
+        ":node_modules/inline-fixtures",
+        ":node_modules/json-stable-stringify",
+        ":node_modules/lodash",
+        ":node_modules/lodash-4.17.21",
+        ":node_modules/lodash-4.17.21-tar",
+        ":node_modules/node-gyp",
+        ":node_modules/plotly.js",
+        ":node_modules/pngjs",
+        ":node_modules/protoc-gen-grpc",
+        ":node_modules/puppeteer",
+        ":node_modules/segfault-handler",
+        ":node_modules/semver-first-satisfied",
+        ":node_modules/syncpack",
+        ":node_modules/typescript",
+        ":node_modules/webpack-bundle-analyzer",
+        ":node_modules/test-npm_package",
+    ], {
+        "@fastify": [":node_modules/@fastify/send"],
+        "@figma": [":node_modules/@figma/nodegit"],
+        "@kubernetes": [":node_modules/@kubernetes/client-node"],
+        "@plotly": [":node_modules/@plotly/regl"],
+        "@vscode": [
+            ":node_modules/@vscode/vsce-sign-alpine-arm64",
+            ":node_modules/@vscode/vsce-sign-alpine-x64",
+        ],
+    }
+
+def _link_pkg_3():
+    link_117()
+    link_119()
+    link_125()
+    link_135(dev=True)
+    link_136(dev=True)
+    link_137(dev=True)
+    link_138(dev=True)
+    link_139(dev=True)
+    link_742(dev=True)
+    return [
+        ":node_modules/@pnpm/lifecycle",
+        ":node_modules/@pnpm/logger",
+        ":node_modules/@pnpm/read-package-json",
+        ":node_modules/@rollup/plugin-commonjs",
+        ":node_modules/@rollup/plugin-json",
+        ":node_modules/@rollup/plugin-node-resolve",
+        ":node_modules/@rollup/plugin-replace",
+        ":node_modules/@rollup/plugin-terser",
+        ":node_modules/rollup",
+    ], {
+        "@pnpm": [
+            ":node_modules/@pnpm/lifecycle",
+            ":node_modules/@pnpm/logger",
+            ":node_modules/@pnpm/read-package-json",
+        ],
+        "@rollup": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@rollup/plugin-replace",
+            ":node_modules/@rollup/plugin-terser",
+        ],
+    }
+
+def _link_pkg_4():
+    link_135(dev=True)
+    link_136(dev=True)
+    link_137(dev=True)
+    link_268()
+    link_742(dev=True)
+    return [
+        ":node_modules/c8",
+        ":node_modules/@rollup/plugin-commonjs",
+        ":node_modules/@rollup/plugin-json",
+        ":node_modules/@rollup/plugin-node-resolve",
+        ":node_modules/rollup",
+    ], {
+        "@rollup": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+        ],
+    }
+
+def _link_pkg_5():
+    link_135(dev=True)
+    link_136(dev=True)
+    link_137(dev=True)
+    link_140(dev=True)
+    link_190(dev=True)
+    link_196(dev=True)
+    link_471()
+    link_742(dev=True)
+    link_842()
+    link_850(dev=True)
+    return [
+        ":node_modules/google-protobuf",
+        ":node_modules/tslib",
+        ":node_modules/@rollup/plugin-commonjs",
+        ":node_modules/@rollup/plugin-json",
+        ":node_modules/@rollup/plugin-node-resolve",
+        ":node_modules/@rollup/plugin-typescript",
+        ":node_modules/@types/google-protobuf",
+        ":node_modules/@types/node",
+        ":node_modules/rollup",
+        ":node_modules/typescript",
+    ], {
+        "@rollup": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@rollup/plugin-typescript",
+        ],
+        "@types": [
+            ":node_modules/@types/google-protobuf",
+            ":node_modules/@types/node",
+        ],
+    }
+
+def _link_pkg_6():
+    link_137(dev=True)
+    link_196(dev=True)
+    link_742(dev=True)
+    return [
+        ":node_modules/@rollup/plugin-node-resolve",
+        ":node_modules/@types/node",
+        ":node_modules/rollup",
+    ], {
+        "@rollup": [":node_modules/@rollup/plugin-node-resolve"],
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_7():
+    link_178()
+    link_179()
+    return [
+        ":node_modules/@rspack/cli",
+        ":node_modules/@rspack/core",
+    ], {
+        "@rspack": [
+            ":node_modules/@rspack/cli",
+            ":node_modules/@rspack/core",
+        ],
+    }
+
+def _link_pkg_8():
+    link_196()
+    link_545()
+    return [
+        ":node_modules/@types/node",
+        ":node_modules/jasmine",
+    ], {
+        "@types": [":node_modules/@types/node"],
+    }
+
+def _link_pkg_9():
+    link_218()
+    _fp_link_2()
+    _fp_link_3()
+    return [
+        ":node_modules/acorn",
+        ":node_modules/@image-test/a",
+        ":node_modules/@image-test/d",
+    ], {
+        "@image-test": [
+            ":node_modules/@image-test/a",
+            ":node_modules/@image-test/d",
+        ],
+    }
+
+def _link_pkg_10():
+    link_279()
+    link_280("chalk-alt")
+    return [
+        ":node_modules/chalk",
+        ":node_modules/chalk-alt",
+    ], None
+
+def _link_pkg_11():
+    link_868()
+    return [":node_modules/uuid"], None
+
+def _link_pkg_12():
+    link_868()
+    return [":node_modules/uuid"], None
+
+def _link_pkg_13():
+    _fp_link_5()
+    _fp_link_6()
+    return [
+        ":node_modules/@subs/a",
+        ":node_modules/@subs/b",
+    ], {
+        "@subs": [
+            ":node_modules/@subs/a",
+            ":node_modules/@subs/b",
+        ],
+    }
+
+_LINK_PACKAGE_FNS = {
+    "js/private/test/node-patches": _link_pkg_0,
+    "": _link_pkg_1,
+    "npm/private/test": _link_pkg_2,
+    "npm/private/lifecycle": _link_pkg_3,
+    "js/private/coverage/bundle": _link_pkg_4,
+    "js/private/worker/src": _link_pkg_5,
+    "js/private/devserver/src": _link_pkg_6,
+    "js/private/test/image/platform_deps": _link_pkg_7,
+    "js/private/test/js_run_devserver": _link_pkg_8,
+    "js/private/test/image": _link_pkg_9,
+    "npm/private/test/npm_package": _link_pkg_10,
+    "js/private/test/image-fixture-a": _link_pkg_11,
+    "js/private/test/image-fixture-d": _link_pkg_12,
+    "npm/private/test/subs": _link_pkg_13,
+}
+
 # buildifier: disable=function-docstring
 def npm_link_all_packages(name = "node_modules", imported_links = [], prod = True, dev = True):
     if name != "node_modules":
@@ -1947,284 +2245,9 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
     scope_targets = None
 
     if is_importer:
-        if bazel_package == "js/private/test/node-patches":
-            link_1(dev=True)
-            link_5(dev=True)
-            link_17(dev=True)
-            link_508(dev=True)
-            link_targets = [
-                ":node_modules/@babel/cli",
-                ":node_modules/@babel/core",
-                ":node_modules/@babel/plugin-transform-modules-commonjs",
-                ":node_modules/inline-fixtures",
-            ]
-            scope_targets = {
-                "@babel": [
-                    ":node_modules/@babel/cli",
-                    ":node_modules/@babel/core",
-                    ":node_modules/@babel/plugin-transform-modules-commonjs",
-                ],
-            }
-        elif bazel_package == "":
-            link_21(dev=True)
-            link_196(dev=True)
-            link_280(dev=True)
-            link_383("circles", dev=True)
-            link_470(dev=True)
-            link_558(dev=True)
-            link_850(dev=True)
-            link_targets = [
-                ":node_modules/@bazel/runfiles",
-                ":node_modules/@types/node",
-                ":node_modules/chalk",
-                ":node_modules/circles",
-                ":node_modules/google-closure-compiler",
-                ":node_modules/jsonpath-plus",
-                ":node_modules/typescript",
-            ]
-            scope_targets = {
-                "@bazel": [":node_modules/@bazel/runfiles"],
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "npm/private/test":
-            link_51(dev=True)
-            link_52(dev=True)
-            link_67(dev=True)
-            link_107(dev=True)
-            link_107("regl", dev=True)
-            link_205()
-            link_206()
-            link_267(dev=True)
-            link_350(dev=True)
-            link_387(dev=True)
-            link_485("handlebars-helpers/helper-date", dev=True)
-            link_487(dev=True)
-            link_509(dev=True)
-            link_554(dev=True)
-            link_567(dev=True)
-            link_568("lodash-4.17.21", dev=True)
-            link_569("lodash-4.17.21-tar", dev=True)
-            link_640(dev=True)
-            link_690(dev=True)
-            link_691(dev=True)
-            link_701(dev=True)
-            link_706(dev=True)
-            link_749()
-            link_752(dev=True)
-            link_753(dev=True)
-            link_813(dev=True)
-            link_850(dev=True)
-            link_864(dev=True)
-            link_877(dev=True)
-            _fp_link_4()
-            link_targets = [
-                ":node_modules/@vscode/vsce-sign-alpine-arm64",
-                ":node_modules/@vscode/vsce-sign-alpine-x64",
-                ":node_modules/sass-embedded-all-unknown",
-                ":node_modules/@fastify/send",
-                ":node_modules/@figma/nodegit",
-                ":node_modules/@kubernetes/client-node",
-                ":node_modules/@plotly/regl",
-                ":node_modules/regl",
-                ":node_modules/bufferutil",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/handlebars-helpers/helper-date",
-                ":node_modules/hot-shots",
-                ":node_modules/inline-fixtures",
-                ":node_modules/json-stable-stringify",
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-tar",
-                ":node_modules/node-gyp",
-                ":node_modules/plotly.js",
-                ":node_modules/pngjs",
-                ":node_modules/protoc-gen-grpc",
-                ":node_modules/puppeteer",
-                ":node_modules/segfault-handler",
-                ":node_modules/semver-first-satisfied",
-                ":node_modules/syncpack",
-                ":node_modules/typescript",
-                ":node_modules/webpack-bundle-analyzer",
-                ":node_modules/test-npm_package",
-            ]
-            scope_targets = {
-                "@fastify": [":node_modules/@fastify/send"],
-                "@figma": [":node_modules/@figma/nodegit"],
-                "@kubernetes": [":node_modules/@kubernetes/client-node"],
-                "@plotly": [":node_modules/@plotly/regl"],
-                "@vscode": [
-                    ":node_modules/@vscode/vsce-sign-alpine-arm64",
-                    ":node_modules/@vscode/vsce-sign-alpine-x64",
-                ],
-            }
-        elif bazel_package == "npm/private/lifecycle":
-            link_117()
-            link_119()
-            link_125()
-            link_135(dev=True)
-            link_136(dev=True)
-            link_137(dev=True)
-            link_138(dev=True)
-            link_139(dev=True)
-            link_742(dev=True)
-            link_targets = [
-                ":node_modules/@pnpm/lifecycle",
-                ":node_modules/@pnpm/logger",
-                ":node_modules/@pnpm/read-package-json",
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@rollup/plugin-replace",
-                ":node_modules/@rollup/plugin-terser",
-                ":node_modules/rollup",
-            ]
-            scope_targets = {
-                "@pnpm": [
-                    ":node_modules/@pnpm/lifecycle",
-                    ":node_modules/@pnpm/logger",
-                    ":node_modules/@pnpm/read-package-json",
-                ],
-                "@rollup": [
-                    ":node_modules/@rollup/plugin-commonjs",
-                    ":node_modules/@rollup/plugin-json",
-                    ":node_modules/@rollup/plugin-node-resolve",
-                    ":node_modules/@rollup/plugin-replace",
-                    ":node_modules/@rollup/plugin-terser",
-                ],
-            }
-        elif bazel_package == "js/private/coverage/bundle":
-            link_135(dev=True)
-            link_136(dev=True)
-            link_137(dev=True)
-            link_268()
-            link_742(dev=True)
-            link_targets = [
-                ":node_modules/c8",
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/rollup",
-            ]
-            scope_targets = {
-                "@rollup": [
-                    ":node_modules/@rollup/plugin-commonjs",
-                    ":node_modules/@rollup/plugin-json",
-                    ":node_modules/@rollup/plugin-node-resolve",
-                ],
-            }
-        elif bazel_package == "js/private/worker/src":
-            link_135(dev=True)
-            link_136(dev=True)
-            link_137(dev=True)
-            link_140(dev=True)
-            link_190(dev=True)
-            link_196(dev=True)
-            link_471()
-            link_742(dev=True)
-            link_842()
-            link_850(dev=True)
-            link_targets = [
-                ":node_modules/google-protobuf",
-                ":node_modules/tslib",
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@rollup/plugin-typescript",
-                ":node_modules/@types/google-protobuf",
-                ":node_modules/@types/node",
-                ":node_modules/rollup",
-                ":node_modules/typescript",
-            ]
-            scope_targets = {
-                "@rollup": [
-                    ":node_modules/@rollup/plugin-commonjs",
-                    ":node_modules/@rollup/plugin-json",
-                    ":node_modules/@rollup/plugin-node-resolve",
-                    ":node_modules/@rollup/plugin-typescript",
-                ],
-                "@types": [
-                    ":node_modules/@types/google-protobuf",
-                    ":node_modules/@types/node",
-                ],
-            }
-        elif bazel_package == "js/private/devserver/src":
-            link_137(dev=True)
-            link_196(dev=True)
-            link_742(dev=True)
-            link_targets = [
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@types/node",
-                ":node_modules/rollup",
-            ]
-            scope_targets = {
-                "@rollup": [":node_modules/@rollup/plugin-node-resolve"],
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "js/private/test/image/platform_deps":
-            link_178()
-            link_179()
-            link_targets = [
-                ":node_modules/@rspack/cli",
-                ":node_modules/@rspack/core",
-            ]
-            scope_targets = {
-                "@rspack": [
-                    ":node_modules/@rspack/cli",
-                    ":node_modules/@rspack/core",
-                ],
-            }
-        elif bazel_package == "js/private/test/js_run_devserver":
-            link_196()
-            link_545()
-            link_targets = [
-                ":node_modules/@types/node",
-                ":node_modules/jasmine",
-            ]
-            scope_targets = {
-                "@types": [":node_modules/@types/node"],
-            }
-        elif bazel_package == "js/private/test/image":
-            link_218()
-            _fp_link_2()
-            _fp_link_3()
-            link_targets = [
-                ":node_modules/acorn",
-                ":node_modules/@image-test/a",
-                ":node_modules/@image-test/d",
-            ]
-            scope_targets = {
-                "@image-test": [
-                    ":node_modules/@image-test/a",
-                    ":node_modules/@image-test/d",
-                ],
-            }
-        elif bazel_package == "npm/private/test/npm_package":
-            link_279()
-            link_280("chalk-alt")
-            link_targets = [
-                ":node_modules/chalk",
-                ":node_modules/chalk-alt",
-            ]
-        elif bazel_package == "js/private/test/image-fixture-a":
-            link_868()
-            link_targets = [":node_modules/uuid"]
-        elif bazel_package == "js/private/test/image-fixture-d":
-            link_868()
-            link_targets = [":node_modules/uuid"]
-        elif bazel_package == "npm/private/test/subs":
-            _fp_link_5()
-            _fp_link_6()
-            link_targets = [
-                ":node_modules/@subs/a",
-                ":node_modules/@subs/b",
-            ]
-            scope_targets = {
-                "@subs": [
-                    ":node_modules/@subs/a",
-                    ":node_modules/@subs/b",
-                ],
-            }
+        _link_pkg_fn = _LINK_PACKAGE_FNS.get(bazel_package)
+        if _link_pkg_fn:
+            link_targets, scope_targets = _link_pkg_fn()
     for link_fn in imported_links:
         new_link_targets, new_scope_targets = link_fn(name, prod, dev)
         if not link_targets:
@@ -2254,6 +2277,147 @@ def npm_link_all_packages(name = "node_modules", imported_links = [], prod = Tru
             visibility = ["//visibility:public"],
         )
 
+_LINK_TARGETS = {
+    "js/private/test/node-patches": {
+        "dev": [
+            ":node_modules/@babel/cli",
+            ":node_modules/@babel/core",
+            ":node_modules/@babel/plugin-transform-modules-commonjs",
+            ":node_modules/inline-fixtures",
+        ],
+    },
+    "": {
+        "dev": [
+            ":node_modules/@bazel/runfiles",
+            ":node_modules/@types/node",
+            ":node_modules/chalk",
+            ":node_modules/circles",
+            ":node_modules/google-closure-compiler",
+            ":node_modules/jsonpath-plus",
+            ":node_modules/typescript",
+        ],
+    },
+    "npm/private/test": {
+        "prod": [
+            ":node_modules/@vscode/vsce-sign-alpine-arm64",
+            ":node_modules/@vscode/vsce-sign-alpine-x64",
+            ":node_modules/sass-embedded-all-unknown",
+        ],
+        "dev": [
+            ":node_modules/@fastify/send",
+            ":node_modules/@figma/nodegit",
+            ":node_modules/@kubernetes/client-node",
+            ":node_modules/@plotly/regl",
+            ":node_modules/regl",
+            ":node_modules/bufferutil",
+            ":node_modules/debug",
+            ":node_modules/esbuild",
+            ":node_modules/handlebars-helpers/helper-date",
+            ":node_modules/hot-shots",
+            ":node_modules/inline-fixtures",
+            ":node_modules/json-stable-stringify",
+            ":node_modules/lodash",
+            ":node_modules/lodash-4.17.21",
+            ":node_modules/lodash-4.17.21-tar",
+            ":node_modules/node-gyp",
+            ":node_modules/plotly.js",
+            ":node_modules/pngjs",
+            ":node_modules/protoc-gen-grpc",
+            ":node_modules/puppeteer",
+            ":node_modules/segfault-handler",
+            ":node_modules/semver-first-satisfied",
+            ":node_modules/syncpack",
+            ":node_modules/typescript",
+            ":node_modules/webpack-bundle-analyzer",
+            ":node_modules/test-npm_package",
+        ],
+    },
+    "npm/private/lifecycle": {
+        "prod": [
+            ":node_modules/@pnpm/lifecycle",
+            ":node_modules/@pnpm/logger",
+            ":node_modules/@pnpm/read-package-json",
+        ],
+        "dev": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@rollup/plugin-replace",
+            ":node_modules/@rollup/plugin-terser",
+            ":node_modules/rollup",
+        ],
+    },
+    "js/private/coverage/bundle": {
+        "prod": [":node_modules/c8"],
+        "dev": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/rollup",
+        ],
+    },
+    "js/private/worker/src": {
+        "prod": [
+            ":node_modules/google-protobuf",
+            ":node_modules/tslib",
+        ],
+        "dev": [
+            ":node_modules/@rollup/plugin-commonjs",
+            ":node_modules/@rollup/plugin-json",
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@rollup/plugin-typescript",
+            ":node_modules/@types/google-protobuf",
+            ":node_modules/@types/node",
+            ":node_modules/rollup",
+            ":node_modules/typescript",
+        ],
+    },
+    "js/private/devserver/src": {
+        "dev": [
+            ":node_modules/@rollup/plugin-node-resolve",
+            ":node_modules/@types/node",
+            ":node_modules/rollup",
+        ],
+    },
+    "js/private/test/image/platform_deps": {
+        "prod": [
+            ":node_modules/@rspack/cli",
+            ":node_modules/@rspack/core",
+        ],
+    },
+    "js/private/test/js_run_devserver": {
+        "prod": [
+            ":node_modules/@types/node",
+            ":node_modules/jasmine",
+        ],
+    },
+    "js/private/test/image": {
+        "prod": [
+            ":node_modules/acorn",
+            ":node_modules/@image-test/a",
+            ":node_modules/@image-test/d",
+        ],
+    },
+    "npm/private/test/npm_package": {
+        "prod": [
+            ":node_modules/chalk",
+            ":node_modules/chalk-alt",
+        ],
+    },
+    "js/private/test/image-fixture-a": {
+        "prod": [":node_modules/uuid"],
+    },
+    "js/private/test/image-fixture-d": {
+        "prod": [":node_modules/uuid"],
+    },
+    "npm/private/test/subs": {
+        "prod": [
+            ":node_modules/@subs/a",
+            ":node_modules/@subs/b",
+        ],
+    },
+}
+
 # buildifier: disable=function-docstring
 def npm_link_targets(name = "node_modules", package = None, prod = True, dev = True):
     if name != "node_modules":
@@ -2263,150 +2427,12 @@ def npm_link_targets(name = "node_modules", package = None, prod = True, dev = T
 
     bazel_package = package if package != None else native.package_name()
 
+    entry = _LINK_TARGETS.get(bazel_package, {})
     link_targets = []
-
-    if bazel_package == "js/private/test/node-patches":
-        if dev:
-            link_targets.extend([
-                ":node_modules/@babel/cli",
-                ":node_modules/@babel/core",
-                ":node_modules/@babel/plugin-transform-modules-commonjs",
-                ":node_modules/inline-fixtures",
-            ])
-    elif bazel_package == "":
-        if dev:
-            link_targets.extend([
-                ":node_modules/@bazel/runfiles",
-                ":node_modules/@types/node",
-                ":node_modules/chalk",
-                ":node_modules/circles",
-                ":node_modules/google-closure-compiler",
-                ":node_modules/jsonpath-plus",
-                ":node_modules/typescript",
-            ])
-    elif bazel_package == "npm/private/test":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@vscode/vsce-sign-alpine-arm64",
-                ":node_modules/@vscode/vsce-sign-alpine-x64",
-                ":node_modules/sass-embedded-all-unknown",
-            ])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@fastify/send",
-                ":node_modules/@figma/nodegit",
-                ":node_modules/@kubernetes/client-node",
-                ":node_modules/@plotly/regl",
-                ":node_modules/regl",
-                ":node_modules/bufferutil",
-                ":node_modules/debug",
-                ":node_modules/esbuild",
-                ":node_modules/handlebars-helpers/helper-date",
-                ":node_modules/hot-shots",
-                ":node_modules/inline-fixtures",
-                ":node_modules/json-stable-stringify",
-                ":node_modules/lodash",
-                ":node_modules/lodash-4.17.21",
-                ":node_modules/lodash-4.17.21-tar",
-                ":node_modules/node-gyp",
-                ":node_modules/plotly.js",
-                ":node_modules/pngjs",
-                ":node_modules/protoc-gen-grpc",
-                ":node_modules/puppeteer",
-                ":node_modules/segfault-handler",
-                ":node_modules/semver-first-satisfied",
-                ":node_modules/syncpack",
-                ":node_modules/typescript",
-                ":node_modules/webpack-bundle-analyzer",
-                ":node_modules/test-npm_package",
-            ])
-    elif bazel_package == "npm/private/lifecycle":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@pnpm/lifecycle",
-                ":node_modules/@pnpm/logger",
-                ":node_modules/@pnpm/read-package-json",
-            ])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@rollup/plugin-replace",
-                ":node_modules/@rollup/plugin-terser",
-                ":node_modules/rollup",
-            ])
-    elif bazel_package == "js/private/coverage/bundle":
-        if prod:
-            link_targets.extend([":node_modules/c8"])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/rollup",
-            ])
-    elif bazel_package == "js/private/worker/src":
-        if prod:
-            link_targets.extend([
-                ":node_modules/google-protobuf",
-                ":node_modules/tslib",
-            ])
-        if dev:
-            link_targets.extend([
-                ":node_modules/@rollup/plugin-commonjs",
-                ":node_modules/@rollup/plugin-json",
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@rollup/plugin-typescript",
-                ":node_modules/@types/google-protobuf",
-                ":node_modules/@types/node",
-                ":node_modules/rollup",
-                ":node_modules/typescript",
-            ])
-    elif bazel_package == "js/private/devserver/src":
-        if dev:
-            link_targets.extend([
-                ":node_modules/@rollup/plugin-node-resolve",
-                ":node_modules/@types/node",
-                ":node_modules/rollup",
-            ])
-    elif bazel_package == "js/private/test/image/platform_deps":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@rspack/cli",
-                ":node_modules/@rspack/core",
-            ])
-    elif bazel_package == "js/private/test/js_run_devserver":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@types/node",
-                ":node_modules/jasmine",
-            ])
-    elif bazel_package == "js/private/test/image":
-        if prod:
-            link_targets.extend([
-                ":node_modules/acorn",
-                ":node_modules/@image-test/a",
-                ":node_modules/@image-test/d",
-            ])
-    elif bazel_package == "npm/private/test/npm_package":
-        if prod:
-            link_targets.extend([
-                ":node_modules/chalk",
-                ":node_modules/chalk-alt",
-            ])
-    elif bazel_package == "js/private/test/image-fixture-a":
-        if prod:
-            link_targets.extend([":node_modules/uuid"])
-    elif bazel_package == "js/private/test/image-fixture-d":
-        if prod:
-            link_targets.extend([":node_modules/uuid"])
-    elif bazel_package == "npm/private/test/subs":
-        if prod:
-            link_targets.extend([
-                ":node_modules/@subs/a",
-                ":node_modules/@subs/b",
-            ])
+    if prod and "prod" in entry:
+        link_targets.extend(entry["prod"])
+    if dev and "dev" in entry:
+        link_targets.extend(entry["dev"])
     return ["//%s%s" % (bazel_package, target) for target in link_targets]
 
 # Generated npm_link_package_store for linking of first-party "@image-test/a" package


### PR DESCRIPTION
This converts 2 `if/elif bazel_package == "pnpm-project-path"` blocks into 2 constants and the `if/elif` is replaced with a lookup into the constant. See the diffs of the snapshot files for the best outline of the changes.

This prevents a reported `java.lang.StackOverflowError` from the bazel starlark parser treating `elif` as nested `else: if`. This reduces the `npm_link_all_packages()` from N `if/elif` statements into a single map lookup. The tradeoff is when the generated `defs.bzl` is `load()`ed it now has 2 giant maps declared at load time.

Overall I (and my robot assistants, and my testing on a repo with ~2k pnpm workspace projects) think this has negligible impact on actually performance but should avoid the `java.lang.StackOverflowError`.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
