### PR TITLE
ci: enable macos unit tests on main module

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -254,19 +254,26 @@ jobs:
                     echo "No test.sh in ${PWD}; skipping"
                   fi
 
-    # Mac/Windows smoke tests - only e2e/bzlmod
+    # Mac/Windows smoke tests for the root workspace and e2e/bzlmod.
     # Only run on main branch (not PRs) to minimize minutes (billed at 10X and 2X respectively)
+    # unless the branch name contains 'macos' or 'windows'.
     # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
     smoke:
+        name: smoke (${{ matrix.workspace.path }}, ${{ matrix.os }})
         if: github.ref_name == 'main' || contains(github.head_ref, 'macos') || contains(github.head_ref, 'windows')
         runs-on: ${{ matrix.os }}
-        defaults:
-            run:
-                working-directory: e2e/bzlmod
         strategy:
             fail-fast: false
             matrix:
                 os: [macos-latest, windows-latest]
+                workspace:
+                    - { path: ., slug: root }
+                    - { path: e2e/bzlmod, slug: bzlmod }
+                exclude:
+                    # The root workspace only builds cleanly on macOS for now; Windows has broad
+                    # pre-existing failures. e2e/bzlmod still smoke-tests on both OSes.
+                    - os: windows-latest
+                      workspace: { path: ., slug: root }
         env:
             ASPECT_RULES_JS_FROZEN_PNPM_LOCK: 1
         steps:
@@ -275,11 +282,12 @@ jobs:
             - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
               with:
                   bazelisk-cache: true
-                  disk-cache: ${{ matrix.os }}-bzlmod
+                  disk-cache: ${{ matrix.os }}-${{ matrix.workspace.slug }}
                   repository-cache: true
 
             - name: bazel test //...
               shell: bash
+              working-directory: ${{ matrix.workspace.path }}
               run: |
                   bazel test \
                     --test_tag_filters=-skip-on-bazel7 \

--- a/js/private/test/image/BUILD.bazel
+++ b/js/private/test/image/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//js:defs.bzl", "js_binary")
-load(":asserts.bzl", "assert_checksum", "assert_js_image_layer_listings", "make_js_image_layer")
+load(":asserts.bzl", "SKIP_ON_WINDOWS", "assert_checksum", "assert_js_image_layer_listings", "make_js_image_layer")
 
 npm_link_all_packages()
 
@@ -11,6 +11,7 @@ js_binary(
         ":node_modules",
     ],
     entry_point = "main.js",
+    target_compatible_with = SKIP_ON_WINDOWS,
 )
 
 platform(
@@ -127,6 +128,7 @@ platform_transition_filegroup(
     name = "transition_js_image_layer_linux_amd64",
     testonly = True,
     srcs = [":js_image_layer_untransitioned"],
+    target_compatible_with = SKIP_ON_WINDOWS,
     target_platform = ":linux_amd64",
 )
 
@@ -134,5 +136,6 @@ platform_transition_filegroup(
     name = "transition_js_image_layer_linux_arm64",
     testonly = True,
     srcs = [":js_image_layer_untransitioned"],
+    target_compatible_with = SKIP_ON_WINDOWS,
     target_platform = ":linux_arm64",
 )

--- a/js/private/test/image/asserts.bzl
+++ b/js/private/test/image/asserts.bzl
@@ -3,6 +3,13 @@
 load("@bazel_lib//lib:write_source_files.bzl", "write_source_file", "write_source_files")
 load("//js:defs.bzl", "js_image_layer")
 
+# These fixtures build Linux OCI layers from non-portable inputs (non-ASCII filenames, bsdtar
+# listings) that don't resolve on a Windows host, so skip the whole image test tree on Windows.
+SKIP_ON_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
 # js_binary launcher scripts have unstable sizes across Bazel versions.
 _UNSTABLE_SIZE_BASENAMES = ["bin", "bin2"]
 
@@ -32,6 +39,7 @@ def assert_tar_listing(name, actual, expected):
         # See: https://github.com/aspect-build/rules_js/actions/runs/11749187598/job/32734931009?pr=2011
         cmd = 'TZ="UTC" LC_ALL="en_US.UTF-8" $(BSDTAR_BIN) -tvf $(execpath {}) --exclude "**/_repo_mapping" | {} >$@'.format(actual, sanitize_cmd),
         toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
+        target_compatible_with = SKIP_ON_WINDOWS,
     )
 
     write_source_file(
@@ -39,6 +47,7 @@ def assert_tar_listing(name, actual, expected):
         in_file = actual_listing,
         out_file = expected,
         testonly = True,
+        target_compatible_with = SKIP_ON_WINDOWS,
     )
 
 layers = [
@@ -66,6 +75,7 @@ def assert_js_image_layer_listings(name, js_image_layer, additional_layers = [])
             for layer in all_layers
         ],
         testonly = True,
+        target_compatible_with = SKIP_ON_WINDOWS,
     )
 
 # buildifier: disable=function-docstring
@@ -79,6 +89,7 @@ def make_js_image_layer(name, layer_groups = {}, **kwargs):
             "no-remote-exec",
         ],
         layer_groups = layer_groups,
+        target_compatible_with = SKIP_ON_WINDOWS,
         **kwargs
     )
 
@@ -88,6 +99,7 @@ def make_js_image_layer(name, layer_groups = {}, **kwargs):
             srcs = [name],
             output_group = layer,
             testonly = 1,
+            target_compatible_with = SKIP_ON_WINDOWS,
         )
 
 def assert_checksum(name, image_layer):
@@ -107,6 +119,7 @@ echo "$${RESULT//$$BINDIR/}" | $$COREUTILS_BIN head -n -1 > $@
     """,
         output_to_bindir = True,
         toolchains = ["@coreutils_toolchains//:resolved_toolchain"],
+        target_compatible_with = SKIP_ON_WINDOWS,
     )
 
     write_source_file(
@@ -115,4 +128,5 @@ echo "$${RESULT//$$BINDIR/}" | $$COREUTILS_BIN head -n -1 > $@
         in_file = name,
         out_file = name + ".expected",
         tags = ["skip-on-bazel8", "skip-on-bazel9"],
+        target_compatible_with = SKIP_ON_WINDOWS,
     )

--- a/js/private/test/image/non_ascii/BUILD.bazel
+++ b/js/private/test/image/non_ascii/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//js:defs.bzl", "js_binary")
-load("//js/private/test/image:asserts.bzl", "assert_js_image_layer_listings", "make_js_image_layer")
+load("//js/private/test/image:asserts.bzl", "SKIP_ON_WINDOWS", "assert_js_image_layer_listings", "make_js_image_layer")
 
 # Case 3: Layer groups
 # bazel run //js/private/test/image/non_ascii:custom_layer_groups_test_update_all
@@ -10,6 +10,7 @@ js_binary(
         "ㅑㅕㅣㅇ.ㄴㅅ",
     ],
     entry_point = "main.js",
+    target_compatible_with = SKIP_ON_WINDOWS,
 )
 
 make_js_image_layer(

--- a/js/private/test/image/platform_deps/BUILD.bazel
+++ b/js/private/test/image/platform_deps/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//js:defs.bzl", "js_binary")
-load("//js/private/test/image:asserts.bzl", "assert_js_image_layer_listings", "make_js_image_layer")
+load("//js/private/test/image:asserts.bzl", "SKIP_ON_WINDOWS", "assert_js_image_layer_listings", "make_js_image_layer")
 
 npm_link_all_packages()
 
@@ -10,6 +10,7 @@ js_binary(
         ":node_modules/@rspack/cli",
     ],
     entry_point = "main.js",
+    target_compatible_with = SKIP_ON_WINDOWS,
 )
 
 # Verify that the arm64 binding is selected when targeting linux/arm64.

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -52,6 +52,12 @@ write_source_files(
         "skip-on-bazel8",
         "skip-on-bazel9",
     ],
+    # The generated defs.bzl enumerates host-platform-specific optional packages, so these snapshots
+    # (checked in from Linux/macOS) don't match on Windows; skip them there rather than maintain a variant.
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 build_test(


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
