### PR TITLE
fix: resolve npm package store tar toolchain as a Label

### DIFF
--- a/e2e/repo_mapping/.bazelrc
+++ b/e2e/repo_mapping/.bazelrc
@@ -1,3 +1,5 @@
 import %workspace%/../../tools/preset.bazelrc
 import %workspace%/../e2e.bazelrc
 
+# Exercise action toolchain resolution when apparent repository names differ.
+common --incompatible_auto_exec_groups

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -260,7 +260,7 @@ def _npm_package_store_impl(ctx):
                     execution_requirements = {
                         "supports-path-mapping": "1",
                     },
-                    toolchain = tar_lib.toolchain_type,
+                    toolchain = Label("@tar.bzl//tar/toolchain:type"),
 
                     # Always override the locale to give better hermeticity.
                     # See https://github.com/aspect-build/rules_js/issues/2039


### PR DESCRIPTION
The --incompatible_auto_exec_groups flag requires Starlark actions to declare whether their executable/tools come from an action toolchain. This is not a Bazel default today, but it is exposed through strict preset configurations and is intended to catch rules that rely on implicit action toolchain inference.

npm_package_store already declares the tar toolchain, but the extraction action passes that action toolchain as a string. That string is resolved in the consuming repository's mapping, which can fail when @tar.bzl is not visible as an apparent repository name. Use a pre-resolved Label so the action's toolchain behavior is explicit without changing its inputs or execution model.

### Test plan

- Manual testing; please provide instructions so we can reproduce: Using this patch on rules_js in our repository with --incompatible_auto_exec_groups everything starts to work.