### PR TITLE
feat(npm): use pnpm publish for npm_package

### DIFF
--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -140,6 +140,7 @@ def npm_package(
         include_runfiles = False,
         hardlink = "auto",
         publishable = False,
+        pnpm_binary = "@pnpm//:pnpm",
         verbose = False,
         **kwargs):
     """A macro that packages sources into a directory (a tree artifact) and provides an `NpmPackageInfo`.
@@ -147,8 +148,11 @@ def npm_package(
     This target can be used as the `src` attribute to `npm_link_package`.
 
     With `publishable = True` the macro also produces a target `[name].publish`, that can be run to publish to an npm registry.
-    Under the hood, this target runs `npm publish`. You can pass arguments to npm by escaping them from Bazel using a double-hyphen,
-    for example: `bazel run //path/to:my_package.publish -- --tag=next`
+    Under the hood, this target runs `pnpm publish`. You can pass arguments to pnpm by escaping them from Bazel using a double-hyphen,
+    for example: `bazel run //path/to:my_package.publish -- --tag=next`.
+
+    pnpm publishing uses the configured `pnpm_binary` and can resolve pnpm workspace settings such as `catalog` entries from
+    `pnpm-workspace.yaml`. Workspace protocol dependencies follow pnpm's own resolution requirements.
 
     Files and directories can be arranged as needed in the output directory using
     the `root_paths`, `include_srcs_patterns`, `exclude_srcs_patterns` and `replace_prefixes` attributes.
@@ -210,7 +214,7 @@ def npm_package(
 
         srcs: Files and/or directories or targets that provide `DirectoryPathInfo` to copy into the output directory.
 
-        args: Arguments that are passed down to `<name>.publish` target and `npm publish` command.
+        args: Arguments that are passed down to `<name>.publish` target and the publish command.
 
         data: Runtime / linktime npm dependencies of this npm package.
 
@@ -409,6 +413,9 @@ def npm_package(
 
         publishable: When True, enable generation of `{name}.publish` target
 
+        pnpm_binary: Label of the pnpm binary used for publishing. This is typically `@pnpm//:pnpm`
+            from the `pnpm` extension in `@aspect_rules_js//npm:extensions.bzl`.
+
         verbose: If true, prints out verbose logs to stdout
 
         **kwargs: Additional attributes such as `tags` and `visibility`
@@ -437,10 +444,11 @@ def npm_package(
             name = "{}.publish".format(name),
             entry_point = Label("@aspect_rules_js//npm/private:npm_publish_mjs"),
             fixed_args = [
+                "$(rootpath {})".format(pnpm_binary),
                 "./$(rootpath :{})".format(name),
             ],
-            data = [name],
-            # required to make npm to be available in PATH
+            data = [name, pnpm_binary],
+            # pnpm <11 may delegate registry operations to npm. This can be removed when rules_js drops pnpm <=10.
             include_npm = True,
             args = args,
             tags = kwargs.get("tags", []) + ["manual"],

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -154,6 +154,16 @@ def npm_package(
     pnpm publishing uses the configured `pnpm_binary` and can resolve pnpm workspace settings such as `catalog` entries from
     `pnpm-workspace.yaml`. Workspace protocol dependencies follow pnpm's own resolution requirements.
 
+    The default `pnpm_binary` requires the consuming module to define and import the `@pnpm` repository:
+
+    ```starlark
+    pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
+    pnpm.pnpm(name = "pnpm")
+    use_repo(pnpm, "pnpm")
+    ```
+
+    Pass a different `pnpm_binary` label when the pnpm repository uses another name.
+
     Files and directories can be arranged as needed in the output directory using
     the `root_paths`, `include_srcs_patterns`, `exclude_srcs_patterns` and `replace_prefixes` attributes.
 
@@ -413,8 +423,9 @@ def npm_package(
 
         publishable: When True, enable generation of `{name}.publish` target
 
-        pnpm_binary: Label of the pnpm binary used for publishing. This is typically `@pnpm//:pnpm`
-            from the `pnpm` extension in `@aspect_rules_js//npm:extensions.bzl`.
+        pnpm_binary: Label of the pnpm binary used for publishing. The default `@pnpm//:pnpm`
+            requires the consuming module to define the `pnpm` extension repository and import it
+            with `use_repo(pnpm, "pnpm")`.
 
         verbose: If true, prints out verbose logs to stdout
 

--- a/npm/private/npm_publish.mjs
+++ b/npm/private/npm_publish.mjs
@@ -1,9 +1,73 @@
 import { spawnSync } from 'node:child_process'
+import {
+    copyFileSync,
+    existsSync,
+    mkdtempSync,
+    rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 
-const restArgs = process.argv.slice(2)
+const [toolPath, packageDir, ...restArgs] = process.argv.slice(2)
 
-const spawn = spawnSync('npm', ['publish', ...restArgs], {
+if (!toolPath || !packageDir) {
+    console.error(
+        'Expected publish tool path and package directory arguments.',
+    )
+    process.exit(1)
+}
+
+const packagePath = path.resolve(packageDir)
+
+let cleanupCwd
+let spawnOptions = {
     stdio: 'inherit',
-})
+}
+
+if (process.env.BUILD_WORKSPACE_DIRECTORY) {
+    cleanupCwd = mkdtempSync(path.join(tmpdir(), 'rules-js-pnpm-publish-'))
+
+    // Give pnpm only the workspace-level files it needs for publish settings.
+    for (const filename of ['pnpm-workspace.yaml', '.npmrc']) {
+        const source = path.join(process.env.BUILD_WORKSPACE_DIRECTORY, filename)
+        if (existsSync(source)) {
+            copyFileSync(source, path.join(cleanupCwd, filename))
+        }
+    }
+
+    spawnOptions = {
+        cwd: cleanupCwd,
+        env: {
+            ...process.env,
+            // The pnpm binary is itself a js_binary launcher; this keeps it runnable after
+            // changing cwd away from the Bazel output tree.
+            BAZEL_BINDIR: process.env.BAZEL_BINDIR || '.',
+        },
+        stdio: 'inherit',
+    }
+}
+
+const spawn = spawnSync(
+    path.resolve(toolPath),
+    ['publish', packagePath, '--no-git-checks', ...restArgs],
+    spawnOptions,
+)
+
+if (cleanupCwd) {
+    rmSync(cleanupCwd, {
+        force: true,
+        recursive: true,
+    })
+}
+
+if (spawn.error) {
+    console.error(spawn.error.message)
+    process.exit(1)
+}
+
+if (spawn.signal) {
+    console.error(`pnpm publish exited with signal ${spawn.signal}`)
+    process.exit(1)
+}
 
 process.exit(spawn.status)

--- a/npm/private/test/npm_package_publish/BUILD.bazel
+++ b/npm/private/test/npm_package_publish/BUILD.bazel
@@ -37,11 +37,15 @@ sh_test(
         "$(locations :pkg_a.publish)",
         "$(locations :pkg_b.publish)",
         "$(locations :pkg_pnpm.publish)",
+        "$(locations @pnpm//:pnpm)",
+        "$(locations :pkg_pnpm)",
     ],
     data = [
         ":pkg_a.publish",
         ":pkg_b.publish",
+        ":pkg_pnpm",
         ":pkg_pnpm.publish",
+        "@pnpm//:pnpm",
     ],
     tags = [
         "no-remote-exec",

--- a/npm/private/test/npm_package_publish/BUILD.bazel
+++ b/npm/private/test/npm_package_publish/BUILD.bazel
@@ -20,16 +20,28 @@ npm_package(
     publishable = True,
 )
 
+npm_package(
+    name = "pkg_pnpm",
+    srcs = [
+        "pnpm_catalog/index.js",
+        "pnpm_catalog/package.json",
+    ],
+    publishable = True,
+    root_paths = [package_name() + "/pnpm_catalog"],
+)
+
 sh_test(
     name = "test",
     srcs = ["test.sh"],
     args = [
         "$(locations :pkg_a.publish)",
         "$(locations :pkg_b.publish)",
+        "$(locations :pkg_pnpm.publish)",
     ],
     data = [
         ":pkg_a.publish",
         ":pkg_b.publish",
+        ":pkg_pnpm.publish",
     ],
     tags = [
         "no-remote-exec",

--- a/npm/private/test/npm_package_publish/pnpm_catalog/index.js
+++ b/npm/private/test/npm_package_publish/pnpm_catalog/index.js
@@ -1,0 +1,1 @@
+export const value = 1

--- a/npm/private/test/npm_package_publish/pnpm_catalog/package.json
+++ b/npm/private/test/npm_package_publish/pnpm_catalog/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@mycorp/pkg-to-publish-pnpm",
+    "version": "1.0.0",
+    "dependencies": {
+        "typescript": "catalog:"
+    }
+}

--- a/npm/private/test/npm_package_publish/test.sh
+++ b/npm/private/test/npm_package_publish/test.sh
@@ -3,6 +3,8 @@
 readonly PUBLISH_A="$1"
 readonly PUBLISH_B="$2"
 readonly PUBLISH_PNPM="$3"
+readonly PNPM="$(cd "$(dirname "$4")" && pwd)/$(basename "$4")"
+readonly PKG_PNPM="$(cd "$(dirname "$5")" && pwd)/$(basename "$5")"
 
 # Assert that pnpm reads package.json from the package directory.
 $PUBLISH_A >pub_a.log 2>&1
@@ -56,12 +58,41 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
-# The source package.json is 132 bytes. pnpm rewrites catalog: to the concrete
-# version before packing, producing the smaller manifest below.
-cat pub_pnpm.log | grep '"size": 116'
+mkdir -p "${TMP_WORKSPACE}/package" "${TMP_WORKSPACE}/packed"
+cp -R "${PKG_PNPM}/." "${TMP_WORKSPACE}/package/"
+
+cat >"${TMP_WORKSPACE}/pnpm-workspace.yaml" <<'EOF'
+packages:
+    - package
+catalog:
+    typescript: 5.9.3
+EOF
+
+(
+    cd "${TMP_WORKSPACE}/package"
+    BAZEL_BINDIR=. "${PNPM}" pack \
+        --pack-destination "${TMP_WORKSPACE}/packed" \
+        --json >pack.log
+)
 
 # shellcheck disable=SC2181
 if [ $? != 0 ]; then
-    echo "FAIL: expected pnpm publish to resolve catalog: in package.json, GOT: $(cat pub_pnpm.log)"
+    echo "FAIL: expected pnpm pack to resolve catalog dependencies, GOT: $(cat "${TMP_WORKSPACE}/package/pack.log")"
+    exit 1
+fi
+
+readonly PACKED_ARCHIVE="$(find "${TMP_WORKSPACE}/packed" -name '*.tgz' -print -quit)"
+tar -xOf "${PACKED_ARCHIVE}" package/package.json >packed-package.json
+
+grep '"typescript": "5.9.3"' packed-package.json
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    echo "FAIL: expected packed package.json to contain the resolved catalog version, GOT: $(cat packed-package.json)"
+    exit 1
+fi
+
+if grep -q 'catalog:' packed-package.json; then
+    echo "FAIL: expected packed package.json not to contain catalog:, GOT: $(cat packed-package.json)"
     exit 1
 fi

--- a/npm/private/test/npm_package_publish/test.sh
+++ b/npm/private/test/npm_package_publish/test.sh
@@ -2,27 +2,66 @@
 
 readonly PUBLISH_A="$1"
 readonly PUBLISH_B="$2"
+readonly PUBLISH_PNPM="$3"
 
-# assert that it prints package name from package.json to stderr,
-# to ensure package directory is properly passed and npm can read it.
-$PUBLISH_A 2>pub_a.log
+# Assert that pnpm reads package.json from the package directory.
+$PUBLISH_A >pub_a.log 2>&1
 
-cat pub_a.log | grep 'npm notice package: @mycorp/pkg-to-publish@'
+cat pub_a.log | grep 'ERR_PNPM_PACKAGE_VERSION_NOT_FOUND'
 
 # shellcheck disable=SC2181
 if [ $? != 0 ]; then
-    echo "FAIL: expected 'npm notice package: @mycorp/pkg-to-publish@' error, GOT: $(cat pub_a.log)"
+    echo "FAIL: expected 'ERR_PNPM_PACKAGE_VERSION_NOT_FOUND' error, GOT: $(cat pub_a.log)"
     exit 1
 fi
 
 # asserting that npm_package has no package.json in it's srcs and we fail correctly.
-# npm publish requires a package.json in the root of the package directory.
-$PUBLISH_B 2>pub_b.log
+# pnpm publish requires a package.json in the root of the package directory.
+$PUBLISH_B >pub_b.log 2>&1
 
-cat pub_b.log | grep 'npm error enoent Could not read package.json:'
+cat pub_b.log | grep 'ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND'
 
 # shellcheck disable=SC2181
 if [ $? != 0 ]; then
-    echo "FAIL: expected 'npm error enoent Could not read package.json:' error, GOT: $(cat pub_b.log)"
+    echo "FAIL: expected 'ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND' error, GOT: $(cat pub_b.log)"
+    exit 1
+fi
+
+readonly TMP_WORKSPACE="$(mktemp -d)"
+trap 'rm -rf "${TMP_WORKSPACE}"' EXIT
+
+cat >"${TMP_WORKSPACE}/pnpm-workspace.yaml" <<'EOF'
+packages:
+    - packages/*
+catalog:
+    typescript: 5.9.3
+EOF
+
+# Ensure pnpm publish can read workspace-level catalog settings when publishing
+# a generated package directory.
+BUILD_WORKSPACE_DIRECTORY="${TMP_WORKSPACE}" \
+    "$PUBLISH_PNPM" --dry-run --json >pub_pnpm.log 2>pub_pnpm.err
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    echo "FAIL: expected pnpm publish dry-run to pass, GOT stdout: $(cat pub_pnpm.log), stderr: $(cat pub_pnpm.err)"
+    exit 1
+fi
+
+cat pub_pnpm.log | grep '"name": "@mycorp/pkg-to-publish-pnpm"'
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    echo "FAIL: expected pnpm publish dry-run output to include package name, GOT: $(cat pub_pnpm.log)"
+    exit 1
+fi
+
+# The source package.json is 132 bytes. pnpm rewrites catalog: to the concrete
+# version before packing, producing the smaller manifest below.
+cat pub_pnpm.log | grep '"size": 116'
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    echo "FAIL: expected pnpm publish to resolve catalog: in package.json, GOT: $(cat pub_pnpm.log)"
     exit 1
 fi


### PR DESCRIPTION
## What

Changes `npm_package(publishable = True)` so the generated `<name>.publish` target runs `pnpm publish` instead of `npm publish`.

This removes the proposed `publish_tool` API and keeps the public target shape unchanged. A `pnpm_binary` override remains available for custom pnpm repository names; by default it uses `@pnpm//:pnpm`.

The publish wrapper now:

- invokes pnpm with the generated package directory from `bazel-bin`
- uses a temporary cwd when `BUILD_WORKSPACE_DIRECTORY` is available, copying in only `pnpm-workspace.yaml` and `.npmrc` when present
- adds `--no-git-checks` because Bazel publishes generated output
- keeps `include_npm = True` for pnpm <=10, where registry operations may delegate to npm

## Why

`pnpm publish` handles pnpm workspace publishing semantics such as replacing `catalog:` dependency specs before packing. `npm publish` does not understand those pnpm-specific specs.

The isolated temporary cwd exposes the workspace-level pnpm settings required for publishing without making the source workspace the child process cwd. Using pnpm directly also avoids adding a new publish-tool selection API while preserving the existing `<name>.publish` entrypoint for users.

## Notes

- The catalog regression test verifies that pnpm rewrites the published `package.json`, not only that dry-run publish exits successfully.
- User-level `.npmrc` and environment-based configuration remain available through the inherited process environment.
- pnpm 11 publishes natively; the npm fallback path is only relevant for older pnpm versions.
