### PR TITLE
fix(watch): treat EXIT as a clean shutdown of the cycle loop

### DIFF
--- a/js/private/devserver/js_run_devserver.mjs
+++ b/js/private/devserver/js_run_devserver.mjs
@@ -123,11 +123,16 @@ class AspectWatchProtocol {
         do {
             // Only receive cycle messages, forever up until the connection is closed.
             // Connection errors will propagate.
-            const cycleMsg = await this._receive();
-            if (cycleMsg.kind !== MessageType.CYCLE &&
-                cycleMsg.kind !== MessageType.CYCLE_RESET) {
-                throw new Error(`Expected CYCLE or CYCLE_RESET, got ${cycleMsg.kind}`);
+            const msg = await this._receive();
+            // The server is shutting down; end the cycle loop cleanly.
+            if (msg.kind === MessageType.EXIT) {
+                return;
             }
+            if (msg.kind !== MessageType.CYCLE &&
+                msg.kind !== MessageType.CYCLE_RESET) {
+                throw new Error(`Expected CYCLE or CYCLE_RESET, got ${msg.kind}`);
+            }
+            const cycleMsg = msg;
             // Invoke the cycle callback while recording+logging errors
             let cycleError = null;
             try {

--- a/js/private/test/watch/BUILD.bazel
+++ b/js/private/test/watch/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//js:defs.bzl", "js_test")
+
+js_test(
+    name = "exit_shutdown_test",
+    data = ["//js/private/watch"],
+    entry_point = "exit_shutdown.test.mjs",
+)

--- a/js/private/test/watch/exit_shutdown.test.mjs
+++ b/js/private/test/watch/exit_shutdown.test.mjs
@@ -1,0 +1,62 @@
+// Test that an EXIT message from the watch protocol server ends the
+// AspectWatchProtocol cycle loop cleanly instead of throwing.
+import * as net from 'node:net'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as assert from 'node:assert'
+import { AspectWatchProtocol } from '../../watch/aspect_watch_protocol.mjs'
+
+const socketFile = path.join(
+    os.tmpdir(),
+    `watch-proto-test-${process.pid}-exit.sock`
+)
+
+// A minimal scripted server: handshake, then an immediate EXIT.
+const srv = net.createServer((conn) => {
+    let tail = ''
+    conn.write(JSON.stringify({ kind: 'NEGOTIATE', versions: [1] }) + '\n')
+    conn.on('data', (data) => {
+        tail += data.toString()
+        let nl
+        while ((nl = tail.indexOf('\n')) !== -1) {
+            const line = tail.slice(0, nl).trim()
+            tail = tail.slice(nl + 1)
+            if (!line) continue
+
+            const msg = JSON.parse(line)
+            if (msg.kind === 'NEGOTIATE_RESPONSE') {
+                assert.equal(msg.version, 1)
+            } else if (msg.kind === 'CAPS') {
+                conn.write(
+                    JSON.stringify({
+                        kind: 'CAPS_RESPONSE',
+                        caps: { scope: ['runfiles'] },
+                    }) + '\n'
+                )
+                // Delayed so the client is inside cycle() awaiting the message.
+                setTimeout(
+                    () =>
+                        conn.write(
+                            JSON.stringify({
+                                kind: 'EXIT',
+                                description: 'shutting down',
+                            }) + '\n'
+                        ),
+                    50
+                )
+            }
+        }
+    })
+})
+await new Promise((resolve) => srv.listen(socketFile, resolve))
+
+const w = new AspectWatchProtocol(socketFile)
+w.onCycle(async () => {
+    throw new Error('no cycle expected')
+})
+await w.connect()
+await w.cycle() // resolves (does not throw) on EXIT
+await w.disconnect()
+srv.close()
+
+console.log('PASS: EXIT ends cycle() cleanly')

--- a/js/private/watch/aspect_watch_protocol.mjs
+++ b/js/private/watch/aspect_watch_protocol.mjs
@@ -115,11 +115,16 @@ export class AspectWatchProtocol {
         do {
             // Only receive cycle messages, forever up until the connection is closed.
             // Connection errors will propagate.
-            const cycleMsg = await this._receive();
-            if (cycleMsg.kind !== MessageType.CYCLE &&
-                cycleMsg.kind !== MessageType.CYCLE_RESET) {
-                throw new Error(`Expected CYCLE or CYCLE_RESET, got ${cycleMsg.kind}`);
+            const msg = await this._receive();
+            // The server is shutting down; end the cycle loop cleanly.
+            if (msg.kind === MessageType.EXIT) {
+                return;
             }
+            if (msg.kind !== MessageType.CYCLE &&
+                msg.kind !== MessageType.CYCLE_RESET) {
+                throw new Error(`Expected CYCLE or CYCLE_RESET, got ${msg.kind}`);
+            }
+            const cycleMsg = msg;
             // Invoke the cycle callback while recording+logging errors
             let cycleError = null;
             try {

--- a/js/private/watch/src/aspect_watch_protocol.mts
+++ b/js/private/watch/src/aspect_watch_protocol.mts
@@ -230,15 +230,22 @@ export class AspectWatchProtocol {
         do {
             // Only receive cycle messages, forever up until the connection is closed.
             // Connection errors will propagate.
-            const cycleMsg = await this._receive<CycleMessage>()
+            const msg = await this._receive<Message>()
+
+            // The server is shutting down; end the cycle loop cleanly.
+            if (msg.kind === MessageType.EXIT) {
+                return
+            }
+
             if (
-                cycleMsg.kind !== MessageType.CYCLE &&
-                cycleMsg.kind !== MessageType.CYCLE_RESET
+                msg.kind !== MessageType.CYCLE &&
+                msg.kind !== MessageType.CYCLE_RESET
             ) {
                 throw new Error(
-                    `Expected CYCLE or CYCLE_RESET, got ${cycleMsg.kind}`
+                    `Expected CYCLE or CYCLE_RESET, got ${msg.kind}`
                 )
             }
+            const cycleMsg = msg as CycleMessage
 
             // Invoke the cycle callback while recording+logging errors
             let cycleError = null


### PR DESCRIPTION
An EXIT message from the server (e.g. the aspect-cli shutting down) was rejected by the cycle loop's message kind check, surfacing a routine shutdown as 'Expected CYCLE or CYCLE_RESET, got EXIT'. End the loop cleanly instead.

Ref #2894

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
