### PR TITLE
feat(npm): add publish_package_json macro for publishConfig field promotion

### DIFF
--- a/e2e/publish_package_json/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/publish_package_json/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,0 +1,9 @@
+# @generated
+# Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "@@//:pnpm-lock.yaml").
+# This file should be checked into version control along with the pnpm-lock.yaml file.
+.npmrc=-1810889885
+consumer/package.json=-161392235
+lib/package.json=720705137
+package.json=-638192911
+pnpm-lock.yaml=-880726515
+pnpm-workspace.yaml=-1339876532

--- a/e2e/publish_package_json/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/e2e/publish_package_json/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -3,7 +3,7 @@
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-1810889885
 consumer/package.json=-161392235
-lib/package.json=720705137
+lib/package.json=-601767299
 package.json=-638192911
 pnpm-lock.yaml=-880726515
 pnpm-workspace.yaml=-1339876532

--- a/e2e/publish_package_json/.bazelignore
+++ b/e2e/publish_package_json/.bazelignore
@@ -1,0 +1,3 @@
+node_modules
+consumer/node_modules
+lib/node_modules

--- a/e2e/publish_package_json/.bazelrc
+++ b/e2e/publish_package_json/.bazelrc
@@ -1,0 +1,2 @@
+import %workspace%/../../tools/preset.bazelrc
+import %workspace%/../e2e.bazelrc

--- a/e2e/publish_package_json/.npmrc
+++ b/e2e/publish_package_json/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/e2e/publish_package_json/BUILD.bazel
+++ b/e2e/publish_package_json/BUILD.bazel
@@ -1,0 +1,3 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages()

--- a/e2e/publish_package_json/MODULE.bazel
+++ b/e2e/publish_package_json/MODULE.bazel
@@ -1,0 +1,34 @@
+bazel_dep(name = "aspect_rules_js", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "aspect_rules_js",
+    path = "../..",
+)
+
+bazel_dep(name = "jq.bzl", version = "0.4.0", dev_dependency = True)
+
+pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
+pnpm.pnpm(
+    name = "pnpm",
+    pnpm_version = "9.15.9",
+)
+use_repo(pnpm, "pnpm", "pnpm__links")
+
+npm = use_extension(
+    "@aspect_rules_js//npm:extensions.bzl",
+    "npm",
+    dev_dependency = True,
+)
+npm.npm_translate_lock(
+    name = "npm",
+    data = [
+        "//:package.json",
+        "//:pnpm-workspace.yaml",
+        "//lib:package.json",
+        "//consumer:package.json",
+    ],
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    update_pnpm_lock = True,
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm")

--- a/e2e/publish_package_json/consumer/BUILD.bazel
+++ b/e2e/publish_package_json/consumer/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages()
+
+js_test(
+    name = "test",
+    data = [
+        ":node_modules/@lib/test",
+    ],
+    entry_point = "test.js",
+)

--- a/e2e/publish_package_json/consumer/package.json
+++ b/e2e/publish_package_json/consumer/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "consumer",
+    "dependencies": {
+        "@lib/test": "workspace:*"
+    }
+}

--- a/e2e/publish_package_json/consumer/test.js
+++ b/e2e/publish_package_json/consumer/test.js
@@ -1,0 +1,10 @@
+const lib = require('@lib/test')
+
+const result = lib.id()
+console.log('loaded:', result)
+
+if (!result.includes('dist')) {
+    throw new Error(
+        'Expected to load from dist (via publishConfig.main) but got: ' + result
+    )
+}

--- a/e2e/publish_package_json/lib/BUILD.bazel
+++ b/e2e/publish_package_json/lib/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package", "publish_package_json")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages()
+
+publish_package_json(
+    name = "package",
+)
+
+js_library(
+    name = "lib",
+    srcs = [
+        "dist/index.js",
+        ":package",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [":lib"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/publish_package_json/lib/dist/index.js
+++ b/e2e/publish_package_json/lib/dist/index.js
@@ -1,0 +1,1 @@
+module.exports = { id: () => '@lib/test (dist)' }

--- a/e2e/publish_package_json/lib/package.json
+++ b/e2e/publish_package_json/lib/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "@lib/test",
+    "private": true,
+    "main": "./src/index.js",
+    "publishConfig": {
+        "main": "./dist/index.js"
+    }
+}

--- a/e2e/publish_package_json/lib/package.json
+++ b/e2e/publish_package_json/lib/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lib/test",
     "private": true,
-    "main": "./src/index.js",
+    "main": "./src/foo.js",
     "publishConfig": {
         "main": "./dist/index.js"
     }

--- a/e2e/publish_package_json/lib/src/index.js
+++ b/e2e/publish_package_json/lib/src/index.js
@@ -1,0 +1,1 @@
+throw new Error('should not load source entry point')

--- a/e2e/publish_package_json/package.json
+++ b/e2e/publish_package_json/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "pnpm": {
+        "onlyBuiltDependencies": []
+    }
+}

--- a/e2e/publish_package_json/pnpm-lock.yaml
+++ b/e2e/publish_package_json/pnpm-lock.yaml
@@ -1,0 +1,17 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  consumer:
+    dependencies:
+      '@lib/test':
+        specifier: workspace:*
+        version: link:../lib
+
+  lib: {}

--- a/e2e/publish_package_json/pnpm-workspace.yaml
+++ b/e2e/publish_package_json/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+    - lib
+    - consumer

--- a/examples/publish_package_json/BUILD.bazel
+++ b/examples/publish_package_json/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@aspect_rules_js//npm:defs.bzl", "publish_package_json")
+load("@jq.bzl//jq:jq.bzl", "jq", "jq_test")
+
+publish_package_json(
+    name = "package",
+)
+
+jq(
+    name = "expected",
+    srcs = [],
+    filter = """
+{
+    name: "@example/publish-config",
+    version: "1.0.0",
+    main: "./dist/index.js",
+    types: "./dist/index.d.ts",
+    exports: {
+        ".": {
+            types: "./dist/index.d.ts",
+            import: "./dist/index.js"
+        }
+    }
+}
+""",
+)
+
+jq_test(
+    name = "publish_config_test",
+    file1 = ":package",
+    file2 = ":expected",
+)

--- a/examples/publish_package_json/package.json
+++ b/examples/publish_package_json/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@example/publish-config",
+    "version": "1.0.0",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.ts",
+            "import": "./src/index.ts"
+        }
+    },
+    "publishConfig": {
+        "main": "./dist/index.js",
+        "types": "./dist/index.d.ts",
+        "exports": {
+            ".": {
+                "types": "./dist/index.d.ts",
+                "import": "./dist/index.js"
+            }
+        }
+    }
+}

--- a/npm/defs.bzl
+++ b/npm/defs.bzl
@@ -9,9 +9,11 @@ load(
 load(
     "//npm/private:npm_package.bzl",
     _npm_package = "npm_package",
+    _publish_package_json = "publish_package_json",
     _stamped_package_json = "stamped_package_json",
 )
 
 npm_package = _npm_package
 npm_link_package = _npm_link_package
+publish_package_json = _publish_package_json
 stamped_package_json = _stamped_package_json

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -468,6 +468,75 @@ def npm_package(
         **kwargs
     )
 
+_PUBLISH_CONFIG_FIELDS = [
+    "bin",
+    "browser",
+    "cpu",
+    "engines",
+    "es2015",
+    "esnext",
+    "exports",
+    "imports",
+    "libc",
+    "main",
+    "module",
+    "os",
+    "type",
+    "types",
+    "typesVersions",
+    "typings",
+    "umd:main",
+    "unpkg",
+]
+
+def publish_package_json(name, stamp_var = None, publish_config_fields = None, **kwargs):
+    """Convenience wrapper to apply publishConfig field promotion to package.json.
+
+    Mimics `pnpm publish` behavior: fields within the `publishConfig` object are promoted to the
+    top level of the package.json, then `publishConfig` is removed. This is useful when your source
+    package.json uses `publishConfig` to override fields like `exports`, `main`, `types`, etc. for
+    the published artifact.
+
+    Optionally stamps the `version` field using a Bazel stamp variable, combining the behavior of
+    `stamped_package_json`.
+
+    For more information on pnpm's publishConfig behavior, see https://pnpm.io/package_json#publishconfig
+
+    Args:
+        name: name of the resulting `jq` target, must be "package"
+        stamp_var: optional key from the bazel-out/stable-status.txt or bazel-out/volatile-status.txt files.
+            When set, the version field is stamped just like `stamped_package_json`.
+        publish_config_fields: optional list of field names to promote from `publishConfig`. Defaults to the
+            set of fields that pnpm promotes: bin, browser, cpu, exports, imports, libc, main, module, os,
+            type, types, typings.
+        **kwargs: additional attributes passed to the jq rule
+    """
+    if name != "package":
+        fail("""publish_package_json should always be named "package" so that the default output is named "package.json".
+        This is required since Bazel doesn't allow a predeclared output to have the same name as an input file.""")
+
+    fields = publish_config_fields if publish_config_fields != None else _PUBLISH_CONFIG_FIELDS
+
+    promote_parts = [
+        "if .publishConfig[\"{field}\"] then .[\"{field}\"] = .publishConfig[\"{field}\"] else . end".format(field = f)
+        for f in fields
+    ]
+
+    filters = promote_parts + ["del(.publishConfig)"]
+
+    if stamp_var:
+        filters = [
+            "$ARGS.named.STAMP as $stamp",
+            ".version = ($stamp[0].{} // \"0.0.0\")".format(stamp_var),
+        ] + filters
+
+    jq(
+        name = name,
+        srcs = ["package.json"],
+        filter = " | ".join(filters),
+        **kwargs
+    )
+
 def stamped_package_json(name, stamp_var, **kwargs):
     """Convenience wrapper to set the "version" property in package.json with the git tag.
 


### PR DESCRIPTION
## Summary

- Adds a new `publish_package_json` convenience macro that mimics `pnpm publish` behavior: promotes fields from `publishConfig` into the top-level `package.json` and removes `publishConfig`
- Enables workspace packages to use `publishConfig` overrides (e.g. `exports`, `main`, `types`) that are applied when the package is linked as a dependency via `npm_package`
- Supports optional `stamp_var` to combine version stamping in a single target, and `publish_config_fields` to customize which fields are promoted (defaults to the pnpm allowlist)

## Motivation

This could fix the long-standing issue of misalignment between in-IDE type resolution and resolution within Bazel. If `pkg` uses a package.json processed with this rule, we can use:
* IDE type resolution pointing to source file (e.g. `src/index.ts`)
* Published package (also resolved with `publishConfig` after #2868)
* Bazel type resolution pointing to output folder (e.g. `dist/index.js`)

## Usage

```starlark
load("@aspect_rules_js//npm:defs.bzl", "npm_package", "publish_package_json")

publish_package_json(
    name = "package",
    # Optional: stamp version at the same time
    # stamp_var = "STABLE_BUILD_VERSION",
)

npm_package(
    name = "pkg",
    srcs = [":lib", ":package"],
)
```

## Test plan

- [x] Example test in `examples/publish_package_json/` verifies jq transform output
- [x] E2e test in `e2e/publish_package_json/` verifies a workspace consumer resolves through `publishConfig.main` (not source `main`)
- [x] Existing `stamped_package_json` tests still pass