### PR TITLE
perf: construct JsInfo directly in npm store and link rules

### DIFF
--- a/npm/private/npm_link_package_store.bzl
+++ b/npm/private/npm_link_package_store.bzl
@@ -1,6 +1,6 @@
 "npm_link_package_store rule"
 
-load("//js:providers.bzl", "JsInfo", "js_info")
+load("//js:providers.bzl", "JsInfo")
 load(":npm_package_store_info.bzl", "NpmPackageStoreInfo")
 load(":utils.bzl", "utils")
 
@@ -125,7 +125,7 @@ def _npm_link_package_store_impl(ctx):
             # of a generic binary target such as sh_binary
             runfiles = ctx.runfiles(transitive_files = transitive_files_depset).merge(ctx.attr.src[DefaultInfo].default_runfiles),
         ),
-        js_info(
+        JsInfo(
             target = ctx.label,
             sources = store_js_info.sources,
             transitive_sources = store_js_info.transitive_sources,

--- a/npm/private/npm_package_store.bzl
+++ b/npm/private/npm_package_store.bzl
@@ -5,7 +5,7 @@ load("@bazel_lib//lib:copy_directory.bzl", "copy_directory_bin_action")
 load("@tar.bzl//tar:tar.bzl", "tar_lib")
 
 # buildifier: disable=bzl-visibility
-load("//js/private:js_info.bzl", "JsInfo", "js_info")
+load("//js/private:js_info.bzl", "JsInfo")
 load(":npm_package_info.bzl", "NpmPackageInfo")
 load(":npm_package_store_info.bzl", "NpmPackageStoreInfo")
 load(":utils.bzl", "utils")
@@ -409,13 +409,14 @@ deps of npm_package_store must be in the same package.""" % (ctx.label.package, 
     files_depset = depset(files)
 
     providers = [
-        js_info(
+        JsInfo(
             target = ctx.label,
             npm_sources = npm_sources,
             sources = sources_depset,
             transitive_sources = sources_depset,
             types = types_depset,
             transitive_types = types_depset,
+            npm_package_store_infos = depset(),
         ),
         NpmPackageStoreInfo(
             key = package_key,


### PR DESCRIPTION
The js_info() factory type-checks every field on each call. These internal rules always pass depsets, so skip the validation on this hot path; the factory remains the API for external rule authors.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
