### PR TITLE
fix(npm): correct package_store_prefix_len for links in external-repo sub-packages

### DIFF
--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -189,9 +189,9 @@ def _npm_package_store_impl(ctx):
 
     package_store_prefix_len = _PACKAGE_STORE_PREFIX_LEN
     if ctx.label.package:
-        package_store_prefix_len += len(ctx.label.package)
+        package_store_prefix_len += len(ctx.label.package) + 1  # +1 for the "/" after the package path
     if ctx.label.repo_name:
-        package_store_prefix_len += len(ctx.label.repo_name) + 3  # +3 for ../
+        package_store_prefix_len += len(ctx.label.repo_name) + 3 + 1  # +3 for "../", +1 for the "/" after the repo name
 
     package_key = "{}@{}".format(package, version)
     package_store_name = utils.package_store_name(package_key)


### PR DESCRIPTION
`_symlink_package_store` strips `package_store_prefix_len` characters from a dependency's `package_store_directory.short_path` to form the relative symlink target. The length omitted the "/" separators that follow the package path and the repo name, so for a link target in a non-root package of an external repository it stripped two characters too few. The leftover was the trailing "s/" of ".aspect_rules_js/", producing dangling symlinks such as `../../s/<pkg>@<ver>/node_modules/<pkg>` and `ERR_MODULE_NOT_FOUND` at runtime.

In a root module the miscount is only one character and is masked by "//" path collapsing, so it surfaces only when a module's npm packages live in a sub-package (e.g. //frontend) and that module is consumed as an external dependency.

Account for both separators: +1 after the package path and +1 after the repo name.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
