### PR TITLE
chore: upgrade aspect_tools_telemetry to 0.4.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
 bazel_dep(name = "tar.bzl", version = "0.10.4")
 bazel_dep(name = "yq.bzl", version = "0.3.4")
 bazel_dep(name = "jq.bzl", version = "0.4.0")
-bazel_dep(name = "aspect_tools_telemetry", version = "0.3.3")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.4.2")
 bazel_dep(name = "bazel_features", version = "1.41.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "1.0.0")


### PR DESCRIPTION
We did [the work](https://github.com/aspect-build/tools_telemetry/pull/25) to warn users before logging telemetry data but we haven't actually updated the MODULE to include that anywhere yet.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
