### PR TITLE
feat: use bazel-lib run_binary's native stdout/stderr/exit_code_out/s…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,10 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Changes ensured by rules_js:
 # 3.2.2: https://github.com/bazel-contrib/bazel-lib/commit/cac2d7855949d1b222fa26888892fbbe1d31015d
-bazel_dep(name = "bazel_lib", version = "3.2.2")
+# 3.5.0: run_binary gained native stdout/stderr/exit_code_out/silent_on_success/fail_on support
+# (via the spawn_binary toolchain), which js_run_binary now uses directly instead of
+# reimplementing capture in the js_binary launcher script.
+bazel_dep(name = "bazel_lib", version = "3.5.0")
 
 # NB: LOWER BOUND on earliest BCR release of protobuf module, to avoid upgrading the root module by accident
 bazel_dep(name = "protobuf", version = "3.19.6")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,9 +19,9 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Changes ensured by rules_js:
 # 3.2.2: https://github.com/bazel-contrib/bazel-lib/commit/cac2d7855949d1b222fa26888892fbbe1d31015d
-# 3.5.0: run_binary gained native stdout/stderr/exit_code_out/silent_on_success/fail_on support
-# (via the spawn_binary toolchain), which js_run_binary now uses directly instead of
-# reimplementing capture in the js_binary launcher script.
+# 3.5.0: run_binary gained native stdout/stderr/exit_code_out/silent_on_success
+# support, which js_run_binary now uses directly instead of reimplementing
+# capture in the js_binary launcher script.
 bazel_dep(name = "bazel_lib", version = "3.5.0")
 
 # NB: LOWER BOUND on earliest BCR release of protobuf module, to avoid upgrading the root module by accident

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -15,82 +15,49 @@ set -o pipefail -o errexit -o nounset
 {{envs}}
 
 # ==============================================================================
-# Prepare stdout capture, stderr capture && logging
+# Logging
 # ==============================================================================
-
-if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ] || [ "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
-    STDOUT_CAPTURE=$(mktemp)
-fi
-
-if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ] || [ "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
-    STDERR_CAPTURE=$(mktemp)
-fi
 
 export JS_BINARY__LOG_PREFIX="{{log_prefix_rule_set}}[{{log_prefix_rule}}]"
 
 function logf_stderr {
     local format_string="$1\n"
     shift
-    if [ "${STDERR_CAPTURE:-}" ]; then
-        # shellcheck disable=SC2059,SC2046
-        echo -e $(printf "$format_string" "$@") >>"$STDERR_CAPTURE"
-    else
-        # shellcheck disable=SC2059,SC2046
-        echo -e $(printf "$format_string" "$@") >&2
-    fi
+    # shellcheck disable=SC2059,SC2046
+    echo -e $(printf "$format_string" "$@") >&2
 }
 
 function logf_fatal {
     if [ "${JS_BINARY__LOG_FATAL:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
 
 function logf_error {
     if [ "${JS_BINARY__LOG_ERROR:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
 
 function logf_warn {
     if [ "${JS_BINARY__LOG_WARN:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "WARN: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "WARN: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "WARN: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
 
 function logf_info {
     if [ "${JS_BINARY__LOG_INFO:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
 
 function logf_debug {
     if [ "${JS_BINARY__LOG_DEBUG:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
@@ -116,26 +83,6 @@ function resolve_execroot_src_path {
 _exit() {
     EXIT_CODE=$?
 
-    if [ "${STDERR_CAPTURE:-}" ]; then
-        if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ]; then
-            cp -f "$STDERR_CAPTURE" "$JS_BINARY__STDERR_OUTPUT_FILE"
-        fi
-        if [ "$EXIT_CODE" != 0 ] || [ -z "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
-            cat "$STDERR_CAPTURE" >&2
-        fi
-        rm "$STDERR_CAPTURE"
-    fi
-
-    if [ "${STDOUT_CAPTURE:-}" ]; then
-        if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
-            cp -f "$STDOUT_CAPTURE" "$JS_BINARY__STDOUT_OUTPUT_FILE"
-        fi
-        if [ "$EXIT_CODE" != 0 ] || [ -z "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
-            cat "$STDOUT_CAPTURE"
-        fi
-        rm "$STDOUT_CAPTURE"
-    fi
-
     logf_debug "exit code: %s" "$EXIT_CODE"
 
     exit $EXIT_CODE
@@ -153,17 +100,6 @@ export JS_BINARY__RUNFILES
 # ==============================================================================
 # Prepare to run main program
 # ==============================================================================
-
-# Convert stdout, stderr and exit_code capture outputs paths to absolute paths
-if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
-    JS_BINARY__STDOUT_OUTPUT_FILE="$PWD/$JS_BINARY__STDOUT_OUTPUT_FILE"
-fi
-if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ]; then
-    JS_BINARY__STDERR_OUTPUT_FILE="$PWD/$JS_BINARY__STDERR_OUTPUT_FILE"
-fi
-if [ "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ]; then
-    JS_BINARY__EXIT_CODE_OUTPUT_FILE="$PWD/$JS_BINARY__EXIT_CODE_OUTPUT_FILE"
-fi
 
 if [[ "$PWD" == *"/bazel-out/"* ]]; then
     bazel_out_segment="/bazel-out/"
@@ -443,25 +379,9 @@ if [ "${JS_BINARY__LOG_INFO:-}" ]; then
     logf_info "$(echo -n "running" "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"})"
 fi
 
-# De-export capture-related vars so child processes (e.g. a nested js_binary)
-# do not inherit them. The bash script has already consumed them above to set up
-# STDOUT_CAPTURE / STDERR_CAPTURE; leaking them would cause a nested js_binary
-# to silently swallow its own stdout or write to the wrong output file.
-# export -n keeps the value accessible to the _exit trap while removing it from
-# the environment seen by node and any processes it spawns.
-export -n JS_BINARY__STDOUT_OUTPUT_FILE JS_BINARY__STDERR_OUTPUT_FILE JS_BINARY__EXIT_CODE_OUTPUT_FILE JS_BINARY__SILENT_ON_SUCCESS
-
 set +e
 
-if [ "${STDOUT_CAPTURE:-}" ] && [ "${STDERR_CAPTURE:-}" ]; then
-    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" 2>>"$STDERR_CAPTURE" &
-elif [ "${STDOUT_CAPTURE:-}" ]; then
-    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" &
-elif [ "${STDERR_CAPTURE:-}" ]; then
-    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 2>>"$STDERR_CAPTURE" &
-else
-    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 &
-fi
+"$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 &
 
 # ==============================================================================
 # Wait for program to finish
@@ -503,10 +423,4 @@ if [ "${JS_BINARY__EXPECTED_EXIT_CODE:-}" ]; then
     fi
 fi
 
-if [ "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ]; then
-    # Exit zero if the exit code was captured
-    echo -n "$RESULT" >"$JS_BINARY__EXIT_CODE_OUTPUT_FILE"
-    exit 0
-else
-    exit $RESULT
-fi
+exit $RESULT

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -3,10 +3,6 @@
 This macro wraps Aspect bazel-lib's run_binary (https://github.com/bazel-contrib/bazel-lib/blob/main/lib/run_binary.bzl)
 and adds attributes and features specific to rules_js's js_binary.
 
-`stdout`, `stderr`, `exit_code_out`, and `silent_on_success` are passed straight through to the
-underlying `run_binary`. `chdir` is handled separately by this macro (see below) since it has
-bindir-relative semantics that don't match `run_binary`'s execroot-relative `chdir` attribute.
-
 Load this with,
 
 ```starlark

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -3,6 +3,11 @@
 This macro wraps Aspect bazel-lib's run_binary (https://github.com/bazel-contrib/bazel-lib/blob/main/lib/run_binary.bzl)
 and adds attributes and features specific to rules_js's js_binary.
 
+`stdout`, `stderr`, `exit_code_out`, `silent_on_success` and `fail_on` are passed straight through
+to the underlying `run_binary`, which captures them via its `spawn_binary` wrapper. `chdir` is
+handled separately by this macro (see below) since it has bindir-relative semantics that don't
+match `run_binary`'s execroot-relative `chdir` attribute.
+
 Load this with,
 
 ```starlark
@@ -30,6 +35,7 @@ def js_run_binary(
         stderr = None,
         exit_code_out = None,
         silent_on_success = True,
+        fail_on = [],
         use_execroot_entry_point = None,
         copy_srcs_to_bin = True,
         include_sources = True,
@@ -133,6 +139,13 @@ def js_run_binary(
         silent_on_success: produce no output on stdout nor stderr when program exits with status code 0.
 
             This makes node binaries match the expected bazel paradigm.
+
+        fail_on: Exit codes that should fail the action.
+
+            When set, only the listed exit codes cause the action to fail; all other exit codes are
+            treated as success. Useful for tools that use non-zero exit codes for non-error
+            conditions. Can be combined with `exit_code_out` to record the exit code while still
+            failing the action on specific codes. See bazel-lib's `run_binary` docs for more details.
 
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.
@@ -313,22 +326,6 @@ def js_run_binary(
                 normalized_chdir = "external/{}/{}".format(repo, chdir)
         fixed_env["JS_BINARY__CHDIR"] = normalized_chdir
 
-    # Configure capturing stdout, stderr and/or the exit code
-    extra_outs = []
-    if stdout:
-        fixed_env["JS_BINARY__STDOUT_OUTPUT_FILE"] = "$(execpath {})".format(stdout)
-        extra_outs.append(stdout)
-    if stderr:
-        fixed_env["JS_BINARY__STDERR_OUTPUT_FILE"] = "$(execpath {})".format(stderr)
-        extra_outs.append(stderr)
-    if exit_code_out:
-        fixed_env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = "$(execpath {})".format(exit_code_out)
-        extra_outs.append(exit_code_out)
-
-    # Configure silent on success
-    if silent_on_success:
-        fixed_env["JS_BINARY__SILENT_ON_SUCCESS"] = "1"
-
     # Disable node patches if requested
     if patch_node_fs:
         fixed_env["JS_BINARY__PATCH_NODE_FS"] = "1"
@@ -407,9 +404,14 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
         tool = tool,
         env = fixed_env | execroot_env | env,
         srcs = srcs + extra_srcs + execroot_extra_srcs,
-        outs = outs + extra_outs,
+        outs = outs,
         out_dirs = out_dirs,
         args = args,
+        stdout = stdout,
+        stderr = stderr,
+        exit_code_out = exit_code_out,
+        silent_on_success = silent_on_success,
+        fail_on = fail_on,
         mnemonic = mnemonic,
         progress_message = progress_message,
         execution_requirements = execution_requirements,

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -3,10 +3,9 @@
 This macro wraps Aspect bazel-lib's run_binary (https://github.com/bazel-contrib/bazel-lib/blob/main/lib/run_binary.bzl)
 and adds attributes and features specific to rules_js's js_binary.
 
-`stdout`, `stderr`, `exit_code_out`, `silent_on_success` and `fail_on` are passed straight through
-to the underlying `run_binary`, which captures them via its `spawn_binary` wrapper. `chdir` is
-handled separately by this macro (see below) since it has bindir-relative semantics that don't
-match `run_binary`'s execroot-relative `chdir` attribute.
+`stdout`, `stderr`, `exit_code_out`, and `silent_on_success` are passed straight through to the
+underlying `run_binary`. `chdir` is handled separately by this macro (see below) since it has
+bindir-relative semantics that don't match `run_binary`'s execroot-relative `chdir` attribute.
 
 Load this with,
 
@@ -35,7 +34,6 @@ def js_run_binary(
         stderr = None,
         exit_code_out = None,
         silent_on_success = True,
-        fail_on = [],
         use_execroot_entry_point = None,
         copy_srcs_to_bin = True,
         include_sources = True,
@@ -139,13 +137,6 @@ def js_run_binary(
         silent_on_success: produce no output on stdout nor stderr when program exits with status code 0.
 
             This makes node binaries match the expected bazel paradigm.
-
-        fail_on: Exit codes that should fail the action.
-
-            When set, only the listed exit codes cause the action to fail; all other exit codes are
-            treated as success. Useful for tools that use non-zero exit codes for non-error
-            conditions. Can be combined with `exit_code_out` to record the exit code while still
-            failing the action on specific codes. See bazel-lib's `run_binary` docs for more details.
 
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.
@@ -411,7 +402,6 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
         stderr = stderr,
         exit_code_out = exit_code_out,
         silent_on_success = silent_on_success,
-        fail_on = fail_on,
         mnemonic = mnemonic,
         progress_message = progress_message,
         execution_requirements = execution_requirements,

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -26,82 +26,49 @@ if [[ -z "${JS_BINARY__LOG_FATAL:-}" ]]; then export JS_BINARY__LOG_FATAL="1"; f
 if [[ -z "${JS_BINARY__LOG_ERROR:-}" ]]; then export JS_BINARY__LOG_ERROR="1"; fi
 
 # ==============================================================================
-# Prepare stdout capture, stderr capture && logging
+# Logging
 # ==============================================================================
-
-if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ] || [ "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
-    STDOUT_CAPTURE=$(mktemp)
-fi
-
-if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ] || [ "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
-    STDERR_CAPTURE=$(mktemp)
-fi
 
 export JS_BINARY__LOG_PREFIX="aspect_rules_js[js_binary]"
 
 function logf_stderr {
     local format_string="$1\n"
     shift
-    if [ "${STDERR_CAPTURE:-}" ]; then
-        # shellcheck disable=SC2059,SC2046
-        echo -e $(printf "$format_string" "$@") >>"$STDERR_CAPTURE"
-    else
-        # shellcheck disable=SC2059,SC2046
-        echo -e $(printf "$format_string" "$@") >&2
-    fi
+    # shellcheck disable=SC2059,SC2046
+    echo -e $(printf "$format_string" "$@") >&2
 }
 
 function logf_fatal {
     if [ "${JS_BINARY__LOG_FATAL:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
 
 function logf_error {
     if [ "${JS_BINARY__LOG_ERROR:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
 
 function logf_warn {
     if [ "${JS_BINARY__LOG_WARN:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "WARN: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "WARN: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "WARN: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
 
 function logf_info {
     if [ "${JS_BINARY__LOG_INFO:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
 
 function logf_debug {
     if [ "${JS_BINARY__LOG_DEBUG:-}" ]; then
-        if [ "${STDERR_CAPTURE:-}" ]; then
-            printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
-        else
-            printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >&2
-        fi
+        printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >&2
         logf_stderr "$@"
     fi
 }
@@ -126,26 +93,6 @@ function resolve_execroot_src_path {
 
 _exit() {
     EXIT_CODE=$?
-
-    if [ "${STDERR_CAPTURE:-}" ]; then
-        if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ]; then
-            cp -f "$STDERR_CAPTURE" "$JS_BINARY__STDERR_OUTPUT_FILE"
-        fi
-        if [ "$EXIT_CODE" != 0 ] || [ -z "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
-            cat "$STDERR_CAPTURE" >&2
-        fi
-        rm "$STDERR_CAPTURE"
-    fi
-
-    if [ "${STDOUT_CAPTURE:-}" ]; then
-        if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
-            cp -f "$STDOUT_CAPTURE" "$JS_BINARY__STDOUT_OUTPUT_FILE"
-        fi
-        if [ "$EXIT_CODE" != 0 ] || [ -z "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
-            cat "$STDOUT_CAPTURE"
-        fi
-        rm "$STDOUT_CAPTURE"
-    fi
 
     logf_debug "exit code: %s" "$EXIT_CODE"
 
@@ -273,17 +220,6 @@ export JS_BINARY__RUNFILES
 # ==============================================================================
 # Prepare to run main program
 # ==============================================================================
-
-# Convert stdout, stderr and exit_code capture outputs paths to absolute paths
-if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
-    JS_BINARY__STDOUT_OUTPUT_FILE="$PWD/$JS_BINARY__STDOUT_OUTPUT_FILE"
-fi
-if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ]; then
-    JS_BINARY__STDERR_OUTPUT_FILE="$PWD/$JS_BINARY__STDERR_OUTPUT_FILE"
-fi
-if [ "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ]; then
-    JS_BINARY__EXIT_CODE_OUTPUT_FILE="$PWD/$JS_BINARY__EXIT_CODE_OUTPUT_FILE"
-fi
 
 if [[ "$PWD" == *"/bazel-out/"* ]]; then
     bazel_out_segment="/bazel-out/"
@@ -563,25 +499,9 @@ if [ "${JS_BINARY__LOG_INFO:-}" ]; then
     logf_info "$(echo -n "running" "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"})"
 fi
 
-# De-export capture-related vars so child processes (e.g. a nested js_binary)
-# do not inherit them. The bash script has already consumed them above to set up
-# STDOUT_CAPTURE / STDERR_CAPTURE; leaking them would cause a nested js_binary
-# to silently swallow its own stdout or write to the wrong output file.
-# export -n keeps the value accessible to the _exit trap while removing it from
-# the environment seen by node and any processes it spawns.
-export -n JS_BINARY__STDOUT_OUTPUT_FILE JS_BINARY__STDERR_OUTPUT_FILE JS_BINARY__EXIT_CODE_OUTPUT_FILE JS_BINARY__SILENT_ON_SUCCESS
-
 set +e
 
-if [ "${STDOUT_CAPTURE:-}" ] && [ "${STDERR_CAPTURE:-}" ]; then
-    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" 2>>"$STDERR_CAPTURE" &
-elif [ "${STDOUT_CAPTURE:-}" ]; then
-    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" &
-elif [ "${STDERR_CAPTURE:-}" ]; then
-    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 2>>"$STDERR_CAPTURE" &
-else
-    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 &
-fi
+"$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 &
 
 # ==============================================================================
 # Wait for program to finish
@@ -623,10 +543,4 @@ if [ "${JS_BINARY__EXPECTED_EXIT_CODE:-}" ]; then
     fi
 fi
 
-if [ "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ]; then
-    # Exit zero if the exit code was captured
-    echo -n "$RESULT" >"$JS_BINARY__EXIT_CODE_OUTPUT_FILE"
-    exit 0
-else
-    exit $RESULT
-fi
+exit $RESULT


### PR DESCRIPTION
…ilent_on_success support

Bump bazel_lib to 3.5.0, which added stdout/stderr/exit_code_out/silent_on_success attributes to run_binary (via its spawn_binary wrapper toolchain). js_run_binary now passes these straight through instead of reimplementing capture itself via JS_BINARY__* env vars, which lets us delete the corresponding buffering/capture logic from the js_binary launcher script. chdir is left untouched since it has bindir-relative semantics that don't map directly onto run_binary's execroot-relative chdir attribute.

One thing to note is that these features all depend on `spawn_binary`, which is a prebuilt Go executable provided by bazel-lib. I think this is OK because capturing output is inevitably going to require some kind of wrapper, and `spawn_binary` is simpler and cheaper than bash. Getting this support out of our wrapper script should help us move toward removing our reliance on bash.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
