### PR TITLE
fix: detect execroot when output_base path contains a bazel-out segment

### DIFF
--- a/e2e/js_binary_workspace/.bazelignore
+++ b/e2e/js_binary_workspace/.bazelignore
@@ -1,1 +1,2 @@
 workspace/
+.e2e_output_base/

--- a/e2e/js_binary_workspace/.bazelrc
+++ b/e2e/js_binary_workspace/.bazelrc
@@ -1,2 +1,6 @@
 import %workspace%/../../tools/preset.bazelrc
 import %workspace%/../e2e.bazelrc
+
+# Regression test for #2919: exercise execroot detection when the output base path contains a
+# "bazel-out" segment (nested so it does not clash with the bazel-out convenience symlink).
+startup --output_base=.e2e_output_base/bazel-out/base

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -173,9 +173,10 @@ elif [[ "$PWD" == *"/bazel-~1/"* ]]; then
     bazel_out_segment="/bazel-~1/"
 fi
 
-# BAZEL_BINDIR is only set for build actions, which run from the execroot; only scan $PWD to find
-# the execroot in the runfiles case (BAZEL_BINDIR unset), never when it is already the execroot.
-if [[ -z "${BAZEL_BINDIR:-}" && "${bazel_out_segment:-}" ]]; then
+# When $PWD is a build action execroot the bindir hangs off it (BAZEL_BINDIR resolves from $PWD), so
+# $PWD is the execroot even if its path contains a "bazel-out" segment (e.g. a matching output base).
+# Otherwise scan the output tree for the execroot (runfiles, or a nested js_binary in the bindir).
+if [[ "${bazel_out_segment:-}" && ( -z "${BAZEL_BINDIR:-}" || ! -d "$PWD/$BAZEL_BINDIR" ) ]]; then
     if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
         logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
     else

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -173,12 +173,14 @@ elif [[ "$PWD" == *"/bazel-~1/"* ]]; then
     bazel_out_segment="/bazel-~1/"
 fi
 
-if [[ "${bazel_out_segment:-}" ]]; then
+# BAZEL_BINDIR is only set for build actions, which run from the execroot; only scan $PWD to find
+# the execroot in the runfiles case (BAZEL_BINDIR unset), never when it is already the execroot.
+if [[ -z "${BAZEL_BINDIR:-}" && "${bazel_out_segment:-}" ]]; then
     if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
         logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
     else
-        # We in runfiles and we don't yet know the execroot
-        rest="${PWD#*"$bazel_out_segment"}"
+        # We in runfiles and we don't yet know the execroot; strip from the last "bazel-out" segment
+        rest="${PWD##*"$bazel_out_segment"}"
         index=$((${#PWD} - ${#rest} - ${#bazel_out_segment}))
         if [ ${index} -lt 0 ]; then
             printf "\nERROR: %s: No 'bazel-out' folder found in path '${PWD}'\n" "$JS_BINARY__LOG_PREFIX" >&2

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -293,9 +293,10 @@ elif [[ "$PWD" == *"/bazel-~1/"* ]]; then
     bazel_out_segment="/bazel-~1/"
 fi
 
-# BAZEL_BINDIR is only set for build actions, which run from the execroot; only scan $PWD to find
-# the execroot in the runfiles case (BAZEL_BINDIR unset), never when it is already the execroot.
-if [[ -z "${BAZEL_BINDIR:-}" && "${bazel_out_segment:-}" ]]; then
+# When $PWD is a build action execroot the bindir hangs off it (BAZEL_BINDIR resolves from $PWD), so
+# $PWD is the execroot even if its path contains a "bazel-out" segment (e.g. a matching output base).
+# Otherwise scan the output tree for the execroot (runfiles, or a nested js_binary in the bindir).
+if [[ "${bazel_out_segment:-}" && ( -z "${BAZEL_BINDIR:-}" || ! -d "$PWD/$BAZEL_BINDIR" ) ]]; then
     if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
         logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
     else

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -293,12 +293,14 @@ elif [[ "$PWD" == *"/bazel-~1/"* ]]; then
     bazel_out_segment="/bazel-~1/"
 fi
 
-if [[ "${bazel_out_segment:-}" ]]; then
+# BAZEL_BINDIR is only set for build actions, which run from the execroot; only scan $PWD to find
+# the execroot in the runfiles case (BAZEL_BINDIR unset), never when it is already the execroot.
+if [[ -z "${BAZEL_BINDIR:-}" && "${bazel_out_segment:-}" ]]; then
     if [ "${JS_BINARY__USE_EXECROOT_ENTRY_POINT:-}" ] && [ "${JS_BINARY__EXECROOT:-}" ]; then
         logf_debug "inheriting JS_BINARY__EXECROOT %s from parent js_binary process as JS_BINARY__USE_EXECROOT_ENTRY_POINT is set" "$JS_BINARY__EXECROOT"
     else
-        # We in runfiles and we don't yet know the execroot
-        rest="${PWD#*"$bazel_out_segment"}"
+        # We in runfiles and we don't yet know the execroot; strip from the last "bazel-out" segment
+        rest="${PWD##*"$bazel_out_segment"}"
         index=$((${#PWD} - ${#rest} - ${#bazel_out_segment}))
         if [ ${index} -lt 0 ]; then
             printf "\nERROR: %s: No 'bazel-out' folder found in path '${PWD}'\n" "$JS_BINARY__LOG_PREFIX" >&2


### PR DESCRIPTION
The `js_binary` launcher infers the Bazel execroot by scanning `$PWD` for the substring `/bazel-out/`. If `--output_base` (or any ancestor directory) is named `bazel-out`, that substring matches the output-base directory instead of the real output tree, so the launcher computes the execroot too shallow. For a `js_binary` used as the tool of a `js_run_binary` this fails with `entry_point '<...>' not found`, and because the wrong branch also skips `cd "$BAZEL_BINDIR"`, tools that rely on being in `$(BINDIR)` then fail to read their inputs.

Detect a fresh build-action execroot structurally instead: `$PWD` is the execroot when the bindir hangs off it (`-d "$PWD/$BAZEL_BINDIR"`), even when its path contains a `bazel-out` segment. Otherwise scan the output tree for the execroot — the runfiles case (e.g. `js_test`), or a nested `js_binary` whose parent already `cd`'d into the bindir. A nested child inherits `BAZEL_BINDIR` but runs from the bindir, so keying off `BAZEL_BINDIR` alone is not enough; the directory check distinguishes the two. The runfiles scan also strips from the last `bazel-out` segment rather than the first, so a `bazel-out` component in the output base is not mistaken for the output tree. None of this changes behavior under the default output base.

Reproduce with any `js_run_binary` and an output base whose path contains a `bazel-out` segment:

```sh
bazel --output_base=/tmp/demo/bazel-out build //path/to:some_js_run_binary_target
```

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (no docs describe this behavior)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fix `js_binary`/`js_run_binary` failing to find the entry point when `--output_base` points at a path containing a `bazel-out` segment.

### Test plan

- Covered by existing test cases (launcher snapshot, `js_binary_sh`, `js_test` toolchain tests, and nested-execution coverage in `examples/runfiles`)
- New e2e case: `e2e/js_binary_workspace` now runs under an output base whose path contains a `bazel-out` segment (via a relative `--output_base` in its `.bazelrc`), reproducing the bug without the fix
