### PR TITLE
feat(js_image_layer): add external compressor passthrough

### DIFF
--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -465,7 +465,10 @@ def _js_image_layer_impl(ctx):
         args.add("--create")
         args.add("--file")
         args.add(output)
-        tar_lib.common.add_compression_args(compress, args)
+        if ctx.executable.compressor:
+            args.add_joined("--use-compress-program", [ctx.executable.compressor.path, ctx.attr.compressor_args], join_with = " ")
+        else:
+            tar_lib.common.add_compression_args(compress, args)
         args.add(mtree, format = "@%s")
 
         ctx.actions.run(
@@ -475,6 +478,7 @@ def _js_image_layer_impl(ctx):
             ),
             arguments = [args],
             executable = tarinfo.binary,
+            tools = [ctx.executable.compressor] if ctx.executable.compressor else [],
             unused_inputs_list = unused_inputs,
             env = tarinfo.default_env,
             outputs = [output],
@@ -538,6 +542,14 @@ js_image_layer_lib = struct(
             doc = "Compression algorithm. See https://github.com/bazel-contrib/bazel-lib/blob/bdc6ade0ba1ebe88d822bcdf4d4aaa2ce7e2cd37/lib/private/tar.bzl#L29-L39",
             values = tar_lib.common.accepted_compression_types + ["none"],
             default = "gzip",
+        ),
+        "compressor": attr.label(
+            doc = "External tool which compresses each layer archive, e.g. `@pigz` for parallel gzip. Overrides bsdtar's built-in single-threaded compressor; `compression` still determines the output file extension.",
+            executable = True,
+            cfg = "exec",
+        ),
+        "compressor_args": attr.string(
+            doc = "Arg list for `compressor`.",
         ),
         "platform": attr.label(
             doc = "Platform to transition.",


### PR DESCRIPTION
Add `compressor`/`compressor_args` attributes to the `js_image_layer` rule, mirroring the `tar` rule from bazel-contrib/tar.bzl. When set, layers are compressed by an external program (e.g. `@pigz` for parallel gzip) via bsdtar's `--use-compress-program` instead of bsdtar's single-threaded built-in compressor.

`compression` still selects the output file extension; `compressor` only swaps the program. No behavior change unless `compressor` is set.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
