### PR TITLE
feat(npm): pnpm publish support with build-time manifest transform

### DIFF
--- a/npm/private/BUILD.bazel
+++ b/npm/private/BUILD.bazel
@@ -6,6 +6,18 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 package(default_visibility = ["//npm:__subpackages__"])
 
 js_library(
+    name = "create_publish_manifest_mjs",
+    srcs = ["create_publish_manifest.mjs"],
+    visibility = ["//visibility:public"],
+)
+
+js_binary(
+    name = "create_publish_manifest",
+    entry_point = "create_publish_manifest.mjs",
+    visibility = ["//visibility:public"],
+)
+
+js_library(
     name = "npm_publish_mjs",
     srcs = ["npm_publish.mjs"],
     visibility = ["//visibility:public"],

--- a/npm/private/create_publish_manifest.mjs
+++ b/npm/private/create_publish_manifest.mjs
@@ -1,0 +1,194 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+
+// Fields that pnpm promotes from publishConfig to the top level.
+// Superset across pnpm 9/10/11.
+const PUBLISH_CONFIG_WHITELIST = new Set([
+    'bin',
+    'browser',
+    'cpu',
+    'engines',
+    'es2015',
+    'esnext',
+    'exports',
+    'imports',
+    'libc',
+    'main',
+    'module',
+    'os',
+    'type',
+    'types',
+    'typings',
+    'typesVersions',
+    'umd:main',
+    'unpkg',
+])
+
+const PUBLISH_LIFECYCLE_SCRIPTS = new Set([
+    'prepublish',
+    'prepare',
+    'prepublishOnly',
+    'postpublish',
+])
+
+function parseCatalogProtocol(specifier) {
+    if (typeof specifier !== 'string' || !specifier.startsWith('catalog:')) {
+        return null
+    }
+    const name = specifier.slice('catalog:'.length).trim()
+    return name === '' ? 'default' : name
+}
+
+function resolveCatalogSpecifier(catalogs, packageName, specifier) {
+    const catalogName = parseCatalogProtocol(specifier)
+    if (catalogName === null) return specifier
+
+    const catalog = catalogs[catalogName]
+    if (!catalog || !(packageName in catalog)) {
+        throw new Error(
+            `No entry for '${packageName}' in catalog '${catalogName}'`
+        )
+    }
+
+    const resolved = catalog[packageName]
+    if (parseCatalogProtocol(resolved) !== null) {
+        throw new Error(
+            `Recursive catalog: reference for '${packageName}' in catalog '${catalogName}'`
+        )
+    }
+    for (const protocol of ['workspace:', 'link:', 'file:']) {
+        if (typeof resolved === 'string' && resolved.startsWith(protocol)) {
+            throw new Error(
+                `Unsupported protocol '${protocol}' in catalog value for '${packageName}'`
+            )
+        }
+    }
+    return resolved
+}
+
+function resolveCatalogs(manifest, catalogs) {
+    for (const field of [
+        'dependencies',
+        'devDependencies',
+        'optionalDependencies',
+        'peerDependencies',
+    ]) {
+        const deps = manifest[field]
+        if (!deps) continue
+        for (const [name, specifier] of Object.entries(deps)) {
+            deps[name] = resolveCatalogSpecifier(catalogs, name, specifier)
+        }
+    }
+}
+
+function applyPublishConfig(manifest) {
+    const { publishConfig } = manifest
+    if (!publishConfig) return
+
+    for (const key of Object.keys(publishConfig)) {
+        if (PUBLISH_CONFIG_WHITELIST.has(key)) {
+            manifest[key] = publishConfig[key]
+            delete publishConfig[key]
+        }
+    }
+    if (Object.keys(publishConfig).length === 0) {
+        delete manifest.publishConfig
+    }
+}
+
+function stripPnpmFields(manifest) {
+    delete manifest.pnpm
+    delete manifest.packageManager
+
+    if (manifest.scripts) {
+        for (const name of PUBLISH_LIFECYCLE_SCRIPTS) {
+            delete manifest.scripts[name]
+        }
+        if (Object.keys(manifest.scripts).length === 0) {
+            delete manifest.scripts
+        }
+    }
+}
+
+// Parse the catalog/catalogs sections from pnpm-workspace.yaml.
+// Handles the subset of YAML used by these sections: flat maps of
+// unquoted or quoted string key-value pairs, optionally nested one
+// level deep for named catalogs.
+function parseCatalogsFromWorkspaceYaml(content) {
+    const catalogs = {}
+    const lines = content.split('\n')
+
+    let section = null
+    let currentCatalogName = null
+
+    for (const raw of lines) {
+        if (/^\s*(#|$)/.test(raw)) continue
+
+        const indent = raw.match(/^(\s*)/)[1].length
+
+        if (indent === 0) {
+            const m = raw.match(/^(catalog|catalogs)\s*:/)
+            section = m ? m[1] : null
+            currentCatalogName = null
+            if (section === 'catalog') {
+                currentCatalogName = 'default'
+                if (!catalogs.default) catalogs.default = {}
+            }
+            continue
+        }
+
+        if (!section) continue
+
+        const stripped = raw.trim()
+        const kvMatch = stripped.match(
+            /^['"]?([^'":\s][^'":]*?)['"]?\s*:\s*['"]?(.*?)['"]?\s*$/
+        )
+        if (!kvMatch) continue
+
+        const [, key, value] = kvMatch
+
+        if (section === 'catalog') {
+            catalogs.default[key] = value
+        } else if (section === 'catalogs') {
+            if (indent <= 4 && !value) {
+                currentCatalogName = key
+                if (!catalogs[key]) catalogs[key] = {}
+            } else if (currentCatalogName && value) {
+                catalogs[currentCatalogName][key] = value
+            }
+        }
+    }
+
+    return catalogs
+}
+
+function createPublishManifest(manifest, catalogs) {
+    const result = JSON.parse(JSON.stringify(manifest))
+    resolveCatalogs(result, catalogs || {})
+    applyPublishConfig(result)
+    stripPnpmFields(result)
+    return result
+}
+
+// CLI: create_publish_manifest <package-json> <output> [pnpm-workspace-yaml]
+const packageJsonPath = process.argv[2]
+const outputPath = process.argv[3]
+const workspaceYamlPath = process.argv[4]
+
+if (!packageJsonPath || !outputPath) {
+    console.error(
+        'Usage: create_publish_manifest <package-json> <output> [pnpm-workspace-yaml]'
+    )
+    process.exit(1)
+}
+
+const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+
+let catalogs = {}
+if (workspaceYamlPath && existsSync(workspaceYamlPath)) {
+    const content = readFileSync(workspaceYamlPath, 'utf8')
+    catalogs = parseCatalogsFromWorkspaceYaml(content)
+}
+
+const result = createPublishManifest(manifest, catalogs)
+writeFileSync(outputPath, JSON.stringify(result, null, 4) + '\n')

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -140,6 +140,7 @@ def npm_package(
         include_runfiles = False,
         hardlink = "auto",
         publishable = False,
+        pnpm_binary = "@pnpm//:pnpm",
         verbose = False,
         **kwargs):
     """A macro that packages sources into a directory (a tree artifact) and provides an `NpmPackageInfo`.
@@ -147,8 +148,11 @@ def npm_package(
     This target can be used as the `src` attribute to `npm_link_package`.
 
     With `publishable = True` the macro also produces a target `[name].publish`, that can be run to publish to an npm registry.
-    Under the hood, this target runs `npm publish`. You can pass arguments to npm by escaping them from Bazel using a double-hyphen,
-    for example: `bazel run //path/to:my_package.publish -- --tag=next`
+    Under the hood, this target runs `pnpm publish`. You can pass arguments to pnpm by escaping them from Bazel using a double-hyphen,
+    for example: `bazel run //path/to:my_package.publish -- --tag=next`.
+
+    pnpm publishing uses the configured `pnpm_binary` and can resolve pnpm workspace settings such as `catalog` entries from
+    `pnpm-workspace.yaml`. Workspace protocol dependencies follow pnpm's own resolution requirements.
 
     Files and directories can be arranged as needed in the output directory using
     the `root_paths`, `include_srcs_patterns`, `exclude_srcs_patterns` and `replace_prefixes` attributes.
@@ -210,7 +214,7 @@ def npm_package(
 
         srcs: Files and/or directories or targets that provide `DirectoryPathInfo` to copy into the output directory.
 
-        args: Arguments that are passed down to `<name>.publish` target and `npm publish` command.
+        args: Arguments that are passed down to `<name>.publish` target and the publish command.
 
         data: Runtime / linktime npm dependencies of this npm package.
 
@@ -409,6 +413,9 @@ def npm_package(
 
         publishable: When True, enable generation of `{name}.publish` target
 
+        pnpm_binary: Label of the pnpm binary used for publishing. This is typically `@pnpm//:pnpm`
+            from the `pnpm` extension in `@aspect_rules_js//npm:extensions.bzl`.
+
         verbose: If true, prints out verbose logs to stdout
 
         **kwargs: Additional attributes such as `tags` and `visibility`
@@ -437,10 +444,11 @@ def npm_package(
             name = "{}.publish".format(name),
             entry_point = Label("@aspect_rules_js//npm/private:npm_publish_mjs"),
             fixed_args = [
+                "$(rootpath {})".format(pnpm_binary),
                 "./$(rootpath :{})".format(name),
             ],
-            data = [name],
-            # required to make npm to be available in PATH
+            data = [name, pnpm_binary],
+            # pnpm <11 may delegate registry operations to npm. This can be removed when rules_js drops pnpm <=10.
             include_npm = True,
             args = args,
             tags = kwargs.get("tags", []) + ["manual"],

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -11,7 +11,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory_bin_action", "copy_to_directory_lib")
 load("@bazel_lib//lib:directory_path.bzl", "DirectoryPathInfo")
 load("@jq.bzl//jq:jq.bzl", "jq")
-load("//js:defs.bzl", "js_binary")
+load("//js:defs.bzl", "js_binary", "js_run_binary")
 load("//js:libs.bzl", "js_lib_helpers")
 load(":npm_package_info.bzl", "NpmPackageInfo")
 
@@ -141,6 +141,7 @@ def npm_package(
         hardlink = "auto",
         publishable = False,
         pnpm_binary = "@pnpm//:pnpm",
+        pnpm_workspace = None,
         verbose = False,
         **kwargs):
     """A macro that packages sources into a directory (a tree artifact) and provides an `NpmPackageInfo`.
@@ -427,6 +428,12 @@ def npm_package(
             requires the consuming module to define the `pnpm` extension repository and import it
             with `use_repo(pnpm, "pnpm")`.
 
+        pnpm_workspace: Label of the `pnpm-workspace.yaml` file. When set, the `package.json`
+            in `srcs` is transformed at build time: `catalog:` specifiers are resolved,
+            `publishConfig` fields are promoted, and pnpm-specific fields are stripped.
+            This ensures workspace consumers see a fully resolved `package.json` in the
+            output directory.
+
         verbose: If true, prints out verbose logs to stdout
 
         **kwargs: Additional attributes such as `tags` and `visibility`
@@ -449,6 +456,34 @@ def npm_package(
             testonly = kwargs.get("testonly", False),
         )
         srcs = srcs + [files_target]
+
+    if pnpm_workspace:
+        # Find package.json in srcs and replace it with a transformed version.
+        pkg_json_src = None
+        for src in srcs:
+            if type(src) == "string" and src.endswith("package.json"):
+                pkg_json_src = src
+                break
+
+        if pkg_json_src:
+            transform_name = "{}._publish_manifest".format(name)
+            transform_srcs = [pkg_json_src, pnpm_workspace]
+            js_run_binary(
+                name = transform_name,
+                tool = Label("@aspect_rules_js//npm/private:create_publish_manifest"),
+                srcs = transform_srcs,
+                outs = ["{}/_package.json".format(name)],
+                args = [
+                    "$(location {})".format(pkg_json_src),
+                    "$(location {}/_package.json)".format(name),
+                    "$(location {})".format(pnpm_workspace),
+                ],
+                tags = kwargs.get("tags", []) + ["manual"],
+                testonly = kwargs.get("testonly", False),
+            )
+            srcs = [s for s in srcs if s != pkg_json_src] + [":{}/_package.json".format(name)]
+            replace_prefixes = dict(replace_prefixes)
+            replace_prefixes["{}/_package.json".format(name)] = "package.json"
 
     if publishable:
         js_binary(

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -154,6 +154,16 @@ def npm_package(
     pnpm publishing uses the configured `pnpm_binary` and can resolve pnpm workspace settings such as `catalog` entries from
     `pnpm-workspace.yaml`. Workspace protocol dependencies follow pnpm's own resolution requirements.
 
+    The default `pnpm_binary` requires the consuming module to define and import the `@pnpm` repository:
+
+    ```starlark
+    pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
+    pnpm.pnpm(name = "pnpm")
+    use_repo(pnpm, "pnpm")
+    ```
+
+    Pass a different `pnpm_binary` label when the pnpm repository uses another name.
+
     Files and directories can be arranged as needed in the output directory using
     the `root_paths`, `include_srcs_patterns`, `exclude_srcs_patterns` and `replace_prefixes` attributes.
 
@@ -413,8 +423,9 @@ def npm_package(
 
         publishable: When True, enable generation of `{name}.publish` target
 
-        pnpm_binary: Label of the pnpm binary used for publishing. This is typically `@pnpm//:pnpm`
-            from the `pnpm` extension in `@aspect_rules_js//npm:extensions.bzl`.
+        pnpm_binary: Label of the pnpm binary used for publishing. The default `@pnpm//:pnpm`
+            requires the consuming module to define the `pnpm` extension repository and import it
+            with `use_repo(pnpm, "pnpm")`.
 
         verbose: If true, prints out verbose logs to stdout
 

--- a/npm/private/npm_publish.mjs
+++ b/npm/private/npm_publish.mjs
@@ -1,9 +1,73 @@
 import { spawnSync } from 'node:child_process'
+import {
+    copyFileSync,
+    existsSync,
+    mkdtempSync,
+    rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 
-const restArgs = process.argv.slice(2)
+const [toolPath, packageDir, ...restArgs] = process.argv.slice(2)
 
-const spawn = spawnSync('npm', ['publish', ...restArgs], {
+if (!toolPath || !packageDir) {
+    console.error(
+        'Expected publish tool path and package directory arguments.',
+    )
+    process.exit(1)
+}
+
+const packagePath = path.resolve(packageDir)
+
+let cleanupCwd
+let spawnOptions = {
     stdio: 'inherit',
-})
+}
+
+if (process.env.BUILD_WORKSPACE_DIRECTORY) {
+    cleanupCwd = mkdtempSync(path.join(tmpdir(), 'rules-js-pnpm-publish-'))
+
+    // Give pnpm only the workspace-level files it needs for publish settings.
+    for (const filename of ['pnpm-workspace.yaml', '.npmrc']) {
+        const source = path.join(process.env.BUILD_WORKSPACE_DIRECTORY, filename)
+        if (existsSync(source)) {
+            copyFileSync(source, path.join(cleanupCwd, filename))
+        }
+    }
+
+    spawnOptions = {
+        cwd: cleanupCwd,
+        env: {
+            ...process.env,
+            // The pnpm binary is itself a js_binary launcher; this keeps it runnable after
+            // changing cwd away from the Bazel output tree.
+            BAZEL_BINDIR: process.env.BAZEL_BINDIR || '.',
+        },
+        stdio: 'inherit',
+    }
+}
+
+const spawn = spawnSync(
+    path.resolve(toolPath),
+    ['publish', packagePath, '--no-git-checks', ...restArgs],
+    spawnOptions,
+)
+
+if (cleanupCwd) {
+    rmSync(cleanupCwd, {
+        force: true,
+        recursive: true,
+    })
+}
+
+if (spawn.error) {
+    console.error(spawn.error.message)
+    process.exit(1)
+}
+
+if (spawn.signal) {
+    console.error(`pnpm publish exited with signal ${spawn.signal}`)
+    process.exit(1)
+}
 
 process.exit(spawn.status)

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -117,3 +117,10 @@ js_test(
     data = [":node_modules"],
     entry_point = "versions.js",
 )
+
+js_test(
+    name = "create_publish_manifest_test",
+    data = ["//npm/private:create_publish_manifest_mjs"],
+    entry_point = "create_publish_manifest_test.mjs",
+    fixed_args = ["$(rootpath //npm/private:create_publish_manifest_mjs)"],
+)

--- a/npm/private/test/create_publish_manifest_test.mjs
+++ b/npm/private/test/create_publish_manifest_test.mjs
@@ -1,0 +1,418 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import assert from 'node:assert/strict'
+
+const SCRIPT = path.resolve(process.argv[2])
+
+let tmpDir
+function setup() {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'publish-manifest-test-'))
+}
+function teardown() {
+    rmSync(tmpDir, { force: true, recursive: true })
+}
+
+function run(packageJson, workspaceYaml) {
+    const pkgPath = path.join(tmpDir, 'package.json')
+    const outPath = path.join(tmpDir, 'output.json')
+    writeFileSync(pkgPath, JSON.stringify(packageJson))
+
+    const args = [SCRIPT, pkgPath, outPath]
+    if (workspaceYaml) {
+        const yamlPath = path.join(tmpDir, 'pnpm-workspace.yaml')
+        writeFileSync(yamlPath, workspaceYaml)
+        args.push(yamlPath)
+    }
+
+    execFileSync(process.execPath, args, { stdio: 'pipe' })
+    return JSON.parse(readFileSync(outPath, 'utf8'))
+}
+
+function runExpectError(packageJson, workspaceYaml) {
+    const pkgPath = path.join(tmpDir, 'package.json')
+    const outPath = path.join(tmpDir, 'output.json')
+    writeFileSync(pkgPath, JSON.stringify(packageJson))
+
+    const args = [SCRIPT, pkgPath, outPath]
+    if (workspaceYaml) {
+        const yamlPath = path.join(tmpDir, 'pnpm-workspace.yaml')
+        writeFileSync(yamlPath, workspaceYaml)
+        args.push(yamlPath)
+    }
+
+    try {
+        execFileSync(process.execPath, args, { stdio: 'pipe' })
+        throw new Error('Expected error but command succeeded')
+    } catch (e) {
+        if (e.message === 'Expected error but command succeeded') throw e
+        return e.stderr.toString()
+    }
+}
+
+const tests = []
+function test(name, fn) {
+    tests.push({ name, fn })
+}
+
+// --- Catalog resolution ---
+
+test('resolves default catalog specifiers', () => {
+    const result = run(
+        {
+            name: 'pkg',
+            dependencies: { typescript: 'catalog:' },
+        },
+        'catalog:\n    typescript: ^5.9.3\n'
+    )
+    assert.equal(result.dependencies.typescript, '^5.9.3')
+})
+
+test('resolves named catalog specifiers', () => {
+    const result = run(
+        {
+            name: 'pkg',
+            dependencies: { react: 'catalog:react17' },
+        },
+        'catalogs:\n    react17:\n        react: ^17.0.2\n'
+    )
+    assert.equal(result.dependencies.react, '^17.0.2')
+})
+
+test('resolves catalogs across all dependency fields', () => {
+    const result = run(
+        {
+            name: 'pkg',
+            dependencies: { a: 'catalog:' },
+            devDependencies: { b: 'catalog:' },
+            optionalDependencies: { c: 'catalog:' },
+            peerDependencies: { d: 'catalog:' },
+        },
+        'catalog:\n    a: ^1.0\n    b: ^2.0\n    c: ^3.0\n    d: ^4.0\n'
+    )
+    assert.equal(result.dependencies.a, '^1.0')
+    assert.equal(result.devDependencies.b, '^2.0')
+    assert.equal(result.optionalDependencies.c, '^3.0')
+    assert.equal(result.peerDependencies.d, '^4.0')
+})
+
+test('leaves non-catalog specifiers unchanged', () => {
+    const result = run(
+        {
+            name: 'pkg',
+            dependencies: { lodash: '^4.17.21', typescript: 'catalog:' },
+        },
+        'catalog:\n    typescript: ^5.9.3\n'
+    )
+    assert.equal(result.dependencies.lodash, '^4.17.21')
+    assert.equal(result.dependencies.typescript, '^5.9.3')
+})
+
+test('errors on missing catalog entry', () => {
+    const stderr = runExpectError(
+        {
+            name: 'pkg',
+            dependencies: { missing: 'catalog:' },
+        },
+        'catalog:\n    typescript: ^5.9.3\n'
+    )
+    assert.ok(stderr.includes("No entry for 'missing' in catalog 'default'"))
+})
+
+test('errors on missing named catalog', () => {
+    const stderr = runExpectError(
+        {
+            name: 'pkg',
+            dependencies: { react: 'catalog:nonexistent' },
+        },
+        'catalog:\n    typescript: ^5.9.3\n'
+    )
+    assert.ok(
+        stderr.includes("No entry for 'react' in catalog 'nonexistent'")
+    )
+})
+
+test('errors on recursive catalog reference', () => {
+    const stderr = runExpectError(
+        {
+            name: 'pkg',
+            dependencies: { a: 'catalog:' },
+        },
+        'catalog:\n    a: "catalog:other"\n'
+    )
+    assert.ok(stderr.includes('Recursive catalog:'))
+})
+
+test('errors on workspace: protocol in catalog value', () => {
+    const stderr = runExpectError(
+        {
+            name: 'pkg',
+            dependencies: { a: 'catalog:' },
+        },
+        'catalog:\n    a: "workspace:*"\n'
+    )
+    assert.ok(stderr.includes("Unsupported protocol 'workspace:'"))
+})
+
+test('errors on link: protocol in catalog value', () => {
+    const stderr = runExpectError(
+        {
+            name: 'pkg',
+            dependencies: { a: 'catalog:' },
+        },
+        'catalog:\n    a: "link:../other"\n'
+    )
+    assert.ok(stderr.includes("Unsupported protocol 'link:'"))
+})
+
+test('errors on file: protocol in catalog value', () => {
+    const stderr = runExpectError(
+        {
+            name: 'pkg',
+            dependencies: { a: 'catalog:' },
+        },
+        'catalog:\n    a: "file:../other"\n'
+    )
+    assert.ok(stderr.includes("Unsupported protocol 'file:'"))
+})
+
+// --- publishConfig overlay ---
+
+test('promotes whitelisted publishConfig fields', () => {
+    const result = run({
+        name: 'pkg',
+        main: 'src/index.js',
+        publishConfig: {
+            main: 'dist/index.js',
+            types: 'dist/index.d.ts',
+            exports: { '.': './dist/index.js' },
+        },
+    })
+    assert.equal(result.main, 'dist/index.js')
+    assert.equal(result.types, 'dist/index.d.ts')
+    assert.deepEqual(result.exports, { '.': './dist/index.js' })
+    assert.equal(result.publishConfig, undefined)
+})
+
+test('keeps non-whitelisted publishConfig fields', () => {
+    const result = run({
+        name: 'pkg',
+        publishConfig: {
+            main: 'dist/index.js',
+            registry: 'https://registry.npmjs.org',
+            access: 'public',
+        },
+    })
+    assert.equal(result.main, 'dist/index.js')
+    assert.deepEqual(result.publishConfig, {
+        registry: 'https://registry.npmjs.org',
+        access: 'public',
+    })
+})
+
+test('deletes publishConfig when all fields promoted', () => {
+    const result = run({
+        name: 'pkg',
+        publishConfig: { main: 'dist/index.js', bin: './cli.js' },
+    })
+    assert.equal(result.main, 'dist/index.js')
+    assert.equal(result.bin, './cli.js')
+    assert.equal(result.publishConfig, undefined)
+})
+
+test('handles all whitelisted publishConfig fields', () => {
+    const whitelist = [
+        'bin', 'browser', 'cpu', 'engines', 'es2015', 'esnext', 'exports',
+        'imports', 'libc', 'main', 'module', 'os', 'type', 'types', 'typings',
+        'typesVersions', 'umd:main', 'unpkg',
+    ]
+    const publishConfig = {}
+    for (const field of whitelist) {
+        publishConfig[field] = `value-${field}`
+    }
+    const result = run({ name: 'pkg', publishConfig })
+    for (const field of whitelist) {
+        assert.equal(result[field], `value-${field}`, `field '${field}' should be promoted`)
+    }
+    assert.equal(result.publishConfig, undefined)
+})
+
+test('no-op when publishConfig is absent', () => {
+    const result = run({ name: 'pkg', main: 'index.js' })
+    assert.equal(result.main, 'index.js')
+    assert.equal(result.publishConfig, undefined)
+})
+
+// --- Field stripping ---
+
+test('strips pnpm field', () => {
+    const result = run({
+        name: 'pkg',
+        pnpm: { overrides: { foo: '1.0.0' } },
+    })
+    assert.equal(result.pnpm, undefined)
+})
+
+test('strips packageManager field', () => {
+    const result = run({
+        name: 'pkg',
+        packageManager: 'pnpm@10.0.0',
+    })
+    assert.equal(result.packageManager, undefined)
+})
+
+test('strips publish lifecycle scripts', () => {
+    const result = run({
+        name: 'pkg',
+        scripts: {
+            prepublish: 'echo prep',
+            prepare: 'echo prepare',
+            prepublishOnly: 'echo prepub',
+            postpublish: 'echo post',
+            build: 'tsc',
+            test: 'jest',
+        },
+    })
+    assert.deepEqual(result.scripts, { build: 'tsc', test: 'jest' })
+})
+
+test('deletes scripts when only lifecycle scripts remain', () => {
+    const result = run({
+        name: 'pkg',
+        scripts: { prepublishOnly: 'tsc' },
+    })
+    assert.equal(result.scripts, undefined)
+})
+
+test('preserves scripts when no lifecycle scripts present', () => {
+    const result = run({
+        name: 'pkg',
+        scripts: { build: 'tsc' },
+    })
+    assert.deepEqual(result.scripts, { build: 'tsc' })
+})
+
+// --- YAML parser ---
+
+test('parses default catalog from workspace yaml', () => {
+    const result = run(
+        { name: 'pkg', dependencies: { a: 'catalog:', b: 'catalog:' } },
+        'catalog:\n    a: ^1.0\n    b: ^2.0\n'
+    )
+    assert.equal(result.dependencies.a, '^1.0')
+    assert.equal(result.dependencies.b, '^2.0')
+})
+
+test('parses named catalogs from workspace yaml', () => {
+    const result = run(
+        { name: 'pkg', dependencies: { a: 'catalog:foo', b: 'catalog:bar' } },
+        'catalogs:\n    foo:\n        a: ^1.0\n    bar:\n        b: ^2.0\n'
+    )
+    assert.equal(result.dependencies.a, '^1.0')
+    assert.equal(result.dependencies.b, '^2.0')
+})
+
+test('ignores non-catalog sections in workspace yaml', () => {
+    const result = run(
+        { name: 'pkg', dependencies: { a: 'catalog:' } },
+        [
+            'packages:',
+            '    - packages/*',
+            'catalog:',
+            '    a: ^1.0',
+            'onlyBuiltDependencies:',
+            '    - esbuild',
+        ].join('\n')
+    )
+    assert.equal(result.dependencies.a, '^1.0')
+})
+
+test('handles comments in workspace yaml', () => {
+    const result = run(
+        { name: 'pkg', dependencies: { a: 'catalog:' } },
+        '# comment\ncatalog:\n    # another comment\n    a: ^1.0\n'
+    )
+    assert.equal(result.dependencies.a, '^1.0')
+})
+
+test('handles quoted keys and values in workspace yaml', () => {
+    const result = run(
+        { name: 'pkg', dependencies: { a: 'catalog:' } },
+        "catalog:\n    'a': '^1.0'\n"
+    )
+    assert.equal(result.dependencies.a, '^1.0')
+})
+
+test('returns empty catalogs when no catalog sections', () => {
+    const result = run(
+        { name: 'pkg', dependencies: { a: '^1.0' } },
+        'packages:\n    - packages/*\n'
+    )
+    assert.equal(result.dependencies.a, '^1.0')
+})
+
+test('works without workspace yaml', () => {
+    const result = run({ name: 'pkg', dependencies: { a: '^1.0' } })
+    assert.equal(result.dependencies.a, '^1.0')
+})
+
+// --- Combined transforms ---
+
+test('applies all transforms together', () => {
+    const result = run(
+        {
+            name: '@mycorp/pkg',
+            version: '1.0.0',
+            main: 'src/index.js',
+            publishConfig: {
+                main: 'dist/index.js',
+                registry: 'https://registry.npmjs.org',
+            },
+            dependencies: {
+                typescript: 'catalog:',
+                lodash: '^4.17.21',
+            },
+            pnpm: { overrides: {} },
+            packageManager: 'pnpm@10.0.0',
+            scripts: {
+                build: 'tsc',
+                prepublishOnly: 'npm run build',
+            },
+        },
+        'catalog:\n    typescript: ^5.9.3\n'
+    )
+    assert.equal(result.name, '@mycorp/pkg')
+    assert.equal(result.version, '1.0.0')
+    assert.equal(result.main, 'dist/index.js')
+    assert.deepEqual(result.publishConfig, {
+        registry: 'https://registry.npmjs.org',
+    })
+    assert.equal(result.dependencies.typescript, '^5.9.3')
+    assert.equal(result.dependencies.lodash, '^4.17.21')
+    assert.equal(result.pnpm, undefined)
+    assert.equal(result.packageManager, undefined)
+    assert.deepEqual(result.scripts, { build: 'tsc' })
+})
+
+// --- Run tests ---
+
+let passed = 0
+let failed = 0
+
+for (const t of tests) {
+    setup()
+    try {
+        t.fn()
+        passed++
+    } catch (e) {
+        failed++
+        console.error(`FAIL: ${t.name}`)
+        console.error(`  ${e.message}`)
+    } finally {
+        teardown()
+    }
+}
+
+console.log(`\n${passed} passed, ${failed} failed, ${tests.length} total`)
+if (failed > 0) process.exit(1)

--- a/npm/private/test/npm_package_publish/BUILD.bazel
+++ b/npm/private/test/npm_package_publish/BUILD.bazel
@@ -37,11 +37,15 @@ sh_test(
         "$(locations :pkg_a.publish)",
         "$(locations :pkg_b.publish)",
         "$(locations :pkg_pnpm.publish)",
+        "$(locations @pnpm//:pnpm)",
+        "$(locations :pkg_pnpm)",
     ],
     data = [
         ":pkg_a.publish",
         ":pkg_b.publish",
+        ":pkg_pnpm",
         ":pkg_pnpm.publish",
+        "@pnpm//:pnpm",
     ],
     tags = [
         "no-remote-exec",

--- a/npm/private/test/npm_package_publish/BUILD.bazel
+++ b/npm/private/test/npm_package_publish/BUILD.bazel
@@ -45,7 +45,7 @@ sh_test(
         ":pkg_b.publish",
         ":pkg_pnpm",
         ":pkg_pnpm.publish",
-        "@pnpm//:pnpm",
+        "@pnpm",
     ],
     tags = [
         "no-remote-exec",

--- a/npm/private/test/npm_package_publish/BUILD.bazel
+++ b/npm/private/test/npm_package_publish/BUILD.bazel
@@ -20,16 +20,28 @@ npm_package(
     publishable = True,
 )
 
+npm_package(
+    name = "pkg_pnpm",
+    srcs = [
+        "pnpm_catalog/index.js",
+        "pnpm_catalog/package.json",
+    ],
+    publishable = True,
+    root_paths = [package_name() + "/pnpm_catalog"],
+)
+
 sh_test(
     name = "test",
     srcs = ["test.sh"],
     args = [
         "$(locations :pkg_a.publish)",
         "$(locations :pkg_b.publish)",
+        "$(locations :pkg_pnpm.publish)",
     ],
     data = [
         ":pkg_a.publish",
         ":pkg_b.publish",
+        ":pkg_pnpm.publish",
     ],
     tags = [
         "no-remote-exec",

--- a/npm/private/test/npm_package_publish/pnpm_catalog/index.js
+++ b/npm/private/test/npm_package_publish/pnpm_catalog/index.js
@@ -1,0 +1,1 @@
+export const value = 1

--- a/npm/private/test/npm_package_publish/pnpm_catalog/package.json
+++ b/npm/private/test/npm_package_publish/pnpm_catalog/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@mycorp/pkg-to-publish-pnpm",
+    "version": "1.0.0",
+    "dependencies": {
+        "typescript": "catalog:"
+    }
+}

--- a/npm/private/test/npm_package_publish/test.sh
+++ b/npm/private/test/npm_package_publish/test.sh
@@ -3,6 +3,8 @@
 readonly PUBLISH_A="$1"
 readonly PUBLISH_B="$2"
 readonly PUBLISH_PNPM="$3"
+readonly PNPM="$(cd "$(dirname "$4")" && pwd)/$(basename "$4")"
+readonly PKG_PNPM="$(cd "$(dirname "$5")" && pwd)/$(basename "$5")"
 
 # Assert that pnpm reads package.json from the package directory.
 $PUBLISH_A >pub_a.log 2>&1
@@ -56,12 +58,41 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
-# The source package.json is 132 bytes. pnpm rewrites catalog: to the concrete
-# version before packing, producing the smaller manifest below.
-cat pub_pnpm.log | grep '"size": 116'
+mkdir -p "${TMP_WORKSPACE}/package" "${TMP_WORKSPACE}/packed"
+cp -R "${PKG_PNPM}/." "${TMP_WORKSPACE}/package/"
+
+cat >"${TMP_WORKSPACE}/pnpm-workspace.yaml" <<'EOF'
+packages:
+    - package
+catalog:
+    typescript: 5.9.3
+EOF
+
+(
+    cd "${TMP_WORKSPACE}/package"
+    BAZEL_BINDIR=. "${PNPM}" pack \
+        --pack-destination "${TMP_WORKSPACE}/packed" \
+        --json >pack.log
+)
 
 # shellcheck disable=SC2181
 if [ $? != 0 ]; then
-    echo "FAIL: expected pnpm publish to resolve catalog: in package.json, GOT: $(cat pub_pnpm.log)"
+    echo "FAIL: expected pnpm pack to resolve catalog dependencies, GOT: $(cat "${TMP_WORKSPACE}/package/pack.log")"
+    exit 1
+fi
+
+readonly PACKED_ARCHIVE="$(find "${TMP_WORKSPACE}/packed" -name '*.tgz' -print -quit)"
+tar -xOf "${PACKED_ARCHIVE}" package/package.json >packed-package.json
+
+grep '"typescript": "5.9.3"' packed-package.json
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    echo "FAIL: expected packed package.json to contain the resolved catalog version, GOT: $(cat packed-package.json)"
+    exit 1
+fi
+
+if grep -q 'catalog:' packed-package.json; then
+    echo "FAIL: expected packed package.json not to contain catalog:, GOT: $(cat packed-package.json)"
     exit 1
 fi

--- a/npm/private/test/npm_package_publish/test.sh
+++ b/npm/private/test/npm_package_publish/test.sh
@@ -2,27 +2,66 @@
 
 readonly PUBLISH_A="$1"
 readonly PUBLISH_B="$2"
+readonly PUBLISH_PNPM="$3"
 
-# assert that it prints package name from package.json to stderr,
-# to ensure package directory is properly passed and npm can read it.
-$PUBLISH_A 2>pub_a.log
+# Assert that pnpm reads package.json from the package directory.
+$PUBLISH_A >pub_a.log 2>&1
 
-cat pub_a.log | grep 'npm notice package: @mycorp/pkg-to-publish@'
+cat pub_a.log | grep 'ERR_PNPM_PACKAGE_VERSION_NOT_FOUND'
 
 # shellcheck disable=SC2181
 if [ $? != 0 ]; then
-    echo "FAIL: expected 'npm notice package: @mycorp/pkg-to-publish@' error, GOT: $(cat pub_a.log)"
+    echo "FAIL: expected 'ERR_PNPM_PACKAGE_VERSION_NOT_FOUND' error, GOT: $(cat pub_a.log)"
     exit 1
 fi
 
 # asserting that npm_package has no package.json in it's srcs and we fail correctly.
-# npm publish requires a package.json in the root of the package directory.
-$PUBLISH_B 2>pub_b.log
+# pnpm publish requires a package.json in the root of the package directory.
+$PUBLISH_B >pub_b.log 2>&1
 
-cat pub_b.log | grep 'npm error enoent Could not read package.json:'
+cat pub_b.log | grep 'ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND'
 
 # shellcheck disable=SC2181
 if [ $? != 0 ]; then
-    echo "FAIL: expected 'npm error enoent Could not read package.json:' error, GOT: $(cat pub_b.log)"
+    echo "FAIL: expected 'ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND' error, GOT: $(cat pub_b.log)"
+    exit 1
+fi
+
+readonly TMP_WORKSPACE="$(mktemp -d)"
+trap 'rm -rf "${TMP_WORKSPACE}"' EXIT
+
+cat >"${TMP_WORKSPACE}/pnpm-workspace.yaml" <<'EOF'
+packages:
+    - packages/*
+catalog:
+    typescript: 5.9.3
+EOF
+
+# Ensure pnpm publish can read workspace-level catalog settings when publishing
+# a generated package directory.
+BUILD_WORKSPACE_DIRECTORY="${TMP_WORKSPACE}" \
+    "$PUBLISH_PNPM" --dry-run --json >pub_pnpm.log 2>pub_pnpm.err
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    echo "FAIL: expected pnpm publish dry-run to pass, GOT stdout: $(cat pub_pnpm.log), stderr: $(cat pub_pnpm.err)"
+    exit 1
+fi
+
+cat pub_pnpm.log | grep '"name": "@mycorp/pkg-to-publish-pnpm"'
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    echo "FAIL: expected pnpm publish dry-run output to include package name, GOT: $(cat pub_pnpm.log)"
+    exit 1
+fi
+
+# The source package.json is 132 bytes. pnpm rewrites catalog: to the concrete
+# version before packing, producing the smaller manifest below.
+cat pub_pnpm.log | grep '"size": 116'
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    echo "FAIL: expected pnpm publish to resolve catalog: in package.json, GOT: $(cat pub_pnpm.log)"
     exit 1
 fi


### PR DESCRIPTION
## Summary
- Switches `npm_package` publishing from `npm publish` to `pnpm publish`, enabling pnpm workspace features like `catalog:` dependency resolution (based on @luciomartinez's work in #2868)
- Adds a build-time `package.json` manifest transform via `create_publish_manifest.mjs` that resolves `catalog:` specifiers, promotes `publishConfig` whitelisted fields, and strips pnpm-specific fields (`pnpm`, `packageManager`, publish lifecycle scripts)
- New `pnpm_workspace` attribute on `npm_package` runs the transform as a `js_run_binary` action, so workspace consumers see a fully resolved `package.json` in the output directory
- New `pnpm_binary` attribute on `npm_package` for configuring which pnpm binary to use for publishing
- Fixes buildifier formatting (`@pnpm//:pnpm` → `@pnpm`)

## Design
The manifest transform runs at **build time** (not publish time), so:
- Workspace consumers always see a resolved `package.json` with no `catalog:` specifiers
- `pnpm publish` sees the same transformed `package.json`; its own catalog/publishConfig transforms become no-ops
- The transform uses a minimal inline YAML parser for the `catalog`/`catalogs` sections of `pnpm-workspace.yaml` — zero npm dependencies
- The `pnpm-workspace.yaml` location is passed explicitly via the `pnpm_workspace` label attribute rather than assumed to be at the Bazel workspace root

## Test plan
- [x] 28 unit tests for `create_publish_manifest.mjs` covering catalog resolution, publishConfig overlay, field stripping, YAML parsing, and error cases
- [x] Existing `npm_package_publish` integration tests for pnpm publish error handling
- [x] Buildifier check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)