### PR TITLE
fix(node-patches): resolve readlink target against the real parent dir

### DIFF
--- a/js/private/node-patches/fs.cjs
+++ b/js/private/node-patches/fs.cjs
@@ -103,6 +103,10 @@ function patcher(roots) {
         .map((root) => {
         const lexical = path.resolve(root);
         let real = lexical;
+        // A configured root need not exist on disk when the patch is
+        // registered (or may be inaccessible); when it can't be realpath'd
+        // we keep real == lexical, i.e. treat the root as not-symlinked so
+        // the remapping below is a no-op.
         try {
             real = origRealpathSyncNative(lexical);
         }

--- a/js/private/node-patches/fs.cjs
+++ b/js/private/node-patches/fs.cjs
@@ -247,7 +247,18 @@ function patcher(roots) {
                 return cb(err);
             const resolved = resolvePathLike(args[0]);
             const linkTarget = p;
-            const targetAbs = path.resolve(path.dirname(resolved), linkTarget);
+            // Resolve the link target against the REAL location of the link's
+            // parent directory. `resolved` may itself traverse symlinks (e.g. an
+            // aliased node_modules path of a different depth than the real dir);
+            // joining a relative target onto the lexical parent then lands at the
+            // wrong absolute path. Falls back to the old behavior if the parent
+            // cannot be realpath'd (identity transform when already resolved).
+            let linkDir = path.dirname(resolved);
+            try {
+                linkDir = origRealpathSyncNative(linkDir);
+            }
+            catch (_a) { }
+            const targetAbs = path.resolve(linkDir, linkTarget);
             const escapedRoot = isEscape(resolved, targetAbs);
             if (escapedRoot) {
                 const escapedRoots = [escapedRoot];
@@ -284,7 +295,14 @@ function patcher(roots) {
     fs.readlinkSync = function readlinkSync(...args) {
         const resolved = resolvePathLike(args[0]);
         const linkTarget = origReadlinkSync(...args);
-        const targetAbs = path.resolve(path.dirname(resolved), linkTarget);
+        // Resolve the link target against the REAL location of the link's parent
+        // directory (see fs.readlink above for the rationale).
+        let linkDir = path.dirname(resolved);
+        try {
+            linkDir = origRealpathSyncNative(linkDir);
+        }
+        catch (_a) { }
+        const targetAbs = path.resolve(linkDir, linkTarget);
         const escapedRoot = isEscape(resolved, targetAbs);
         if (escapedRoot) {
             const next = nextHopSync(targetAbs);

--- a/js/private/node-patches/fs.cjs
+++ b/js/private/node-patches/fs.cjs
@@ -122,6 +122,16 @@ function patcher(roots) {
         }
         return real;
     }
+    // Resolve a relative symlink `linkTarget` against the REAL location of the
+    // link's parent directory. `resolved` is an absolute path whose final
+    // component is a symlink we just read successfully, but the path we were
+    // queried through may be an alias of a different depth than the real dir
+    // (e.g. a pnpm/node_modules alias); joining `linkTarget` onto the *lexical*
+    // parent would then land at the wrong absolute path.
+    function resolveTargetAgainstRealParent(resolved, linkTarget) {
+        const linkDir = realpathInRootNamespace(path.dirname(resolved));
+        return path.resolve(linkDir, linkTarget);
+    }
     // =========================================================================
     // fs.lstat
     // =========================================================================
@@ -270,18 +280,7 @@ function patcher(roots) {
                 return cb(err);
             const resolved = resolvePathLike(args[0]);
             const linkTarget = p;
-            // Resolve the link target against the REAL location of the link's
-            // parent directory. `resolved` may itself traverse symlinks (e.g. an
-            // aliased node_modules path of a different depth than the real dir);
-            // joining a relative target onto the lexical parent then lands at the
-            // wrong absolute path. Falls back to the old behavior if the parent
-            // cannot be realpath'd (identity transform when already resolved).
-            let linkDir = path.dirname(resolved);
-            try {
-                linkDir = realpathInRootNamespace(linkDir);
-            }
-            catch (_a) { }
-            const targetAbs = path.resolve(linkDir, linkTarget);
+            const targetAbs = resolveTargetAgainstRealParent(resolved, linkTarget);
             const escapedRoot = isEscape(resolved, targetAbs);
             if (escapedRoot) {
                 const escapedRoots = [escapedRoot];
@@ -318,14 +317,7 @@ function patcher(roots) {
     fs.readlinkSync = function readlinkSync(...args) {
         const resolved = resolvePathLike(args[0]);
         const linkTarget = origReadlinkSync(...args);
-        // Resolve the link target against the REAL location of the link's parent
-        // directory (see fs.readlink above for the rationale).
-        let linkDir = path.dirname(resolved);
-        try {
-            linkDir = realpathInRootNamespace(linkDir);
-        }
-        catch (_a) { }
-        const targetAbs = path.resolve(linkDir, linkTarget);
+        const targetAbs = resolveTargetAgainstRealParent(resolved, linkTarget);
         const escapedRoot = isEscape(resolved, targetAbs);
         if (escapedRoot) {
             const next = nextHopSync(targetAbs);

--- a/js/private/node-patches/fs.cjs
+++ b/js/private/node-patches/fs.cjs
@@ -99,6 +99,29 @@ function patcher(roots) {
     const origRealpathSyncNative = fs.realpathSync
         .native;
     const { canEscape, isEscape } = escapeFunction(roots);
+    const rootMappings = roots
+        .map((root) => {
+        const lexical = path.resolve(root);
+        let real = lexical;
+        try {
+            real = origRealpathSyncNative(lexical);
+        }
+        catch (_a) { }
+        return { lexical, real };
+    })
+        .sort((a, b) => b.lexical.length - a.lexical.length);
+    // Keep real paths in the lexical namespace when the configured root is
+    // itself a symlink. Nested links that leave the root remain canonical.
+    function realpathInRootNamespace(p) {
+        const real = origRealpathSyncNative(p);
+        for (const root of rootMappings) {
+            if (isSubPath(root.lexical, p) &&
+                isSubPath(root.real, real)) {
+                return path.resolve(root.lexical, path.relative(root.real, real));
+            }
+        }
+        return real;
+    }
     // =========================================================================
     // fs.lstat
     // =========================================================================
@@ -255,7 +278,7 @@ function patcher(roots) {
             // cannot be realpath'd (identity transform when already resolved).
             let linkDir = path.dirname(resolved);
             try {
-                linkDir = origRealpathSyncNative(linkDir);
+                linkDir = realpathInRootNamespace(linkDir);
             }
             catch (_a) { }
             const targetAbs = path.resolve(linkDir, linkTarget);
@@ -299,7 +322,7 @@ function patcher(roots) {
         // directory (see fs.readlink above for the rationale).
         let linkDir = path.dirname(resolved);
         try {
-            linkDir = origRealpathSyncNative(linkDir);
+            linkDir = realpathInRootNamespace(linkDir);
         }
         catch (_a) { }
         const targetAbs = path.resolve(linkDir, linkTarget);

--- a/js/private/node-patches/src/fs.cts
+++ b/js/private/node-patches/src/fs.cts
@@ -111,6 +111,10 @@ export function patcher(roots: string[]): () => void {
         .map((root) => {
             const lexical = path.resolve(root)
             let real = lexical
+            // A configured root need not exist on disk when the patch is
+            // registered (or may be inaccessible); when it can't be realpath'd
+            // we keep real == lexical, i.e. treat the root as not-symlinked so
+            // the remapping below is a no-op.
             try {
                 real = origRealpathSyncNative(lexical) as string
             } catch {}

--- a/js/private/node-patches/src/fs.cts
+++ b/js/private/node-patches/src/fs.cts
@@ -107,6 +107,34 @@ export function patcher(roots: string[]): () => void {
         .native as typeof FsType.realpathSync.native
 
     const { canEscape, isEscape } = escapeFunction(roots)
+    const rootMappings = roots
+        .map((root) => {
+            const lexical = path.resolve(root)
+            let real = lexical
+            try {
+                real = origRealpathSyncNative(lexical) as string
+            } catch {}
+            return { lexical, real }
+        })
+        .sort((a, b) => b.lexical.length - a.lexical.length)
+
+    // Keep real paths in the lexical namespace when the configured root is
+    // itself a symlink. Nested links that leave the root remain canonical.
+    function realpathInRootNamespace(p: string): string {
+        const real = origRealpathSyncNative(p) as string
+        for (const root of rootMappings) {
+            if (
+                isSubPath(root.lexical, p) &&
+                isSubPath(root.real, real)
+            ) {
+                return path.resolve(
+                    root.lexical,
+                    path.relative(root.real, real)
+                )
+            }
+        }
+        return real
+    }
 
     // =========================================================================
     // fs.lstat
@@ -310,7 +338,7 @@ export function patcher(roots: string[]): () => void {
             // cannot be realpath'd (identity transform when already resolved).
             let linkDir = path.dirname(resolved)
             try {
-                linkDir = origRealpathSyncNative(linkDir) as string
+                linkDir = realpathInRootNamespace(linkDir)
             } catch {}
             const targetAbs = path.resolve(linkDir, linkTarget)
             const escapedRoot: string | false = isEscape(resolved, targetAbs)
@@ -359,7 +387,7 @@ export function patcher(roots: string[]): () => void {
         // directory (see fs.readlink above for the rationale).
         let linkDir = path.dirname(resolved)
         try {
-            linkDir = origRealpathSyncNative(linkDir) as string
+            linkDir = realpathInRootNamespace(linkDir)
         } catch {}
         const targetAbs = path.resolve(linkDir, linkTarget)
 

--- a/js/private/node-patches/src/fs.cts
+++ b/js/private/node-patches/src/fs.cts
@@ -302,7 +302,17 @@ export function patcher(roots: string[]): () => void {
             if (err) return cb(err)
             const resolved = resolvePathLike(args[0])
             const linkTarget = p!
-            const targetAbs = path.resolve(path.dirname(resolved), linkTarget)
+            // Resolve the link target against the REAL location of the link's
+            // parent directory. `resolved` may itself traverse symlinks (e.g. an
+            // aliased node_modules path of a different depth than the real dir);
+            // joining a relative target onto the lexical parent then lands at the
+            // wrong absolute path. Falls back to the old behavior if the parent
+            // cannot be realpath'd (identity transform when already resolved).
+            let linkDir = path.dirname(resolved)
+            try {
+                linkDir = origRealpathSyncNative(linkDir) as string
+            } catch {}
+            const targetAbs = path.resolve(linkDir, linkTarget)
             const escapedRoot: string | false = isEscape(resolved, targetAbs)
             if (escapedRoot) {
                 const escapedRoots = [escapedRoot]
@@ -345,7 +355,13 @@ export function patcher(roots: string[]): () => void {
     ) {
         const resolved = resolvePathLike(args[0])
         const linkTarget = origReadlinkSync(...args)
-        const targetAbs = path.resolve(path.dirname(resolved), linkTarget)
+        // Resolve the link target against the REAL location of the link's parent
+        // directory (see fs.readlink above for the rationale).
+        let linkDir = path.dirname(resolved)
+        try {
+            linkDir = origRealpathSyncNative(linkDir) as string
+        } catch {}
+        const targetAbs = path.resolve(linkDir, linkTarget)
 
         const escapedRoot: string | false = isEscape(resolved, targetAbs)
         if (escapedRoot) {

--- a/js/private/node-patches/src/fs.cts
+++ b/js/private/node-patches/src/fs.cts
@@ -136,6 +136,20 @@ export function patcher(roots: string[]): () => void {
         return real
     }
 
+    // Resolve a relative symlink `linkTarget` against the REAL location of the
+    // link's parent directory. `resolved` is an absolute path whose final
+    // component is a symlink we just read successfully, but the path we were
+    // queried through may be an alias of a different depth than the real dir
+    // (e.g. a pnpm/node_modules alias); joining `linkTarget` onto the *lexical*
+    // parent would then land at the wrong absolute path.
+    function resolveTargetAgainstRealParent(
+        resolved: string,
+        linkTarget: string
+    ): string {
+        const linkDir = realpathInRootNamespace(path.dirname(resolved))
+        return path.resolve(linkDir, linkTarget)
+    }
+
     // =========================================================================
     // fs.lstat
     // =========================================================================
@@ -330,17 +344,10 @@ export function patcher(roots: string[]): () => void {
             if (err) return cb(err)
             const resolved = resolvePathLike(args[0])
             const linkTarget = p!
-            // Resolve the link target against the REAL location of the link's
-            // parent directory. `resolved` may itself traverse symlinks (e.g. an
-            // aliased node_modules path of a different depth than the real dir);
-            // joining a relative target onto the lexical parent then lands at the
-            // wrong absolute path. Falls back to the old behavior if the parent
-            // cannot be realpath'd (identity transform when already resolved).
-            let linkDir = path.dirname(resolved)
-            try {
-                linkDir = realpathInRootNamespace(linkDir)
-            } catch {}
-            const targetAbs = path.resolve(linkDir, linkTarget)
+            const targetAbs = resolveTargetAgainstRealParent(
+                resolved,
+                linkTarget
+            )
             const escapedRoot: string | false = isEscape(resolved, targetAbs)
             if (escapedRoot) {
                 const escapedRoots = [escapedRoot]
@@ -383,13 +390,7 @@ export function patcher(roots: string[]): () => void {
     ) {
         const resolved = resolvePathLike(args[0])
         const linkTarget = origReadlinkSync(...args)
-        // Resolve the link target against the REAL location of the link's parent
-        // directory (see fs.readlink above for the rationale).
-        let linkDir = path.dirname(resolved)
-        try {
-            linkDir = realpathInRootNamespace(linkDir)
-        } catch {}
-        const targetAbs = path.resolve(linkDir, linkTarget)
+        const targetAbs = resolveTargetAgainstRealParent(resolved, linkTarget)
 
         const escapedRoot: string | false = isEscape(resolved, targetAbs)
         if (escapedRoot) {

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-d593b54327e834bc737c57553f55c5f1e25370850ad0e9b594804acfd7957b98  js/private/test/image/cksum_node.tar
+03e50f6824205d5c7d2362e267e62047a4379b24dac3689104b20339732c6f81  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 b28409f66a999e8763c603645eb477942ae9b4f6fcb7ce75b104d7a66281ec6f  js/private/test/image/cksum_package_store_1p.tar
 812caba3b24b89e5390a2a20791a90aa87cb8aba3584a018c53b54859a38ef1d  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-f456e5b60a3a53b566a44a52277d5b148aa85954187406581a8935d7f0db09e1  js/private/test/image/cksum_node.tar
+9d11f575b6217b8f310772a693263d24fd56e6c0d4d98792f4fc84e8ceeec307  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 b28409f66a999e8763c603645eb477942ae9b4f6fcb7ce75b104d7a66281ec6f  js/private/test/image/cksum_package_store_1p.tar
 812caba3b24b89e5390a2a20791a90aa87cb8aba3584a018c53b54859a38ef1d  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-03e50f6824205d5c7d2362e267e62047a4379b24dac3689104b20339732c6f81  js/private/test/image/cksum_node.tar
+82bbebac3082e8752d537a6984c36a0cde2b1fb76208f4f04ea91096d4d61afd  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 b28409f66a999e8763c603645eb477942ae9b4f6fcb7ce75b104d7a66281ec6f  js/private/test/image/cksum_package_store_1p.tar
 812caba3b24b89e5390a2a20791a90aa87cb8aba3584a018c53b54859a38ef1d  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-82bbebac3082e8752d537a6984c36a0cde2b1fb76208f4f04ea91096d4d61afd  js/private/test/image/cksum_node.tar
+f456e5b60a3a53b566a44a52277d5b148aa85954187406581a8935d7f0db09e1  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 b28409f66a999e8763c603645eb477942ae9b4f6fcb7ce75b104d7a66281ec6f  js/private/test/image/cksum_package_store_1p.tar
 812caba3b24b89e5390a2a20791a90aa87cb8aba3584a018c53b54859a38ef1d  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37118 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       35357 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 100    0       35357 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 100    0       36276 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 100    0        1460 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 100    0       37119 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 100    0       36853 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 100    0        1460 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 100    0       36853 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 100    0       37118 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 100    0        1460 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 100    0       36276 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 100    0       37119 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 100    0        1460 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37118 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       35357 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_just_the_fs_patch.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_just_the_fs_patch.listing
@@ -9,4 +9,4 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/fs.cjs

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_just_the_fs_patch.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_just_the_fs_patch.listing
@@ -9,4 +9,4 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37118 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/fs.cjs

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_just_the_fs_patch.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_just_the_fs_patch.listing
@@ -9,4 +9,4 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       35357 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/fs.cjs

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_just_the_fs_patch.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_just_the_fs_patch.listing
@@ -9,4 +9,4 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-patches/fs.cjs

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       35357 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37118 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37118 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36853 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       35357 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/
--r-xr-xr-x  0 0      0       36276 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
+-r-xr-xr-x  0 0      0       37119 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/fs.cjs
 -r-xr-xr-x  0 0      0        1460 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-patches/register.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/node-patches/readlink.mjs
+++ b/js/private/test/node-patches/readlink.mjs
@@ -124,6 +124,67 @@ describe('testing readlink', async () => {
         )
     })
 
+    await it('resolves relative targets from the real parent of an aliased path', async () => {
+        await withFixtures(
+            {
+                execroot: { package: {} },
+                real: { file: 'contents' },
+                sandbox: { aliases: { real: {} } },
+            },
+            async (fixturesDir) => {
+                fixturesDir = fs.realpathSync(fixturesDir)
+                const execrootDir = path.join(fixturesDir, 'execroot')
+                const realFile = path.join(fixturesDir, 'real', 'file')
+                const sandboxDir = path.join(fixturesDir, 'sandbox')
+                const aliasDir = path.join(sandboxDir, 'aliases', 'package')
+
+                // The queried parent has one more path segment than its real
+                // location, so resolving ../target from the lexical parent
+                // incorrectly lands at sandbox/aliases/target.
+                fs.symlinkSync(
+                    path.join(execrootDir, 'package'),
+                    aliasDir,
+                    process.platform === 'win32' ? 'junction' : 'dir'
+                )
+                fs.symlinkSync(
+                    path.join('..', 'target'),
+                    path.join(execrootDir, 'package', 'link')
+                )
+                fs.symlinkSync(realFile, path.join(execrootDir, 'target'))
+                fs.symlinkSync(
+                    realFile,
+                    path.join(sandboxDir, 'aliases', 'real', 'file')
+                )
+
+                const revertPatches = patcher([sandboxDir])
+                const linkPath = path.join(aliasDir, 'link')
+                const expectedTarget = path.join('..', 'real', 'file')
+
+                try {
+                    assert.deepStrictEqual(
+                        fs.readlinkSync(linkPath),
+                        expectedTarget,
+                        'SYNC: should resolve from the real parent directory'
+                    )
+
+                    assert.deepStrictEqual(
+                        await util.promisify(fs.readlink)(linkPath),
+                        expectedTarget,
+                        'CB: should resolve from the real parent directory'
+                    )
+
+                    assert.deepStrictEqual(
+                        await fs.promises.readlink(linkPath),
+                        expectedTarget,
+                        'Promise: should resolve from the real parent directory'
+                    )
+                } finally {
+                    revertPatches()
+                }
+            }
+        )
+    })
+
     await it("doesn't resolve as symlink outside of root", async () => {
         await withFixtures(
             {

--- a/js/private/test/node-patches/readlink.mjs
+++ b/js/private/test/node-patches/readlink.mjs
@@ -124,6 +124,58 @@ describe('testing readlink', async () => {
         )
     })
 
+    await it('preserves relative targets when the root is a symlink', async () => {
+        await withFixtures(
+            {
+                realroot: {
+                    a: {},
+                    b: { file: 'contents' },
+                },
+            },
+            async (fixturesDir) => {
+                fixturesDir = fs.realpathSync(fixturesDir)
+                const realRoot = path.join(fixturesDir, 'realroot')
+                const rootLink = path.join(fixturesDir, 'rootlink')
+                const relativeTarget = path.join('..', 'b', 'file')
+
+                fs.symlinkSync(
+                    realRoot,
+                    rootLink,
+                    process.platform === 'win32' ? 'junction' : 'dir'
+                )
+                fs.symlinkSync(
+                    relativeTarget,
+                    path.join(realRoot, 'a', 'link')
+                )
+
+                const revertPatches = patcher([rootLink])
+                const linkPath = path.join(rootLink, 'a', 'link')
+
+                try {
+                    assert.deepStrictEqual(
+                        fs.readlinkSync(linkPath),
+                        relativeTarget,
+                        'SYNC: should preserve target within a symlinked root'
+                    )
+
+                    assert.deepStrictEqual(
+                        await util.promisify(fs.readlink)(linkPath),
+                        relativeTarget,
+                        'CB: should preserve target within a symlinked root'
+                    )
+
+                    assert.deepStrictEqual(
+                        await fs.promises.readlink(linkPath),
+                        relativeTarget,
+                        'Promise: should preserve target within a symlinked root'
+                    )
+                } finally {
+                    revertPatches()
+                }
+            }
+        )
+    })
+
     await it('resolves relative targets from the real parent of an aliased path', async () => {
         await withFixtures(
             {


### PR DESCRIPTION
Fixes #2914

## Problem

`fs.readlink` / `fs.readlinkSync` in the node-patches compute the target's absolute path by joining the raw kernel link target onto the **lexical** parent of the *queried* path:

```js
const targetAbs = path.resolve(path.dirname(resolved), linkTarget)
```

`path.dirname(resolved)` is the parent of the path *as the caller wrote it*, which may itself traverse symlinks. When the caller reaches the link through symlinks whose resolution changes directory depth (e.g. an aliased `node_modules` path that is a different number of segments deep than the link's real location), a relative (`../…`) target is counted from the wrong base. The resulting absolute path lands one or more levels off — but still *inside* the guard root, so `isEscape` doesn't flag it and the bogus path is handed to the caller.

Any tool that resolves modules via `readlink` then stats a nonexistent path and fails with `ENOENT`. We hit this with ESLint's `import/namespace` rule (via `eslint-import-resolver-typescript` → `enhanced-resolve`) resolving a first-party package reached through a package-store alias one segment shallower than its real `bazel-out` dir.

## Fix

Resolve the link's parent to its **real** path before joining the target (`origRealpathSyncNative`, with a try/catch fallback to the previous behavior). This is an identity transform whenever the queried path is already fully resolved, so it only changes results that were previously wrong. Applied to both the async `readlink` callback and `readlinkSync`; regenerated the checked-in `fs.cjs` from `src/fs.cts` via the `write_source_files` target.

## Testing

- Existing `//js/private/test/node-patches:readlink_*` targets pass on node 20/22/24 (cjs + esm) — no regression.
- Verified end-to-end in a downstream monorepo: the fix resolves an `ENOENT` in an `eslint_test` that was resolving `@scope/base` through `@scope/web`'s store copy.

Isolated repro (no Bazel): load `js/private/node-patches/register.cjs` with `JS_BINARY__FS_PATCH_ROOTS` set, then `fs.readlinkSync()` a symlink reached through a parent symlink of a different depth — the returned absolute path is wrong before this change, correct after.

Happy to add a dedicated regression test to `readlink.mjs` if you'd like to guide the fixture shape (the observable difference is in the escape/`nextHop` mapping, so it needs a sandbox-style fixture with a depth-mismatched alias).

Co-Authored-By: Claude Code