### PR TITLE
fix: do not assume testonly=False in macros to support default_testonly

### DIFF
--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -280,8 +280,7 @@ def js_run_binary(
             include_npm_sources = include_npm_sources,
             # Always tag the target manual since we should only build it when the final target is built.
             tags = kwargs.get("tags", []) + ["manual"],
-            # Always propagate the testonly attribute
-            testonly = kwargs.get("testonly", False),
+            testonly = kwargs.get("testonly"),
         )
         extra_srcs.append(":{}".format(js_info_files_name))
 
@@ -293,8 +292,7 @@ def js_run_binary(
             srcs = srcs,
             # Always tag the target manual since we should only build it when the final target is built.
             tags = kwargs.get("tags", []) + ["manual"],
-            # Always propagate the testonly attribute
-            testonly = kwargs.get("testonly", False),
+            testonly = kwargs.get("testonly"),
         )
         extra_srcs.append(":{}".format(copy_to_bin_name))
 
@@ -368,8 +366,7 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
             srcs = [tool],
             # Always tag the target manual since we should only build it when the final target is built.
             tags = kwargs.get("tags", []) + ["manual"],
-            # Always propagate the testonly attribute
-            testonly = kwargs.get("testonly", False),
+            testonly = kwargs.get("testonly"),
         )
         js_runfiles_name = "{}_runfiles".format(name)
         native.filegroup(
@@ -378,8 +375,7 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
             srcs = [":{}".format(js_runfiles_lib_name)],
             # Always tag the target manual since we should only build it when the final target is built.
             tags = kwargs.get("tags", []) + ["manual"],
-            # Always propagate the testonly attribute
-            testonly = kwargs.get("testonly", False),
+            testonly = kwargs.get("testonly"),
         )
 
         if use_execroot_entry_point == True:

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -1,6 +1,8 @@
 load("//js/private/coverage:merger.bzl", "coverage_merger")
 load(":test.bzl", "coverage_fail_test", "coverage_pass_test")
 
+package(default_testonly = True)
+
 FAIL_CMD = """\
 echo "require('fs').writeFileSync(process.env.COVERAGE_OUTPUT_FILE, '# no coverage');" >> $@
 cat $(location //js/private/coverage:coverage.js) >> $@

--- a/js/private/test/create_launcher/BUILD.bazel
+++ b/js/private/test/create_launcher/BUILD.bazel
@@ -1,5 +1,7 @@
 load(":custom_test.bzl", "custom_test")
 
+package(default_testonly = True)
+
 custom_test(
     name = "test",
     entry_point = "test.js",

--- a/js/private/test/data/BUILD.bazel
+++ b/js/private/test/data/BUILD.bazel
@@ -1,6 +1,8 @@
 load("//js:defs.bzl", "js_binary", "js_library", "js_run_binary", "js_test")
 load(":data.bzl", "extract_test")
 
+package(default_testonly = True)
+
 # js_library(srcs) wrapper of the data
 js_library(
     name = "data-js_library-srcs",

--- a/js/private/test/fixed_args/BUILD.bazel
+++ b/js/private/test/fixed_args/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@bazel_lib//lib:testing.bzl", "assert_contains")
 load("//js:defs.bzl", "js_binary", "js_run_binary")
 
+package(default_testonly = True)
+
 js_binary(
     name = "fixed_args_bin",
     entry_point = "fixed_args.mjs",

--- a/js/private/test/image/BUILD.bazel
+++ b/js/private/test/image/BUILD.bazel
@@ -3,6 +3,8 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//js:defs.bzl", "js_binary")
 load(":asserts.bzl", "SKIP_ON_WINDOWS", "assert_checksum", "assert_js_image_layer_listings", "make_js_image_layer")
 
+package(default_testonly = True)
+
 npm_link_all_packages()
 
 js_binary(

--- a/js/private/test/image/non_ascii/BUILD.bazel
+++ b/js/private/test/image/non_ascii/BUILD.bazel
@@ -1,6 +1,8 @@
 load("//js:defs.bzl", "js_binary")
 load("//js/private/test/image:asserts.bzl", "SKIP_ON_WINDOWS", "assert_js_image_layer_listings", "make_js_image_layer")
 
+package(default_testonly = True)
+
 # Case 3: Layer groups
 # bazel run //js/private/test/image/non_ascii:custom_layer_groups_test_update_all
 js_binary(

--- a/js/private/test/image/platform_deps/BUILD.bazel
+++ b/js/private/test/image/platform_deps/BUILD.bazel
@@ -2,6 +2,8 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//js:defs.bzl", "js_binary")
 load("//js/private/test/image:asserts.bzl", "SKIP_ON_WINDOWS", "assert_js_image_layer_listings", "make_js_image_layer")
 
+package(default_testonly = True)
+
 npm_link_all_packages()
 
 js_binary(

--- a/js/private/test/js_run_binary/BUILD.bazel
+++ b/js/private/test/js_run_binary/BUILD.bazel
@@ -4,6 +4,8 @@ load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//js:defs.bzl", "js_binary", "js_run_binary")
 
+package(default_testonly = True)
+
 # We want to verify that a js_binary's data dependencies are found only in the
 # runfiles when use_execroot_entry_point = False. To do this we use
 # find_cfg_probe.mjs to tell us whether cfg_probe.txt landed in just the

--- a/js/private/test/js_run_devserver/BUILD.bazel
+++ b/js/private/test/js_run_devserver/BUILD.bazel
@@ -3,6 +3,8 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//js/private/test/js_run_devserver:jasmine/package_json.bzl", jasmine_bin = "bin")
 load(":js_run_devserver_test.bzl", "js_run_devserver_test")
 
+package(default_testonly = True)
+
 npm_link_all_packages()
 
 # Checks node_modules symlinks that they refer to exec root (instead of runfiles)

--- a/js/private/test/launcher/BUILD.bazel
+++ b/js/private/test/launcher/BUILD.bazel
@@ -119,7 +119,6 @@ js_binary(
 
 js_run_binary(
     name = "exit_zero_run",
-    testonly = True,
     chdir = package_name(),
     exit_code_out = "exit_zero_code.txt",
     stderr = "exit_zero_stderr.txt",
@@ -148,7 +147,6 @@ js_binary(
 
 js_run_binary(
     name = "exit_seven_run",
-    testonly = True,
     chdir = package_name(),
     exit_code_out = "exit_seven_code.txt",
     stderr = "exit_seven_stderr.txt",
@@ -177,7 +175,6 @@ js_binary(
 
 js_run_binary(
     name = "exit_expected_run",
-    testonly = True,
     chdir = package_name(),
     exit_code_out = "exit_expected_code.txt",
     stderr = "exit_expected_stderr.txt",
@@ -208,7 +205,6 @@ js_binary(
 
 js_run_binary(
     name = "exit_plain_run",
-    testonly = True,
     chdir = package_name(),
     exit_code_out = "exit_plain_code.txt",
     stderr = "exit_plain_stderr.txt",
@@ -259,7 +255,6 @@ js_binary(
 
 js_run_binary(
     name = "stdout_stderr_run",
-    testonly = True,
     chdir = package_name(),
     stderr = "stdout_stderr_stderr.txt",
     stdout = "stdout_stderr_stdout.txt",

--- a/js/private/test/no_copy_to_bin/BUILD.bazel
+++ b/js/private/test/no_copy_to_bin/BUILD.bazel
@@ -1,5 +1,7 @@
 load("//js:defs.bzl", "js_test")
 
+package(default_testonly = True)
+
 js_test(
     name = "no_copy_to_bin_test",
     data = ["//js/private/test/no_copy_to_bin/subpkg:42.js"],

--- a/js/private/test/no_copy_to_bin/subpkg/BUILD.bazel
+++ b/js/private/test/no_copy_to_bin/subpkg/BUILD.bazel
@@ -1,1 +1,3 @@
+package(default_testonly = True)
+
 exports_files(["42.js"])

--- a/js/private/test/node-patches/BUILD.bazel
+++ b/js/private/test/node-patches/BUILD.bazel
@@ -3,6 +3,8 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//js/private/test/node-patches:@babel/cli/package_json.bzl", babel_bin = "bin")
 load("//js:defs.bzl", "js_library", "js_test")
 
+package(default_testonly = True)
+
 TESTS = [
     "escape.js",
 ]

--- a/js/private/test/proto/BUILD.bazel
+++ b/js/private/test/proto/BUILD.bazel
@@ -4,6 +4,8 @@ load("//js:rpc.bzl", "js_rpc_toolchain")
 load(":js_proto_aspect_test.bzl", "js_proto_aspect_test_suite")
 load(":js_rpc_library_test.bzl", "js_rpc_library_test_suite")
 
+package(default_testonly = True)
+
 ####################################################################################################
 # Proto analysis tests
 

--- a/js/private/test/proto/other_pkg/BUILD.bazel
+++ b/js/private/test/proto/other_pkg/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
+package(default_testonly = True)
+
 write_file(
     name = "other_proto_src",
     out = "other.proto",

--- a/js/private/test/watch/BUILD.bazel
+++ b/js/private/test/watch/BUILD.bazel
@@ -1,5 +1,7 @@
 load("//js:defs.bzl", "js_test")
 
+package(default_testonly = True)
+
 js_test(
     name = "aspect_watch_protocol_test",
     data = ["//js/private/watch"],

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -437,8 +437,7 @@ def npm_package(
             include_runfiles = include_runfiles,
             # Always tag the target manual since we should only build it when the final target is built.
             tags = kwargs.get("tags", []) + ["manual"],
-            # Always propagate the testonly attribute
-            testonly = kwargs.get("testonly", False),
+            testonly = kwargs.get("testonly"),
         )
         srcs = srcs + [files_target]
 
@@ -454,7 +453,7 @@ def npm_package(
             include_npm = True,
             args = args,
             tags = kwargs.get("tags", []) + ["manual"],
-            testonly = kwargs.get("testonly", False),
+            testonly = kwargs.get("testonly"),
             visibility = kwargs.get("visibility", None),
         )
 
@@ -482,7 +481,7 @@ def npm_package(
                 pack_out,
             ],
             tags = kwargs.get("tags", []) + ["manual"],
-            testonly = kwargs.get("testonly", False),
+            testonly = kwargs.get("testonly"),
             visibility = kwargs.get("visibility", None),
         )
 


### PR DESCRIPTION
There are probably more places in other rulesets we need to be doing this...

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing
