### PR TITLE
fix(watch): read the socket with a single persistent reader

### DIFF
--- a/js/private/devserver/js_run_devserver.mjs
+++ b/js/private/devserver/js_run_devserver.mjs
@@ -25,6 +25,8 @@ var MessageType;
 })(MessageType || (MessageType = {}));
 // Environment constants
 const { JS_BINARY__LOG_DEBUG: JS_BINARY__LOG_DEBUG$1 } = process.env;
+// The message framing delimiter byte.
+const NEWLINE = '\n'.charCodeAt(0);
 function selectVersion(versions) {
     if (versions.includes(3)) {
         return 3;
@@ -40,10 +42,21 @@ function selectVersion(versions) {
 class AspectWatchProtocol {
     constructor(socketFile) {
         this._version = -1;
+        // Single persistent reader state: partial trailing line, parsed but
+        // unconsumed messages, the pending _receive() and the terminal error.
+        this._readTail = Buffer.alloc(0);
+        this._received = [];
+        this._receiver = null;
+        this._terminated = null;
         this.socketFile = socketFile;
         this.connection = new net.Socket({});
         // Propagate connection errors to a configurable callback
         this._error = console.error;
+        // A single persistent reader for the lifetime of the connection so
+        // messages are framed correctly and never dropped between receives.
+        this.connection.on('data', (data) => this._dataReceived(data));
+        this.connection.on('error', (err) => this._terminate(err));
+        this.connection.on('close', () => this._terminate(new Error('watch protocol connection closed')));
     }
     /**
      * Establish a connection to the Aspect Watcher server and complete the initial
@@ -157,46 +170,75 @@ class AspectWatchProtocol {
             }
         } while (!once && this.connection.readable && this.connection.writable);
     }
+    // Split the byte stream into newline-delimited JSON messages, delivering
+    // them to the pending _receive() or queueing them until one arrives.
+    _dataReceived(data) {
+        const buf = this._readTail.length
+            ? Buffer.concat([this._readTail, data])
+            : data;
+        let start = 0;
+        for (let nl = buf.indexOf(NEWLINE, start); nl !== -1; nl = buf.indexOf(NEWLINE, start)) {
+            const line = buf.subarray(start, nl).toString().trim();
+            start = nl + 1;
+            if (!line) {
+                continue;
+            }
+            let msg;
+            try {
+                msg = JSON.parse(line);
+            }
+            catch (e) {
+                this._terminate(new Error(`Failed to parse watch protocol message: ${e}`));
+                this.connection.destroy();
+                return;
+            }
+            if (this._receiver) {
+                const receiver = this._receiver;
+                this._receiver = null;
+                receiver.resolve(msg);
+            }
+            else {
+                this._received.push(msg);
+            }
+        }
+        // Copy the partial trailing line so the full chunk can be released.
+        this._readTail =
+            start < buf.length
+                ? Buffer.from(buf.subarray(start))
+                : Buffer.alloc(0);
+    }
+    // Fail the pending _receive() and all future receives, e.g. on socket error or close.
+    _terminate(err) {
+        if (this._terminated) {
+            return;
+        }
+        this._terminated = err;
+        if (this._receiver) {
+            const receiver = this._receiver;
+            this._receiver = null;
+            receiver.reject(err);
+        }
+    }
     async _receive(type = null) {
-        return await new Promise((resolve, reject) => {
-            const dataBufs = [];
-            const connection = this.connection;
-            connection.once('error', onError);
-            connection.once('close', onError);
-            connection.on('data', dataReceived);
-            // Destructor removing all temporary event handlers.
-            function removeHandlers() {
-                connection.off('error', onError);
-                connection.off('close', onError);
-                connection.off('data', dataReceived);
-            }
-            // Error event handler
-            function onError(err) {
-                removeHandlers();
-                reject(err);
-            }
-            // Data event handler to receive data and determine when to resolve the promise.
-            function dataReceived(data) {
-                dataBufs.push(data);
-                if (data.at(data.byteLength - 1) !== '\n'.charCodeAt(0)) {
-                    return;
-                }
-                // Removal all temporary event handlers before resolving the promise
-                removeHandlers();
-                try {
-                    const msg = JSON.parse(Buffer.concat(dataBufs).toString().trim());
-                    if (type && msg.kind !== type) {
-                        reject(new Error(`Expected message kind ${type}, got ${msg.kind}`));
-                    }
-                    else {
-                        resolve(msg);
-                    }
-                }
-                catch (e) {
-                    reject(e);
-                }
-            }
-        });
+        let msg;
+        if (this._received.length > 0) {
+            msg = this._received.shift();
+        }
+        else if (this._terminated) {
+            throw this._terminated;
+        }
+        else if (this._receiver) {
+            throw new Error('Concurrent _receive() calls are not supported');
+        }
+        else {
+            msg = await new Promise((resolve, reject) => {
+                this._receiver = { resolve, reject };
+            });
+        }
+        if (type && msg.kind !== type) {
+            throw new Error(`Expected message kind ${type}, got ${msg.kind}`);
+        }
+        return msg;
     }
     async _send(type, data) {
         await new Promise((resolve, reject) => {

--- a/js/private/test/watch/BUILD.bazel
+++ b/js/private/test/watch/BUILD.bazel
@@ -1,6 +1,12 @@
 load("//js:defs.bzl", "js_test")
 
 js_test(
+    name = "aspect_watch_protocol_test",
+    data = ["//js/private/watch"],
+    entry_point = "aspect_watch_protocol.test.mjs",
+)
+
+js_test(
     name = "connect_error_test",
     data = ["//js/private/watch"],
     entry_point = "connect_error.test.mjs",

--- a/js/private/test/watch/aspect_watch_protocol.test.mjs
+++ b/js/private/test/watch/aspect_watch_protocol.test.mjs
@@ -1,0 +1,205 @@
+// Tests for the AspectWatchProtocol client message framing and error routing,
+// driven against scripted fake servers on a real unix socket.
+import * as net from 'node:net'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as assert from 'node:assert'
+import { AspectWatchProtocol } from '../../watch/aspect_watch_protocol.mjs'
+
+let socketCounter = 0
+function socketPath() {
+    return path.join(
+        os.tmpdir(),
+        `watch-proto-test-${process.pid}-${socketCounter++}.sock`
+    )
+}
+
+// Line-framed JSON fake server; `onMessage` scripts its side of the protocol.
+function serveScript(onMessage, onConnect) {
+    const file = socketPath()
+    const srv = net.createServer((conn) => {
+        let tail = ''
+        if (onConnect) onConnect(conn)
+        conn.on('data', (data) => {
+            tail += data.toString()
+            let nl
+            while ((nl = tail.indexOf('\n')) !== -1) {
+                const line = tail.slice(0, nl).trim()
+                tail = tail.slice(nl + 1)
+                if (line) onMessage(conn, JSON.parse(line))
+            }
+        })
+    })
+    return new Promise((resolve) =>
+        srv.listen(file, () => resolve({ file, srv }))
+    )
+}
+
+function negotiate(conn) {
+    conn.write(JSON.stringify({ kind: 'NEGOTIATE', versions: [1] }) + '\n')
+}
+
+function handshakeHandler(conn, msg, { coalesceFirstCycle = false } = {}) {
+    if (msg.kind === 'NEGOTIATE_RESPONSE') {
+        assert.equal(msg.version, 1)
+        return true
+    }
+    if (msg.kind === 'CAPS') {
+        const capsResp =
+            JSON.stringify({
+                kind: 'CAPS_RESPONSE',
+                caps: { scope: ['runfiles'] },
+            }) + '\n'
+        if (coalesceFirstCycle) {
+            // CAPS_RESPONSE and the first CYCLE coalesced into ONE write/chunk.
+            conn.write(
+                capsResp +
+                    JSON.stringify({
+                        kind: 'CYCLE',
+                        cycle_id: 1,
+                        sources: { 'a.txt': null },
+                    }) +
+                    '\n'
+            )
+        } else {
+            conn.write(capsResp)
+        }
+        return true
+    }
+    return false
+}
+
+async function test(name, fn) {
+    await fn()
+    console.log(`PASS: ${name}`)
+}
+
+// Multiple messages coalesced into a single 'data' chunk must be framed apart.
+await test('coalesced messages in one chunk', async () => {
+    const cycles = []
+    const { file, srv } = await serveScript((conn, msg) => {
+        if (handshakeHandler(conn, msg, { coalesceFirstCycle: true })) return
+        if (msg.kind === 'CYCLE_COMPLETED') {
+            assert.equal(msg.cycle_id, 1)
+            conn.end()
+        }
+    }, negotiate)
+
+    const w = new AspectWatchProtocol(file)
+    w.onError((e) => {
+        throw e
+    })
+    w.onCycle(async (msg) => cycles.push(msg))
+    await w.connect()
+    await w.awaitFirstCycle()
+    assert.equal(cycles.length, 1)
+    assert.deepEqual(cycles[0].sources, { 'a.txt': null })
+    await w.disconnect()
+    srv.close()
+})
+
+// A message split across many chunks, including mid-JSON boundaries.
+await test('message split across chunks', async () => {
+    const cycles = []
+    const { file, srv } = await serveScript((conn, msg) => {
+        if (handshakeHandler(conn, msg)) {
+            if (msg.kind === 'CAPS') {
+                // Dribble a CYCLE out in 5 byte chunks after the handshake.
+                const cycle =
+                    JSON.stringify({
+                        kind: 'CYCLE',
+                        cycle_id: 1,
+                        sources: {},
+                    }) + '\n'
+                let i = 0
+                const step = () => {
+                    if (i < cycle.length) {
+                        conn.write(cycle.slice(i, i + 5))
+                        i += 5
+                        setTimeout(step, 1)
+                    }
+                }
+                step()
+            }
+            return
+        }
+        if (msg.kind === 'CYCLE_COMPLETED') conn.end()
+    }, negotiate)
+
+    const w = new AspectWatchProtocol(file)
+    w.onCycle(async (msg) => cycles.push(msg))
+    await w.connect()
+    await w.awaitFirstCycle()
+    assert.equal(cycles.length, 1)
+    await w.disconnect()
+    srv.close()
+})
+
+// A message arriving while the client has no receive pending must be queued.
+await test('message arriving between receives is queued, not dropped', async () => {
+    const cycles = []
+    const { file, srv } = await serveScript((conn, msg) => {
+        if (handshakeHandler(conn, msg)) {
+            if (msg.kind === 'CAPS') {
+                conn.write(
+                    JSON.stringify({
+                        kind: 'CYCLE',
+                        cycle_id: 1,
+                        sources: {},
+                    }) + '\n'
+                )
+            }
+            return
+        }
+        if (msg.kind === 'CYCLE_COMPLETED') conn.end()
+    }, negotiate)
+
+    const w = new AspectWatchProtocol(file)
+    w.onCycle(async (msg) => cycles.push(msg))
+    await w.connect()
+    // Idle: the CYCLE arrives now, with no _receive() outstanding.
+    await new Promise((r) => setTimeout(r, 100))
+    await w.awaitFirstCycle()
+    assert.equal(cycles.length, 1)
+    await w.disconnect()
+    srv.close()
+})
+
+// An out-of-order message during the handshake: catchable error, not a crash.
+await test('early CYCLE during handshake rejects connect()', async () => {
+    const { file, srv } = await serveScript((conn, msg) => {
+        if (msg.kind === 'CAPS') {
+            // Protocol violation: CYCLE instead of CAPS_RESPONSE.
+            conn.write(
+                JSON.stringify({ kind: 'CYCLE', cycle_id: 1, sources: {} }) +
+                    '\n'
+            )
+        }
+    }, negotiate)
+
+    const w = new AspectWatchProtocol(file)
+    await assert.rejects(
+        () => w.connect(),
+        /Expected message kind CAPS_RESPONSE, got CYCLE/
+    )
+    await w.disconnect()
+    srv.close()
+})
+
+// The server closing mid-cycle-loop surfaces as a catchable error.
+await test('server close during cycle loop rejects catchably', async () => {
+    const { file, srv } = await serveScript((conn, msg) => {
+        if (handshakeHandler(conn, msg)) {
+            if (msg.kind === 'CAPS') setTimeout(() => conn.destroy(), 20)
+            return
+        }
+    }, negotiate)
+
+    const w = new AspectWatchProtocol(file)
+    w.onCycle(async () => {})
+    await w.connect()
+    await assert.rejects(() => w.cycle(), /connection closed/)
+    srv.close()
+})
+
+console.log('All watch protocol tests passed.')

--- a/js/private/watch/aspect_watch_protocol.d.mts
+++ b/js/private/watch/aspect_watch_protocol.d.mts
@@ -73,6 +73,10 @@ export declare class AspectWatchProtocol {
     private _version;
     private _error;
     private _cycle;
+    private _readTail;
+    private _received;
+    private _receiver;
+    private _terminated;
     constructor(socketFile: string);
     /**
      * Establish a connection to the Aspect Watcher server and complete the initial
@@ -101,6 +105,8 @@ export declare class AspectWatchProtocol {
      * the connection is closed or an error occurs.
      */
     cycle(once?: boolean): Promise<void>;
+    private _dataReceived;
+    private _terminate;
     _receive<M extends Message>(type?: M['kind'] | null): Promise<M>;
     _send<M extends Message>(type: M['kind'], data: Omit<M, 'kind'>): Promise<void>;
 }

--- a/js/private/watch/aspect_watch_protocol.mjs
+++ b/js/private/watch/aspect_watch_protocol.mjs
@@ -17,6 +17,8 @@ export var MessageType;
 })(MessageType || (MessageType = {}));
 // Environment constants
 const { JS_BINARY__LOG_DEBUG } = process.env;
+// The message framing delimiter byte.
+const NEWLINE = '\n'.charCodeAt(0);
 function selectVersion(versions) {
     if (versions.includes(3)) {
         return 3;
@@ -32,10 +34,21 @@ function selectVersion(versions) {
 export class AspectWatchProtocol {
     constructor(socketFile) {
         this._version = -1;
+        // Single persistent reader state: partial trailing line, parsed but
+        // unconsumed messages, the pending _receive() and the terminal error.
+        this._readTail = Buffer.alloc(0);
+        this._received = [];
+        this._receiver = null;
+        this._terminated = null;
         this.socketFile = socketFile;
         this.connection = new net.Socket({});
         // Propagate connection errors to a configurable callback
         this._error = console.error;
+        // A single persistent reader for the lifetime of the connection so
+        // messages are framed correctly and never dropped between receives.
+        this.connection.on('data', (data) => this._dataReceived(data));
+        this.connection.on('error', (err) => this._terminate(err));
+        this.connection.on('close', () => this._terminate(new Error('watch protocol connection closed')));
     }
     /**
      * Establish a connection to the Aspect Watcher server and complete the initial
@@ -149,46 +162,75 @@ export class AspectWatchProtocol {
             }
         } while (!once && this.connection.readable && this.connection.writable);
     }
+    // Split the byte stream into newline-delimited JSON messages, delivering
+    // them to the pending _receive() or queueing them until one arrives.
+    _dataReceived(data) {
+        const buf = this._readTail.length
+            ? Buffer.concat([this._readTail, data])
+            : data;
+        let start = 0;
+        for (let nl = buf.indexOf(NEWLINE, start); nl !== -1; nl = buf.indexOf(NEWLINE, start)) {
+            const line = buf.subarray(start, nl).toString().trim();
+            start = nl + 1;
+            if (!line) {
+                continue;
+            }
+            let msg;
+            try {
+                msg = JSON.parse(line);
+            }
+            catch (e) {
+                this._terminate(new Error(`Failed to parse watch protocol message: ${e}`));
+                this.connection.destroy();
+                return;
+            }
+            if (this._receiver) {
+                const receiver = this._receiver;
+                this._receiver = null;
+                receiver.resolve(msg);
+            }
+            else {
+                this._received.push(msg);
+            }
+        }
+        // Copy the partial trailing line so the full chunk can be released.
+        this._readTail =
+            start < buf.length
+                ? Buffer.from(buf.subarray(start))
+                : Buffer.alloc(0);
+    }
+    // Fail the pending _receive() and all future receives, e.g. on socket error or close.
+    _terminate(err) {
+        if (this._terminated) {
+            return;
+        }
+        this._terminated = err;
+        if (this._receiver) {
+            const receiver = this._receiver;
+            this._receiver = null;
+            receiver.reject(err);
+        }
+    }
     async _receive(type = null) {
-        return await new Promise((resolve, reject) => {
-            const dataBufs = [];
-            const connection = this.connection;
-            connection.once('error', onError);
-            connection.once('close', onError);
-            connection.on('data', dataReceived);
-            // Destructor removing all temporary event handlers.
-            function removeHandlers() {
-                connection.off('error', onError);
-                connection.off('close', onError);
-                connection.off('data', dataReceived);
-            }
-            // Error event handler
-            function onError(err) {
-                removeHandlers();
-                reject(err);
-            }
-            // Data event handler to receive data and determine when to resolve the promise.
-            function dataReceived(data) {
-                dataBufs.push(data);
-                if (data.at(data.byteLength - 1) !== '\n'.charCodeAt(0)) {
-                    return;
-                }
-                // Removal all temporary event handlers before resolving the promise
-                removeHandlers();
-                try {
-                    const msg = JSON.parse(Buffer.concat(dataBufs).toString().trim());
-                    if (type && msg.kind !== type) {
-                        reject(new Error(`Expected message kind ${type}, got ${msg.kind}`));
-                    }
-                    else {
-                        resolve(msg);
-                    }
-                }
-                catch (e) {
-                    reject(e);
-                }
-            }
-        });
+        let msg;
+        if (this._received.length > 0) {
+            msg = this._received.shift();
+        }
+        else if (this._terminated) {
+            throw this._terminated;
+        }
+        else if (this._receiver) {
+            throw new Error('Concurrent _receive() calls are not supported');
+        }
+        else {
+            msg = await new Promise((resolve, reject) => {
+                this._receiver = { resolve, reject };
+            });
+        }
+        if (type && msg.kind !== type) {
+            throw new Error(`Expected message kind ${type}, got ${msg.kind}`);
+        }
+        return msg;
     }
     async _send(type, data) {
         await new Promise((resolve, reject) => {

--- a/js/private/watch/src/aspect_watch_protocol.mts
+++ b/js/private/watch/src/aspect_watch_protocol.mts
@@ -95,6 +95,9 @@ export interface ExitMessage extends Message {
 // Environment constants
 const { JS_BINARY__LOG_DEBUG } = process.env
 
+// The message framing delimiter byte.
+const NEWLINE = '\n'.charCodeAt(0)
+
 function selectVersion(versions: number[]): number {
     if (versions.includes(3)) {
         return 3
@@ -117,12 +120,30 @@ export class AspectWatchProtocol {
     private _error: (err: Error) => void
     private _cycle: (msg: CycleMessage) => Promise<void>
 
+    // Single persistent reader state: partial trailing line, parsed but
+    // unconsumed messages, the pending _receive() and the terminal error.
+    private _readTail: Buffer = Buffer.alloc(0)
+    private _received: Message[] = []
+    private _receiver: {
+        resolve: (msg: Message) => void
+        reject: (err: Error) => void
+    } | null = null
+    private _terminated: Error | null = null
+
     constructor(socketFile: string) {
         this.socketFile = socketFile
         this.connection = new net.Socket({})
 
         // Propagate connection errors to a configurable callback
         this._error = console.error
+
+        // A single persistent reader for the lifetime of the connection so
+        // messages are framed correctly and never dropped between receives.
+        this.connection.on('data', (data) => this._dataReceived(data))
+        this.connection.on('error', (err) => this._terminate(err))
+        this.connection.on('close', () =>
+            this._terminate(new Error('watch protocol connection closed'))
+        )
     }
 
     /**
@@ -275,59 +296,86 @@ export class AspectWatchProtocol {
         } while (!once && this.connection.readable && this.connection.writable)
     }
 
+    // Split the byte stream into newline-delimited JSON messages, delivering
+    // them to the pending _receive() or queueing them until one arrives.
+    private _dataReceived(data: Buffer) {
+        const buf = this._readTail.length
+            ? Buffer.concat([this._readTail, data])
+            : data
+
+        let start = 0
+        for (
+            let nl = buf.indexOf(NEWLINE, start);
+            nl !== -1;
+            nl = buf.indexOf(NEWLINE, start)
+        ) {
+            const line = buf.subarray(start, nl).toString().trim()
+            start = nl + 1
+            if (!line) {
+                continue
+            }
+
+            let msg: Message
+            try {
+                msg = JSON.parse(line)
+            } catch (e) {
+                this._terminate(
+                    new Error(`Failed to parse watch protocol message: ${e}`)
+                )
+                this.connection.destroy()
+                return
+            }
+
+            if (this._receiver) {
+                const receiver = this._receiver
+                this._receiver = null
+                receiver.resolve(msg)
+            } else {
+                this._received.push(msg)
+            }
+        }
+
+        // Copy the partial trailing line so the full chunk can be released.
+        this._readTail =
+            start < buf.length
+                ? Buffer.from(buf.subarray(start))
+                : Buffer.alloc(0)
+    }
+
+    // Fail the pending _receive() and all future receives, e.g. on socket error or close.
+    private _terminate(err: Error) {
+        if (this._terminated) {
+            return
+        }
+        this._terminated = err
+
+        if (this._receiver) {
+            const receiver = this._receiver
+            this._receiver = null
+            receiver.reject(err)
+        }
+    }
+
     async _receive<M extends Message>(
         type: M['kind'] | null = null
     ): Promise<M> {
-        return await new Promise((resolve, reject) => {
-            const dataBufs: Buffer[] = []
-            const connection = this.connection
+        let msg: Message
+        if (this._received.length > 0) {
+            msg = this._received.shift()
+        } else if (this._terminated) {
+            throw this._terminated
+        } else if (this._receiver) {
+            throw new Error('Concurrent _receive() calls are not supported')
+        } else {
+            msg = await new Promise<Message>((resolve, reject) => {
+                this._receiver = { resolve, reject }
+            })
+        }
 
-            connection.once('error', onError)
-            connection.once('close', onError)
-            connection.on('data', dataReceived)
-
-            // Destructor removing all temporary event handlers.
-            function removeHandlers() {
-                connection.off('error', onError)
-                connection.off('close', onError)
-                connection.off('data', dataReceived)
-            }
-
-            // Error event handler
-            function onError(err) {
-                removeHandlers()
-                reject(err)
-            }
-
-            // Data event handler to receive data and determine when to resolve the promise.
-            function dataReceived(data) {
-                dataBufs.push(data)
-
-                if (data.at(data.byteLength - 1) !== '\n'.charCodeAt(0)) {
-                    return
-                }
-
-                // Removal all temporary event handlers before resolving the promise
-                removeHandlers()
-
-                try {
-                    const msg = JSON.parse(
-                        Buffer.concat(dataBufs).toString().trim()
-                    )
-                    if (type && msg.kind !== type) {
-                        reject(
-                            new Error(
-                                `Expected message kind ${type}, got ${msg.kind}`
-                            )
-                        )
-                    } else {
-                        resolve(msg)
-                    }
-                } catch (e) {
-                    reject(e)
-                }
-            }
-        })
+        if (type && msg.kind !== type) {
+            throw new Error(`Expected message kind ${type}, got ${msg.kind}`)
+        }
+        return msg as M
     }
 
     async _send<M extends Message>(type: M['kind'], data: Omit<M, 'kind'>) {


### PR DESCRIPTION
The previous per-receive 'data' listener had two framing bugs that caused occasional crashes or hangs of watch protocol clients such as js_run_devserver:

- multiple messages coalesced into one chunk were parsed as a single JSON document, rejecting with a SyntaxError
- messages arriving while no receive was pending were silently dropped, deadlocking the client and server

A single persistent reader now splits the stream on newlines, buffers partial lines across chunks, and queues messages until consumed. Socket errors and close reject the pending and all future receives instead of leaking unhandled 'error' events.

Fix #2894

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
