### PR TITLE
fix(js_binary): tools/sh toolchain required on windows

### DIFF
--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -578,6 +578,8 @@ js_binary_lib = struct(
     create_launcher = _create_launcher,
     implementation = _js_binary_impl,
     toolchains = [
+        # Optional: only referenced on Windows
+        config_common.toolchain_type("@bazel_tools//tools/sh:toolchain_type", mandatory = False),
         "@rules_nodejs//nodejs:runtime_toolchain_type",
     ] + COPY_FILE_TO_BIN_TOOLCHAINS,
 )


### PR DESCRIPTION
I guess that [last one](https://github.com/aspect-build/rules_js/commit/cbb35ca1748243273135f6fba32deee8c5405b0a) didn't [work on windows](https://github.com/aspect-build/rules_js/actions/runs/29720005746/job/88281713415) so I guess it is required then.

Last time I the PR never ran on windows so I didn't notice.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
