### PR TITLE
fix: node coverage

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -62,6 +62,7 @@ jobs:
                   paths=(
                     .
                     e2e/bzlmod
+                    e2e/coverage
                     e2e/gyp_no_install_script
                     e2e/js_binary_workspace
                     e2e/js_image_oci

--- a/e2e/coverage/.bazelrc
+++ b/e2e/coverage/.bazelrc
@@ -1,0 +1,2 @@
+import %workspace%/../../tools/preset.bazelrc
+import %workspace%/../e2e.bazelrc

--- a/e2e/coverage/.bazelversion
+++ b/e2e/coverage/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/coverage/BUILD.bazel
+++ b/e2e/coverage/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library", "js_test")
+
+js_library(
+    name = "lib",
+    srcs = ["lib.js"],
+)
+
+js_test(
+    name = "test",
+    data = [":lib"],
+    entry_point = "test.js",
+)

--- a/e2e/coverage/MODULE.bazel
+++ b/e2e/coverage/MODULE.bazel
@@ -1,0 +1,7 @@
+module(name = "e2e_coverage")
+
+bazel_dep(name = "aspect_rules_js", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "aspect_rules_js",
+    path = "../..",
+)

--- a/e2e/coverage/lib.js
+++ b/e2e/coverage/lib.js
@@ -1,0 +1,9 @@
+function covered() {
+    return 'covered'
+}
+
+function uncovered() {
+    return 'uncovered'
+}
+
+module.exports = { covered, uncovered }

--- a/e2e/coverage/test.js
+++ b/e2e/coverage/test.js
@@ -1,0 +1,4 @@
+const assert = require('node:assert')
+const lib = require('./lib.js')
+
+assert.strictEqual(lib.covered(), 'covered')

--- a/e2e/coverage/test.sh
+++ b/e2e/coverage/test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+# Regression test for https://github.com/aspect-build/rules_js/issues/2901:
+# `bazel coverage` produced empty (0%) lcov reports when the V8->lcov
+# conversion ran in the _lcov_merger action, which does not have the
+# instrumented sources. That happens when coverage postprocessing runs as its
+# own action (--experimental_split_coverage_postprocessing, remote execution).
+# The conversion now runs in the test action itself and the merger just
+# publishes the resulting report.
+
+coverage_dat="$(bazel info bazel-testlogs)/test/coverage.dat"
+
+assert_coverage() {
+    local mode="$1"
+
+    fail() {
+        echo "FAIL($mode): $1"
+        echo "--- $coverage_dat ---"
+        cat "$coverage_dat" 2>/dev/null || true
+        exit 1
+    }
+
+    [[ -s "$coverage_dat" ]] || fail "coverage.dat is missing or empty"
+
+    grep -q '^SF:lib.js$' "$coverage_dat" || fail "no coverage recorded for lib.js"
+
+    # The function exercised by the test must be recorded as hit ...
+    grep -q '^FNDA:1,covered$' "$coverage_dat" || fail "covered() not marked as executed"
+
+    # ... and the one that is not exercised must be recorded as a miss.
+    grep -q '^FNDA:0,uncovered$' "$coverage_dat" || fail "uncovered() not marked as unexecuted"
+
+    # At least one line must have a non-zero execution count.
+    grep -Eq '^DA:[0-9]+,[1-9]' "$coverage_dat" || fail "all line execution counts are zero"
+
+    echo "PASS($mode)"
+}
+
+# --nocache_test_results: the two invocations below differ only in coverage
+# postprocessing flags, which do not invalidate a cached test result — without
+# it the second run would just republish the first run's coverage.dat.
+
+# Default mode: the lcov merger runs inside the test action.
+bazel coverage --nocache_test_results //:test
+assert_coverage "inline-postprocessing"
+
+# Split mode: the lcov merger runs as its own action, without the test's
+# runfiles. This is the configuration from #2901 (also implied by remote
+# execution) that used to yield an empty report.
+bazel coverage --nocache_test_results \
+    --experimental_split_coverage_postprocessing \
+    --experimental_fetch_all_coverage_outputs \
+    //:test
+assert_coverage "split-postprocessing"

--- a/e2e/pnpm_repo_install/pnpm_patch_test.sh
+++ b/e2e/pnpm_repo_install/pnpm_patch_test.sh
@@ -3,14 +3,21 @@ set -o errexit -o nounset -o pipefail
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+    source "$0.runfiles/$f" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+    {
+        echo >&2 "ERROR: cannot find $f"
+        exit 1
+    }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 HELLO=$(rlocation "pnpm_patched/package/hello.txt")

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -2,6 +2,20 @@ import { Report } from 'c8'
 import fs from 'fs'
 import path from 'path'
 
+// The V8->lcov conversion needs the instrumented sources, which only exist in the
+// test action (not this _lcov_merger action). So the test action runs this script
+// with JS_COVERAGE__GENERATE_ONLY=1 and leaves the report in COVERAGE_DIR; here in
+// the merger we just publish it. See aspect-build/rules_js#2901.
+const jsCovStash = path.join(process.env.COVERAGE_DIR || '', '_rules_js_report.dat')
+if (!process.env.JS_COVERAGE__GENERATE_ONLY) {
+    try {
+        if (fs.statSync(jsCovStash).size != 0) {
+            fs.renameSync(jsCovStash, process.env.COVERAGE_OUTPUT_FILE)
+            process.exit(0)
+        }
+    } catch {}
+}
+
 // bazel will create the COVERAGE_OUTPUT_FILE whilst setting up the sandbox.
 // therefore, should be doing a file size check rather than presence.
 try {
@@ -40,9 +54,13 @@ new Report({
 })
     .run()
     .then(() => {
+        // In the test action, stash the report in COVERAGE_DIR for the merger to
+        // publish; the test action's COVERAGE_OUTPUT_FILE is not the final one.
         fs.renameSync(
             path.join(process.env.COVERAGE_DIR, 'lcov.info'),
-            process.env.COVERAGE_OUTPUT_FILE
+            process.env.JS_COVERAGE__GENERATE_ONLY
+                ? jsCovStash
+                : process.env.COVERAGE_OUTPUT_FILE
         )
     })
     .catch((err) => {

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16067,6 +16067,20 @@ function requireC8 () {
 
 var c8Exports = requireC8();
 
+// The V8->lcov conversion needs the instrumented sources, which only exist in the
+// test action (not this _lcov_merger action). So the test action runs this script
+// with JS_COVERAGE__GENERATE_ONLY=1 and leaves the report in COVERAGE_DIR; here in
+// the merger we just publish it. See aspect-build/rules_js#2901.
+const _jsCovStash = require$$0$2.join(process.env.COVERAGE_DIR || '', '_rules_js_report.dat');
+if (!process.env.JS_COVERAGE__GENERATE_ONLY) {
+    try {
+        if (require$$0$1.statSync(_jsCovStash).size != 0) {
+            require$$0$1.renameSync(_jsCovStash, process.env.COVERAGE_OUTPUT_FILE);
+            process.exit(0);
+        }
+    } catch {}
+}
+
 // bazel will create the COVERAGE_OUTPUT_FILE whilst setting up the sandbox.
 // therefore, should be doing a file size check rather than presence.
 try {
@@ -16105,9 +16119,12 @@ new c8Exports.Report({
 })
     .run()
     .then(() => {
+        const _lcov = require$$0$2.join(process.env.COVERAGE_DIR, 'lcov.info');
+        // In the test action, stash the report in COVERAGE_DIR for the merger to
+        // publish; the test action's COVERAGE_OUTPUT_FILE is not the final one.
         require$$0$1.renameSync(
-            require$$0$2.join(process.env.COVERAGE_DIR, 'lcov.info'),
-            process.env.COVERAGE_OUTPUT_FILE
+            _lcov,
+            process.env.JS_COVERAGE__GENERATE_ONLY ? _jsCovStash : process.env.COVERAGE_OUTPUT_FILE
         );
     })
     .catch((err) => {

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -482,6 +482,23 @@ RESULT="$?"
 set -e
 
 # ==============================================================================
+# Generate the lcov coverage report here in the test action, where the V8
+# coverage data (NODE_V8_COVERAGE) and the instrumented sources both exist and
+# their paths match. The _lcov_merger runs in a separate action that does not
+# have the sources, so running the c8 conversion there yields 0% (see #2901).
+# The merger early-exits when COVERAGE_OUTPUT_FILE is already non-empty, keeping
+# the report produced here.
+# ==============================================================================
+if [ "${COVERAGE_DIR:-}" ] && [ "${COVERAGE_OUTPUT_FILE:-}" ]; then
+    js_coverage_report=$(find "$JS_BINARY__RUNFILES" -path '*/js/private/coverage/coverage.js' 2>/dev/null | head -1)
+    if [ -n "${js_coverage_report:-}" ]; then
+        JS_COVERAGE__RUNFILES="$JS_BINARY__RUNFILES" JS_COVERAGE__GENERATE_ONLY=1 \
+            "$JS_BINARY__NODE_BINARY" "$js_coverage_report" ||
+            logf_error "coverage report generation failed"
+    fi
+fi
+
+# ==============================================================================
 # Mop up after main program
 # ==============================================================================
 


### PR DESCRIPTION
Fixes #2901: `bazel coverage` reported 0% (empty `coverage.dat`) for JS tests whenever coverage postprocessing ran as its own action (`--experimental_split_coverage_postprocessing`, which is typical with remote execution).

The V8 -> lcov conversion ran in the `_lcov_merger` action, whose runfiles contain only the merger and node, not the instrumented sources, so c8 emitted `LF:0` for every file. The conversion now runs at the end of the test action, where the V8 data and sources coexist; the report is stashed in `$COVERAGE_DIR` and the merger simply publishes it, falling back to the old behavior when no stash exists. Adding the sources to the merger action was considered instead, but the V8 URLs still point at the test's sandbox paths and would need fragile rewriting.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no docs cover the coverage merger; none needed
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

> fix: `bazel coverage` no longer reports 0% for JS tests when coverage postprocessing runs as a separate action (#2901)

### Test plan

- New test cases added: `e2e/coverage/test.sh` runs `bazel coverage` in both the default and split-postprocessing modes and asserts the lcov report attributes hits and misses to `lib.js`. Fails against pre-fix sources (`coverage.dat is missing or empty`), passes with the fix.


Disclaimer: This is my first contribution on this project. I've read the code of conduct and the contributing guidelines, but if I made a mistake in the creation of this PR, please let me know! I'm happy to change the target branch or anything else that is required.