### PR TITLE
fix(nextjs): add missing dependencies in nextjs_standalone_server

### DIFF
--- a/contrib/nextjs/defs.bzl
+++ b/contrib/nextjs/defs.bzl
@@ -405,15 +405,6 @@ def nextjs_standalone_server(name, app, pkg = None, data = [], **kwargs):
     # directory name, so they must be preserved.
     app_dir = app.split(":")[-1] if ":" in app else app.split("/")[-1]
 
-    # The standalone server binary
-    js_binary(
-        name = name,
-        entry_point = ":_{}.js".format(name),
-        chdir = native.package_name(),
-        data = data,
-        **kwargs
-    )
-
     # The server entry point into the standalone directory.
     directory_path(
         name = "_{}.js".format(name),
@@ -445,6 +436,15 @@ def nextjs_standalone_server(name, app, pkg = None, data = [], **kwargs):
         allow_overwrites = True,
         visibility = ["//visibility:private"],
         tags = ["manual"],
+    )
+
+    # The standalone server binary
+    js_binary(
+        name = name,
+        entry_point = ":_{}.js".format(name),
+        chdir = native.package_name(),
+        data = data + ["_{}.standalone".format(name)],
+        **kwargs
     )
 
 def _copy_exec_to_bin_impl(ctx):

--- a/examples/nextjs/BUILD.bazel
+++ b/examples/nextjs/BUILD.bazel
@@ -4,6 +4,7 @@ load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//nextjs:next/package_json.bzl", next_bin = "bin")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 npm_link_all_packages()
 
@@ -66,6 +67,10 @@ nextjs_standalone_build(
 nextjs_standalone_server(
     name = "server",
     app = ":standalone",
+    data = [
+        ":node_modules/next",
+        ":node_modules/react",
+    ],
 )
 
 platform(
@@ -108,6 +113,16 @@ build_test(
 build_test(
     name = "next_build_test",
     targets = [":node_modules/next"],
+)
+
+# Verify that the standalone server actually starts and serves HTTP.
+sh_test(
+    name = "server_test",
+    srcs = ["server_test.sh"],
+    args = ["$(rootpath :server)"],
+    data = [":server"],
+    size = "large",
+    timeout = "moderate",
 )
 
 write_source_files(

--- a/examples/nextjs/BUILD.bazel
+++ b/examples/nextjs/BUILD.bazel
@@ -121,8 +121,6 @@ sh_test(
     srcs = ["server_test.sh"],
     args = ["$(rootpath :server)"],
     data = [":server"],
-    size = "large",
-    timeout = "moderate",
 )
 
 write_source_files(

--- a/examples/nextjs/server_test.sh
+++ b/examples/nextjs/server_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+SERVER="$1"
+PORT=3099
+TIMEOUT=30
+
+export PORT
+"$SERVER" &
+SERVER_PID=$!
+
+cleanup() {
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for i in $(seq 1 "$TIMEOUT"); do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "FAIL: Server process died before responding"
+        exit 1
+    fi
+    if curl -sf "http://localhost:$PORT/" > /dev/null 2>&1; then
+        echo "PASS: Next.js standalone server responded on port $PORT"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "FAIL: Server did not respond within $TIMEOUT seconds"
+exit 1

--- a/examples/nextjs/server_test.sh
+++ b/examples/nextjs/server_test.sh
@@ -20,7 +20,7 @@ for i in $(seq 1 "$TIMEOUT"); do
         echo "FAIL: Server process died before responding"
         exit 1
     fi
-    if curl -sf "http://localhost:$PORT/" > /dev/null 2>&1; then
+    if curl -sf "http://localhost:$PORT/" >/dev/null 2>&1; then
         echo "PASS: Next.js standalone server responded on port $PORT"
         exit 0
     fi


### PR DESCRIPTION
Adds a server_test to examples/nextjs that starts the standalone server binary and polls for an HTTP response, catching potential regressions where the build succeeds but the server fails to run.

This turned up some issues where we had some missing dependencies. These would not necessarily be easy to catch with manual testing, since "bazel run" does not use a sandbox and can therefore succeed even when important dependencies are absent. The most important thing was making sure the `js_binary` takes a dependency on the actual sources produced by `next build`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fix handling of dependencies in nextjs_standalone_server()

### Test plan

- Covered by existing test cases
- New test cases added
