### PR TITLE
fix: declare use_execroot_entry_point config setting as public

### DIFF
--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -14,6 +14,10 @@ bool_flag(
 config_setting(
     name = "_use_execroot_entry_point_true",
     flag_values = {"use_execroot_entry_point": "True"},
+    # Must be public: this is referenced by select() expressions that the js_run_binary
+    # macro expands into user packages, where visibility is checked from the use site.
+    # Without this, builds fail under --incompatible_config_setting_private_default_visibility.
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; BCR
