### PR TITLE
docs: correct broken anchor links in docstrings for Bazel registry docs

### DIFF
--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -81,7 +81,7 @@ def js_binary(**kwargs):
     * JS_BINARY__EXECROOT: the absolute path to the root of the execution root for the action; if in the sandbox, this path absolute path to the root of the execution root within the sandbox
 
     Args:
-        **kwargs: All attributes of the [js_binary](#js_binary) rule.
+        **kwargs: All attributes of the [js_binary](#function-js_binary) rule.
     """
 
     # Often a js_binary target will set "chdir = package_name()", and if it is
@@ -124,7 +124,7 @@ def js_test(**kwargs):
     the contract between Bazel and a test runner.
 
     Args:
-        **kwargs: All attributes of the [js_test](#js_test) rule.
+        **kwargs: All attributes of the [js_test](#function-js_test) rule.
     """
     if kwargs.get("chdir") == "":
         kwargs["chdir"] = "."

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -203,7 +203,7 @@ def npm_package(
     `node_modules` files from being included.
 
     To stamp the current git tag as the "version" in the package.json file, see
-    [stamped_package_json](#stamped_package_json)
+    [stamped_package_json](#function-stamped_package_json)
 
     Args:
         name: Unique name for this target.


### PR DESCRIPTION
## Summary
The Bazel registry (registry.bazel.build) renders function/macro definition anchors with a `function-` prefix (e.g. `id="function-js_binary"`), but the docstring links used bare names (e.g. `#js_binary`), causing the links to not navigate to the correct section.

- `#js_binary` -> `#function-js_binary` in `js_binary` macro docstring
- `#js_test` -> `#function-js_test` in `js_test` macro docstring
- `#stamped_package_json` -> `#function-stamped_package_json` in `npm_package` docstring

### Test plan
Manual testing:
1. Visit https://registry.bazel.build/docs/aspect_rules_js
2. Find the `js_binary` macro — click the link to "js_binary" in its kwargs description — currently doesn't navigate
3. Same for `js_test` and `stamped_package_json` links
4. After this fix, the links navigate to the correct sections