### PR TITLE
fix(coverage): generate lcov report in the test action

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -243,6 +243,13 @@ jobs:
               if: matrix.workspace.path == '.' && matrix.bazel.id == 'bazel-7'
               run: aspect test --task-key=coverage-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} --bazel-flag=--collect_code_coverage --bazel-flag=--instrument_test_targets --bazel-flag=--nocache_test_results -- //js/private/test/coverage/...
 
+            # Again with the merger as its own action, as remote execution requires. The
+            # mergers assert different things in that mode -- bazel discards a report the
+            # test wrote to COVERAGE_OUTPUT_FILE itself -- so both modes need a run.
+            - name: Coverage (split postprocessing)
+              if: matrix.workspace.path == '.' && matrix.bazel.id == 'bazel-7'
+              run: aspect test --task-key=coverage-split-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} --bazel-flag=--collect_code_coverage --bazel-flag=--instrument_test_targets --bazel-flag=--nocache_test_results --bazel-flag=--experimental_split_coverage_postprocessing --bazel-flag=--experimental_fetch_all_coverage_outputs -- //js/private/test/coverage/...
+
             # Skipped on the no-execroot-entry-point variant: test.sh scripts invoke plain
             # `bazel` without matrix.bazel.flags, so that leg wouldn't exercise the flag —
             # it would only duplicate the bazel-9 run.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -227,3 +227,75 @@ You can also reduce the size of the extracted packages themselves with
 `npm.npm_exclude_package_contents`, which removes files you consider unnecessary (docs,
 tests, etc.) at extraction time; see
 [Unnecessary npm package content](#unnecessary-npm-package-content) above.
+
+## Code coverage
+
+Under `bazel coverage`, `js_test` produces its lcov report while the test runs,
+where the V8 coverage data and the instrumented sources are both available.
+
+### Coverage runs count against the test's timeout
+
+Because the report is produced while the test runs, generating it consumes the
+target's own `timeout`/`size` budget. Converting V8 coverage to lcov takes time
+proportional to the number of instrumented files, so a test that sits near its
+timeout under `bazel test` may need a larger `size` or `timeout` to pass under
+`bazel coverage`.
+
+For the same reason the report is produced by the target's own `node_toolchain`,
+not by the one used for build actions. A test pinned to an old Node version runs
+the coverage reporter under that version too.
+
+### Coverage requires a runfiles tree
+
+The reporter maps V8 coverage data back onto sources through the test's runfiles,
+so a target built without a runfiles tree (`enable_runfiles = False`, which is the
+default on Windows without `--enable_runfiles`) reports empty coverage and logs
+
+```
+ERROR: ...: coverage report generator '...' not found; code coverage requires a runfiles tree
+```
+
+The test itself still passes; enable runfiles to collect coverage for it.
+
+### Empty coverage reports
+
+An empty `coverage.dat` usually means nothing was instrumented — see
+`--instrumentation_filter` and `--instrument_test_targets`.
+
+If it is accompanied by
+
+```
+WARNING: no coverage report was generated in the test action, reporting empty coverage.
+```
+
+then either the target is `testonly = False`, which rules_js does not collect
+coverage for, or it is a custom test rule that reuses only part of rules_js's
+coverage support. In the latter case use `js_test`, or the test rule provided by the
+ruleset for your test framework, rather than assembling one from rules_js internals.
+
+### First-party code repackaged with `npm_package`
+
+Coverage of first-party code imported by package name (`require("@my-scope/lib")`)
+is supported when the package is linked from a `js_library` (a pnpm-workspace-style
+first-party dependency): the `.aspect_rules_js` store entry points at the library's
+own sources, so coverage attributes to them.
+
+It is **not** supported when the code is repackaged with `npm_package` and then
+linked by name. `npm_package` produces a distributable _copy_ in the store with no
+link back to the sources, so the executed file cannot be mapped to them and the
+target reports empty coverage. This is a deliberate limitation: for coverage of
+first-party code under test, depend on it as a `js_library` (by relative path or by
+name), not as a repackaged `npm_package`. See
+[#2933](https://github.com/aspect-build/rules_js/issues/2933).
+
+### Test frameworks that report their own coverage
+
+A test program that writes lcov directly to `$COVERAGE_OUTPUT_FILE` (jest, nyc, ...)
+owns that report, and rules_js will not overwrite it — but only while
+post-processing runs alongside the test. Under
+`--experimental_split_coverage_postprocessing` (required for remote execution, along
+with `--experimental_fetch_all_coverage_outputs`) Bazel discards whatever the test
+wrote there and publishes the report rules_js generated instead. Rulesets in that
+situation, such as
+[rules_jest](https://github.com/aspect-build/rules_jest), handle coverage themselves
+rather than relying on the rules_js implementation.

--- a/e2e/coverage/test.sh
+++ b/e2e/coverage/test.sh
@@ -16,11 +16,8 @@ set -o errexit -o nounset -o pipefail
 # Coverage is checked twice: inline (the _lcov_merger runs in the test action) and
 # split (--experimental_split_coverage_postprocessing, required for remote
 # execution), where the merger runs as its own action without the test's runfiles.
-#
-# Split mode currently reports empty coverage for every target -- the merger runs
-# where neither the V8 data nor the instrumented sources are reachable. That is
-# https://github.com/aspect-build/rules_js/issues/2901, asserted here as BROKEN so
-# the fix for it shows up as a change to this file.
+# Both must report the same coverage: the report is generated in the test action,
+# and the merger only publishes it.
 
 readonly WORKING_TARGETS=(//:test //:expected_exit_test //:first_party_jslib_test)
 readonly UNSUPPORTED_TARGETS=(//:first_party_npmpkg_test)
@@ -75,18 +72,6 @@ check_unsupported() {
     fi
 }
 
-# A scenario that should work but does not yet; fails once it starts working so the
-# expectation is updated with the fix rather than left behind.
-check_broken() {
-    local target="$1" mode="$2" issue="$3" dat="$testlogs/${1#//:}/coverage.dat" reason
-    if reason="$(coverage_is_real "$dat")"; then
-        echo "BROKEN($target, $mode) now produces coverage — $issue is fixed, assert it instead."
-        exit 1
-    else
-        echo "BROKEN($target, $mode): empty coverage, see $issue ($reason)"
-    fi
-}
-
 # The code under test executes in every scenario. If this passes but coverage below
 # is empty, the failure is in coverage reporting, not test execution.
 bazel test --nocache_test_results "${ALL_TARGETS[@]}"
@@ -106,6 +91,5 @@ bazel coverage --nocache_test_results \
     --experimental_split_coverage_postprocessing \
     --experimental_fetch_all_coverage_outputs \
     "${ALL_TARGETS[@]}"
-readonly ISSUE_2901=https://github.com/aspect-build/rules_js/issues/2901
-for t in "${WORKING_TARGETS[@]}"; do check_broken "$t" split "$ISSUE_2901"; done
+for t in "${WORKING_TARGETS[@]}"; do assert_coverage "$t" split; done
 for t in "${UNSUPPORTED_TARGETS[@]}"; do check_unsupported "$t" split; done

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -2,17 +2,9 @@ import { Report } from 'c8'
 import fs from 'fs'
 import path from 'path'
 
-// bazel will create the COVERAGE_OUTPUT_FILE whilst setting up the sandbox.
-// therefore, should be doing a file size check rather than presence.
-try {
-    const stats = fs.statSync(process.env.COVERAGE_OUTPUT_FILE)
-    if (stats.size != 0) {
-        // early exit here does not affect the outcome of the tests.
-        // bazel will only execute _lcov_merger when tests pass.
-        process.exit(0)
-    }
-    // in case file doesn't exist or some other error is thrown, just ignore it.
-} catch {}
+// Runs in the test action, the only place the V8 data and instrumented sources are
+// both present. coverage.sh.tpl reads back this exact filename; keep them in sync.
+const stash = path.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov')
 
 const include = fs
     .readFileSync(process.env.COVERAGE_MANIFEST)
@@ -40,10 +32,7 @@ new Report({
 })
     .run()
     .then(() => {
-        fs.renameSync(
-            path.join(process.env.COVERAGE_DIR, 'lcov.info'),
-            process.env.COVERAGE_OUTPUT_FILE
-        )
+        fs.renameSync(path.join(process.env.COVERAGE_DIR, 'lcov.info'), stash)
     })
     .catch((err) => {
         console.error(err)

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16067,17 +16067,9 @@ function requireC8 () {
 
 var c8Exports = requireC8();
 
-// bazel will create the COVERAGE_OUTPUT_FILE whilst setting up the sandbox.
-// therefore, should be doing a file size check rather than presence.
-try {
-    const stats = require$$0$1.statSync(process.env.COVERAGE_OUTPUT_FILE);
-    if (stats.size != 0) {
-        // early exit here does not affect the outcome of the tests.
-        // bazel will only execute _lcov_merger when tests pass.
-        process.exit(0);
-    }
-    // in case file doesn't exist or some other error is thrown, just ignore it.
-} catch {}
+// Runs in the test action, the only place the V8 data and instrumented sources are
+// both present. coverage.sh.tpl reads back this exact filename; keep them in sync.
+const stash = require$$0$2.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov');
 
 const include = require$$0$1
     .readFileSync(process.env.COVERAGE_MANIFEST)
@@ -16105,10 +16097,7 @@ new c8Exports.Report({
 })
     .run()
     .then(() => {
-        require$$0$1.renameSync(
-            require$$0$2.join(process.env.COVERAGE_DIR, 'lcov.info'),
-            process.env.COVERAGE_OUTPUT_FILE
-        );
+        require$$0$1.renameSync(require$$0$2.join(process.env.COVERAGE_DIR, 'lcov.info'), stash);
     })
     .catch((err) => {
         console.error(err);

--- a/js/private/coverage/coverage.sh.tpl
+++ b/js/private/coverage/coverage.sh.tpl
@@ -2,58 +2,34 @@
 
 set -o pipefail -o errexit -o nounset
 
-function logf_stderr {
-    local format_string="$1\n"
-    shift
-    # shellcheck disable=SC2059
-    printf "$format_string" "$@" >&2
-}
+# The _lcov_merger step: publishes the lcov report the test action already generated
+# (see coverage.js). Computes nothing, so it needs no node or runfiles. See #2901.
+#
+# The only placeholder is the trailing comment, so this file is valid bash as-is,
+# letting shellcheck lint it directly rather than a snapshot of its expansion.
 
-function logf_fatal {
-    printf "FATAL: " >&2
-    logf_stderr "$@"
-}
-
-# ==============================================================================
-# Initialize RUNFILES environment variable
-# ==============================================================================
-{{initialize_runfiles}}
-
-# When --experimental_split_coverage_postprocessing is enabled, bazel creates
-# separate runfiles directory for the coverage merger. 
-# When --experimental_split_coverage_postprocessing is disabled we observe the issue 
-# in https://github.com/bazelbuild/bazel/issues/4033
-if [ $SPLIT_COVERAGE_POST_PROCESSING == 1 ]; then
-    RUNFILES=$(_normalize_path "$LCOV_MERGER.runfiles")
-fi
-
-JS_COVERAGE__RUNFILES="$RUNFILES"
-export JS_COVERAGE__RUNFILES
-
-# ==============================================================================
-# Prepare to run coverage program
-# ==============================================================================
-
-entry_point="$RUNFILES/{{workspace_name}}/{{entry_point_path}}"
-if [ ! -f "$entry_point" ]; then
-    printf "FATAL: the entry_point '%s' not found in runfiles" "$entry_point"
+# Bazel always sets both for an _lcov_merger; fail legibly rather than with an
+# unbound-variable error if this is run outside a coverage run.
+if [ -z "${COVERAGE_DIR:-}" ] || [ -z "${COVERAGE_OUTPUT_FILE:-}" ]; then
+    printf "FATAL: COVERAGE_DIR and COVERAGE_OUTPUT_FILE must both be set; this script is only usable as a bazel _lcov_merger\n" >&2
     exit 1
 fi
 
-node="$RUNFILES/{{workspace_name}}/{{node}}"
-if [ ! -f "$node" ]; then
-    logf_fatal "node binary '%s' not found in runfiles" "$node"
-    exit 1
-fi
-if [ ! -x "$node" ]; then
-    logf_fatal "node binary '%s' is not executable" "$node"
-    exit 1
-fi
+# COVERAGE_DIR is the only channel bazel carries from the test action to this one.
+# coverage.js writes this exact filename; keep the two in sync.
+stash="$COVERAGE_DIR/_rules_js_report.lcov"
 
-# ==============================================================================
-# Run the coverage program
-# ==============================================================================
-
-"$node" "$entry_point"
+if [ -s "$COVERAGE_OUTPUT_FILE" ]; then
+    # The test reported its own coverage (jest, nyc, ...); it owns the output file.
+    # See https://github.com/aspect-build/rules_js/pull/430.
+    :
+elif [ -s "$stash" ]; then
+    # cp, not mv: an executor is free to materialize COVERAGE_DIR read-only.
+    cp "$stash" "$COVERAGE_OUTPUT_FILE"
+elif [ ! -e "$stash" ]; then
+    # No stash at all: coverage.js never ran, so the test rule is missing a
+    # _coverage_report attr. An empty stash means it ran with nothing to report.
+    printf "WARNING: no coverage report was generated in the test action, reporting empty coverage. See https://github.com/aspect-build/rules_js/issues/2901\n" >&2
+fi
 
 #{{merge_assertions}}

--- a/js/private/coverage/merger.bzl
+++ b/js/private/coverage/merger.bzl
@@ -1,12 +1,10 @@
 "Internal use only"
 
-# Simple binary that call coverage.js with node toolchain
+# Publishes the lcov report generated in the test action; see coverage.js and #2901.
 load("@bazel_lib//lib:windows_utils.bzl", "create_windows_native_launcher_script")
-load("//js/private:bash.bzl", "BASH_INITIALIZE_RUNFILES")
 
 _ATTRS = {
-    "entry_point": attr.label(default = Label("//js/private/coverage:coverage.js"), allow_single_file = [".js"]),
-    # Test-only: bash appended after the merger runs, with COVERAGE_DIR and
+    # Test-only: bash appended after the report is published, with COVERAGE_DIR and
     # COVERAGE_OUTPUT_FILE set. See //js/private/test/coverage.
     "merge_assertions": attr.string(),
     "_launcher_template": attr.label(
@@ -18,9 +16,6 @@ _ATTRS = {
 
 def _coverage_merger_impl(ctx):
     is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
-    nodeinfo = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo
-
-    node_path = nodeinfo.node.short_path if nodeinfo.node else nodeinfo.node_path
 
     # The '_' avoids collisions with another file matching the label name.
     # For example, test and test/my.spec.ts. This naming scheme is borrowed from rules_go:
@@ -32,24 +27,14 @@ def _coverage_merger_impl(ctx):
         substitutions = {
             # The '#' is part of the placeholder; see coverage.sh.tpl.
             "#{{merge_assertions}}": ctx.attr.merge_assertions,
-            "{{entry_point_path}}": ctx.file.entry_point.short_path,
-            "{{initialize_runfiles}}": BASH_INITIALIZE_RUNFILES,
-            "{{node}}": node_path,
-            "{{workspace_name}}": ctx.workspace_name,
         },
         is_executable = True,
     )
 
     launcher = create_windows_native_launcher_script(ctx, bash_launcher) if is_windows else bash_launcher
 
-    runfiles = [ctx.file.entry_point]
-
-    if is_windows:
-        # The .bat launcher resolves the bash script through its own runfiles.
-        runfiles.append(bash_launcher)
-
-    if nodeinfo.node:
-        runfiles.append(nodeinfo.node)
+    # The .bat launcher resolves the bash script through its own runfiles.
+    runfiles = [bash_launcher] if is_windows else []
 
     return DefaultInfo(
         executable = launcher,
@@ -63,6 +48,5 @@ coverage_merger = rule(
     toolchains = [
         # Optional: only referenced on Windows, to wrap the bash script in a .bat launcher.
         config_common.toolchain_type("@bazel_tools//tools/sh:toolchain_type", mandatory = False),
-        "@rules_nodejs//nodejs:toolchain_type",
     ],
 )

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -283,6 +283,12 @@ def _expand_env_if_needed(ctx, value):
 def _bash_quote(value):
     return json.encode(value)
 
+def _generates_coverage_report(ctx):
+    """Whether the launcher generates the lcov report in the test action. See #2901."""
+    return (hasattr(ctx.file, "_coverage_report") and
+            ctx.attr.testonly and
+            ctx.configuration.coverage_enabled)
+
 def _bash_launcher(ctx, nodeinfo, entry_point_path, log_prefix_rule_set, log_prefix_rule, fixed_args, fixed_env, is_windows):
     # Explicitly disable node fs patches on Windows:
     # https://github.com/aspect-build/rules_js/issues/1137
@@ -418,7 +424,13 @@ def _bash_launcher(ctx, nodeinfo, entry_point_path, log_prefix_rule_set, log_pre
 
     node_path = nodeinfo.node.short_path if nodeinfo.node else nodeinfo.node_path
 
+    if _generates_coverage_report(ctx):
+        coverage_entry_point = "/".join([ctx.workspace_name, ctx.file._coverage_report.short_path])
+    else:
+        coverage_entry_point = ""
+
     launcher_subst = {
+        "{{coverage_entry_point}}": coverage_entry_point,
         "{{target_label}}": str(ctx.label),
         "{{template_label}}": str(ctx.attr._launcher_template.label),
         "{{entry_point_label}}": str(ctx.attr.entry_point.label),
@@ -546,6 +558,12 @@ def _js_binary_impl(ctx):
         # TODO: Remove once bazel<8 support is dropped.
         if hasattr(ctx.attr, "_lcov_merger"):
             runfiles = runfiles.merge(ctx.attr._lcov_merger[DefaultInfo].default_runfiles)
+
+        # The launcher runs coverage.js after the test to generate the report, so
+        # it must be in the test's runfiles. See #2901.
+        if _generates_coverage_report(ctx):
+            runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file._coverage_report]))
+
         providers.append(
             coverage_common.instrumented_files_info(
                 ctx,
@@ -604,6 +622,13 @@ js_test = rule(
             executable = True,
             default = Label("//js/private/coverage:merger"),
             cfg = "exec",
+        ),
+        # Run by the launcher in the test action to generate the lcov report, which
+        # _lcov_merger above then publishes. A test rule built on js_binary_lib needs
+        # both halves. See #2901.
+        "_coverage_report": attr.label(
+            default = Label("//js/private/coverage:coverage.js"),
+            allow_single_file = [".js"],
         ),
     }),
     test = True,

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -478,6 +478,29 @@ wait "$child"
 RESULT="$?"
 set -e
 
+# Generate the lcov report for a passing test; empty when not collecting coverage. See #2901.
+coverage_entry_point="{{coverage_entry_point}}"
+
+if [ -n "$coverage_entry_point" ] && [ "$RESULT" = "${JS_BINARY__EXPECTED_EXIT_CODE:-0}" ] && [ -n "${COVERAGE_DIR:-}" ] &&
+    # A test reporting its own coverage owns it, except in split mode where bazel drops it.
+    { [ ! -s "${COVERAGE_OUTPUT_FILE:-}" ] || [ "${SPLIT_COVERAGE_POST_PROCESSING:-0}" = "1" ]; }; then
+    coverage_entry_point="$JS_BINARY__RUNFILES/$coverage_entry_point"
+    if [ ! -f "$coverage_entry_point" ]; then
+        # Report empty coverage rather than fail an otherwise passing test.
+        logf_error "coverage report generator '%s' not found; code coverage requires a runfiles tree" "$coverage_entry_point"
+    else
+        # NODE_V8_COVERAGE unset so this process writes no profile of its own.
+        (
+            unset NODE_V8_COVERAGE
+            export JS_COVERAGE__RUNFILES="$JS_BINARY__RUNFILES"
+            exec "$JS_BINARY__NODE_BINARY" "$coverage_entry_point"
+        ) || {
+            logf_error "coverage report generation failed"
+            exit 1
+        }
+    fi
+fi
+
 # ==============================================================================
 # Mop up after main program
 # ==============================================================================

--- a/js/private/test/BUILD.bazel
+++ b/js/private/test/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_lib_host//:defs.bzl", "host")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//js:defs.bzl", "js_binary", "js_library", "js_test")
 load(":js_library_test.bzl", "js_library_test_suite")
 load(":run_environment_info_test.bzl", "run_environment_info_test_suite")
@@ -37,6 +38,19 @@ write_source_files(
     files = {
         "snapshots/launcher.sh": ":shell_launcher_sed",
     },
+)
+
+# Drives the merger's branches directly. //js/private/test/coverage covers them
+# too, but only under `bazel coverage`, which CI runs on one matrix leg.
+sh_test(
+    name = "coverage_merger_test",
+    srcs = ["coverage_merger_test.sh"],
+    args = ["$(rootpath //js/private/coverage:merger)"],
+    data = ["//js/private/coverage:merger"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 js_library_test_suite(name = "js_library_test")

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -1,27 +1,41 @@
 load("//js/private/coverage:merger.bzl", "coverage_merger")
 load(":merger_test.bzl", "merger_test_suite")
-load(":test.bzl", "coverage_pass_test", "coverage_preexisting_test")
+load(":test.bzl", "coverage_no_report_test", "coverage_pass_test", "coverage_preexisting_test")
 
 package(default_testonly = True)
 
 merger_test_suite(name = "merger_test")
 
 # The test program reported its own coverage to COVERAGE_OUTPUT_FILE, so the merger
-# must publish that report rather than the c8 one.
-# See https://github.com/aspect-build/rules_js/pull/430.
+# must publish that report rather than the c8 one. See
+# https://github.com/aspect-build/rules_js/pull/430. Under
+# --experimental_split_coverage_postprocessing bazel discards what the test wrote, so
+# the c8 report is published instead; SPLIT_COVERAGE_POST_PROCESSING tells them apart.
 coverage_merger(
     name = "preexisting_merger",
     merge_assertions = """\
-grep -q '^# reported by the test itself$' "$COVERAGE_OUTPUT_FILE" || {
-    echo "the test's own report was overwritten with:" >&2
-    cat "$COVERAGE_OUTPUT_FILE" >&2
-    exit 1
-}
-! grep -q '^SF:' "$COVERAGE_OUTPUT_FILE" || {
-    echo "the c8 report was merged into the test's own:" >&2
-    cat "$COVERAGE_OUTPUT_FILE" >&2
-    exit 1
-}
+if [ "${SPLIT_COVERAGE_POST_PROCESSING:-0}" = "1" ]; then
+    grep -q '^SF:js/private/test/coverage/preexisting.js$' "$COVERAGE_OUTPUT_FILE" || {
+        echo "expected the c8 report for preexisting.js, got:" >&2
+        cat "$COVERAGE_OUTPUT_FILE" >&2
+        exit 1
+    }
+else
+    grep -q '^# reported by the test itself$' "$COVERAGE_OUTPUT_FILE" || {
+        echo "expected the report the test wrote, got:" >&2
+        cat "$COVERAGE_OUTPUT_FILE" >&2
+        exit 1
+    }
+    ! grep -q '^SF:' "$COVERAGE_OUTPUT_FILE" || {
+        echo "the c8 report was merged into the test's own:" >&2
+        cat "$COVERAGE_OUTPUT_FILE" >&2
+        exit 1
+    }
+    [ ! -e "$COVERAGE_DIR/_rules_js_report.lcov" ] || {
+        echo "the report was generated even though the test wrote its own" >&2
+        exit 1
+    }
+fi
 """,
     visibility = ["//visibility:public"],
 )
@@ -36,20 +50,53 @@ coverage_preexisting_test(
     entry_point = "preexisting.js",
 )
 
-# The merger publishes the c8 report, so COVERAGE_OUTPUT_FILE must hold real lcov.
-# The SF: check is a directory prefix so any entry_point in this package works.
+# The test action generates + stashes the report, the merger publishes it, and
+# COVERAGE_OUTPUT_FILE must then hold the real lcov report. The SF: check is a
+# directory prefix so any entry_point in this package works.
 coverage_merger(
     name = "pass_merger",
     merge_assertions = """\
 grep -q '^SF:js/private/test/coverage/' "$COVERAGE_OUTPUT_FILE" || { echo "expected SF: under this package" >&2; exit 1; }
 grep -Eq '^DA:[0-9]+,[1-9]' "$COVERAGE_OUTPUT_FILE" || { echo "expected an executed line" >&2; exit 1; }
 grep -Eq '^DA:[0-9]+,0' "$COVERAGE_OUTPUT_FILE" || { echo "expected an unexecuted line" >&2; exit 1; }
+
+# The launcher clears NODE_V8_COVERAGE before running coverage.js, so coverage.js
+# must not have written its own profile alongside the ones it just read.
+if grep -l 'js/private/coverage/coverage.js' "$COVERAGE_DIR"/coverage-*.json >/dev/null 2>&1; then
+    echo "coverage.js wrote its own V8 profile into COVERAGE_DIR:" >&2
+    grep -l 'js/private/coverage/coverage.js' "$COVERAGE_DIR"/coverage-*.json >&2
+    exit 1
+fi
 """,
     visibility = ["//visibility:public"],
 )
 
 coverage_pass_test(
     name = "pass",
+    data = ["lib.js"],
+    enable_runfiles = select({
+        "@bazel_lib//lib:enable_runfiles": True,
+        "//conditions:default": False,
+    }),
+    entry_point = "lib.js",
+)
+
+# coverage_no_report_test has no _coverage_report, so the test action stashes nothing
+# and the merger must leave the empty COVERAGE_OUTPUT_FILE bazel created in place.
+coverage_merger(
+    name = "no_report_merger",
+    merge_assertions = """\
+if [ -s "$COVERAGE_OUTPUT_FILE" ]; then
+    echo "expected empty coverage output, got:" >&2
+    cat "$COVERAGE_OUTPUT_FILE" >&2
+    exit 1
+fi
+""",
+    visibility = ["//visibility:public"],
+)
+
+coverage_no_report_test(
+    name = "no_report",
     data = ["lib.js"],
     enable_runfiles = select({
         "@bazel_lib//lib:enable_runfiles": True,

--- a/js/private/test/coverage/test.bzl
+++ b/js/private/test/coverage/test.bzl
@@ -3,19 +3,27 @@
 load("//js/private:js_binary.bzl", "js_binary_lib")
 
 # _lcov_merger must be a private attribute, so each merger needs its own rule.
-def _coverage_test(merger):
+def _coverage_test(merger, coverage_report = True):
+    attrs = {
+        "_lcov_merger": attr.label(
+            executable = True,
+            default = Label("//js/private/test/coverage:" + merger),
+            cfg = "exec",
+        ),
+    }
+    if coverage_report:
+        # Generate + stash the report in the test action, the same as js_test.
+        attrs["_coverage_report"] = attr.label(
+            default = Label("//js/private/coverage:coverage.js"),
+            allow_single_file = [".js"],
+        )
     return rule(
         implementation = js_binary_lib.implementation,
-        attrs = dict(js_binary_lib.attrs, **{
-            "_lcov_merger": attr.label(
-                executable = True,
-                default = Label("//js/private/test/coverage:" + merger),
-                cfg = "exec",
-            ),
-        }),
+        attrs = dict(js_binary_lib.attrs, **attrs),
         test = True,
         toolchains = js_binary_lib.toolchains,
     )
 
 coverage_preexisting_test = _coverage_test("preexisting_merger")
 coverage_pass_test = _coverage_test("pass_merger")
+coverage_no_report_test = _coverage_test("no_report_merger", coverage_report = False)

--- a/js/private/test/coverage_merger_test.sh
+++ b/js/private/test/coverage_merger_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Unit tests for the _lcov_merger script (js/private/coverage/coverage.sh.tpl).
+# It is pure bash reading COVERAGE_DIR/COVERAGE_OUTPUT_FILE, so its branches can be
+# driven directly here rather than only through a `bazel coverage` run, which
+# //js/private/test/coverage does but only on CI's one coverage leg.
+
+set -o errexit -o nounset -o pipefail
+
+merger="$PWD/$1"
+
+die() {
+    printf "FAIL: %s\n" "$*" >&2
+    exit 1
+}
+
+# Runs the merger in a fresh COVERAGE_DIR. Sets `output` to the published report and
+# `stderr` to what the merger wrote to stderr.
+#
+# $1: contents of COVERAGE_OUTPUT_FILE before the merger runs.
+# $2: contents of the stashed report, or the literal "<none>" for no stash at all.
+run_merger() {
+    dir="$(mktemp -d "${TEST_TMPDIR:-/tmp}/merger.XXXXXX")"
+    printf "%s" "$1" >"$dir/coverage.dat"
+    [ "$2" = "<none>" ] || printf "%s" "$2" >"$dir/_rules_js_report.lcov"
+
+    stderr="$(COVERAGE_DIR="$dir" COVERAGE_OUTPUT_FILE="$dir/coverage.dat" "$merger" 2>&1 >/dev/null)"
+    output="$(cat "$dir/coverage.dat")"
+}
+
+# The test program wrote its own report; the merger must not overwrite it.
+# https://github.com/aspect-build/rules_js/pull/430
+run_merger "# from the test itself" "SF:c8.js"
+[ "$output" = "# from the test itself" ] || die "the test's own report was overwritten with '$output'"
+
+# Same, with no stash at all: a rule that publishes a report it never generates still
+# must not clobber what the test wrote, and has nothing to warn about.
+run_merger "# from the test itself" "<none>"
+[ "$output" = "# from the test itself" ] || die "the test's own report was overwritten with '$output'"
+[ "$stderr" = "" ] || die "the test's own report: expected no warning, got '$stderr'"
+
+# Nothing in COVERAGE_OUTPUT_FILE, a real stash: publish the stash.
+run_merger "" "SF:c8.js"
+[ "$output" = "SF:c8.js" ] || die "expected the stash to be published, got '$output'"
+# cp, not mv: COVERAGE_DIR may be materialized read-only by the executor.
+[ -e "$dir/_rules_js_report.lcov" ] || die "the stash was consumed (mv) rather than copied (cp)"
+
+# coverage.js ran but had nothing to report: empty coverage, but not a misconfigured
+# rule, so no warning.
+run_merger "" ""
+[ "$output" = "" ] || die "empty stash: expected empty coverage, got '$output'"
+[ "$stderr" = "" ] || die "empty stash: expected no warning, got '$stderr'"
+
+# No stash at all: the test rule wired up _lcov_merger without _coverage_report.
+run_merger "" "<none>"
+[ "$output" = "" ] || die "no stash: expected empty coverage, got '$output'"
+case "$stderr" in
+*"WARNING: no coverage report was generated in the test action"*) ;;
+*) die "no stash: expected a warning about the missing report, got '$stderr'" ;;
+esac
+
+# Run outside a coverage run: a legible error, not an unbound-variable failure or a
+# stash path resolved against the filesystem root.
+expect_fatal() {
+    local status=0
+    local stderr
+    stderr="$("$@" "$merger" 2>&1 >/dev/null)" || status=$?
+    [ "$status" = 1 ] || die "$1 $2: expected exit 1, got $status"
+    case "$stderr" in
+    *"FATAL: COVERAGE_DIR and COVERAGE_OUTPUT_FILE must both be set"*) ;;
+    *) die "$1 $2: expected a FATAL message, got '$stderr'" ;;
+    esac
+}
+
+expect_fatal env -u COVERAGE_DIR COVERAGE_OUTPUT_FILE=/dev/null
+expect_fatal env -u COVERAGE_OUTPUT_FILE COVERAGE_DIR=/dev/null

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -598,6 +598,29 @@ wait "$child"
 RESULT="$?"
 set -e
 
+# Generate the lcov report for a passing test; empty when not collecting coverage. See #2901.
+coverage_entry_point=""
+
+if [ -n "$coverage_entry_point" ] && [ "$RESULT" = "${JS_BINARY__EXPECTED_EXIT_CODE:-0}" ] && [ -n "${COVERAGE_DIR:-}" ] &&
+    # A test reporting its own coverage owns it, except in split mode where bazel drops it.
+    { [ ! -s "${COVERAGE_OUTPUT_FILE:-}" ] || [ "${SPLIT_COVERAGE_POST_PROCESSING:-0}" = "1" ]; }; then
+    coverage_entry_point="$JS_BINARY__RUNFILES/$coverage_entry_point"
+    if [ ! -f "$coverage_entry_point" ]; then
+        # Report empty coverage rather than fail an otherwise passing test.
+        logf_error "coverage report generator '%s' not found; code coverage requires a runfiles tree" "$coverage_entry_point"
+    else
+        # NODE_V8_COVERAGE unset so this process writes no profile of its own.
+        (
+            unset NODE_V8_COVERAGE
+            export JS_COVERAGE__RUNFILES="$JS_BINARY__RUNFILES"
+            exec "$JS_BINARY__NODE_BINARY" "$coverage_entry_point"
+        ) || {
+            logf_error "coverage report generation failed"
+            exit 1
+        }
+    fi
+fi
+
 # ==============================================================================
 # Mop up after main program
 # ==============================================================================


### PR DESCRIPTION
Fix #2901
Fix #965
Ref #2933
Close #2904
Close #991

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed `bazel coverage` returning empty (0%) reports under split-postprocessing and remote execution.

### Test plan

- Covered by existing test cases
- New test cases added
