### PR TITLE
refactor: directly run node from shell using exec when not using expected_exit_code

### DIFF
--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -447,6 +447,17 @@ export -n JS_BINARY__STDOUT_OUTPUT_FILE JS_BINARY__STDERR_OUTPUT_FILE JS_BINARY_
 
 set +e
 
+# Generate the lcov report for a passing test; empty when not collecting coverage. See #2901.
+coverage_entry_point="{{coverage_entry_point}}"
+
+if [ -z "${JS_BINARY__EXPECTED_EXIT_CODE:-}" ] && [ -z "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ] && [ -z "${STDOUT_CAPTURE:-}" ] && [ -z "${STDERR_CAPTURE:-}" ] && [ -z "$coverage_entry_point" ]; then
+    # Nothing must run after node exits, so replace this shell with node. Signals
+    # and terminal control are then delivered directly to node instead of being
+    # proxied through a backgrounded child.
+    exec "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"}
+    exit 127
+fi
+
 if [ "${STDOUT_CAPTURE:-}" ] && [ "${STDERR_CAPTURE:-}" ]; then
     "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" 2>>"$STDERR_CAPTURE" &
 elif [ "${STDOUT_CAPTURE:-}" ]; then
@@ -477,9 +488,6 @@ wait "$child"
 
 RESULT="$?"
 set -e
-
-# Generate the lcov report for a passing test; empty when not collecting coverage. See #2901.
-coverage_entry_point="{{coverage_entry_point}}"
 
 if [ -n "$coverage_entry_point" ] && [ "$RESULT" = "${JS_BINARY__EXPECTED_EXIT_CODE:-0}" ] && [ -n "${COVERAGE_DIR:-}" ] &&
     # A test reporting its own coverage owns it, except in split mode where bazel drops it.

--- a/js/private/test/launcher/BUILD.bazel
+++ b/js/private/test/launcher/BUILD.bazel
@@ -12,11 +12,11 @@ _POSIX_ONLY = select({
 })
 
 # ==================================================================================================
-# Case 1: the launcher forwards a directed termination signal to node.
+# Case 1: a directed termination signal reaches node's own handler.
 #
-# signal_driver spawns signal_target and sends the signal to the launcher PID. The launcher backgrounds
-# node and forwards trapped signals, so node's own handler runs and prints HANDLED. SIGTERM and SIGINT
-# are forwarded via separate traps in the launcher, so both are exercised.
+# signal_driver spawns signal_target and sends the signal to the launcher PID. On the exec path the
+# launcher has replaced itself with node, so the signal is delivered straight to node and its handler
+# runs and prints HANDLED. SIGTERM and SIGINT are both exercised.
 
 js_binary(
     name = "signal_target_sigterm",
@@ -61,10 +61,62 @@ js_test(
 )
 
 # ==================================================================================================
-# Case 2: node killed by an unhandled signal is reported as exit code 128+N.
+# Case 1b: a directed termination signal reaches node's own handler on the expected_exit_code path.
 #
-# stay_alive installs no signal handlers, so the forwarded signal terminates node. The launcher's
-# wait picks up node's signal death and propagates 128+N (143 for SIGTERM, 130 for SIGINT).
+# With expected_exit_code set the launcher cannot exec (it must observe node's exit code to remap
+# it), so it must forward a directed signal to node itself. node's handler must still run and print
+# HANDLED. SIGTERM and SIGINT are both exercised.
+
+js_binary(
+    name = "signal_target_remap_sigterm",
+    entry_point = "signal_target.mjs",
+    expected_exit_code = 42,
+    fixed_args = ["SIGTERM"],
+)
+
+js_test(
+    name = "signal_forwarding_remap_sigterm_test",
+    size = "small",
+    data = [
+        ":signal_target_remap_sigterm",
+        "//:node_modules/@bazel/runfiles",
+    ],
+    entry_point = "signal_driver.mjs",
+    fixed_args = [
+        "$(rlocationpath :signal_target_remap_sigterm)",
+        "SIGTERM",
+    ],
+    target_compatible_with = _POSIX_ONLY,
+)
+
+js_binary(
+    name = "signal_target_remap_sigint",
+    entry_point = "signal_target.mjs",
+    expected_exit_code = 42,
+    fixed_args = ["SIGINT"],
+)
+
+js_test(
+    name = "signal_forwarding_remap_sigint_test",
+    size = "small",
+    data = [
+        ":signal_target_remap_sigint",
+        "//:node_modules/@bazel/runfiles",
+    ],
+    entry_point = "signal_driver.mjs",
+    fixed_args = [
+        "$(rlocationpath :signal_target_remap_sigint)",
+        "SIGINT",
+    ],
+    target_compatible_with = _POSIX_ONLY,
+)
+
+# ==================================================================================================
+# Case 2: node killed by an unhandled signal is terminated by that signal.
+#
+# stay_alive installs no signal handlers. On the exec path the launcher has replaced itself with
+# node, so the signal kills node directly and the process is reported as signal-terminated
+# (code=null, signal=<name>) rather than exiting with a 128+N code.
 
 js_binary(
     name = "stay_alive_bin",
@@ -82,7 +134,6 @@ js_test(
     fixed_args = [
         "$(rlocationpath :stay_alive_bin)",
         "SIGTERM",
-        "143",
     ],
     target_compatible_with = _POSIX_ONLY,
 )
@@ -98,7 +149,6 @@ js_test(
     fixed_args = [
         "$(rlocationpath :stay_alive_bin)",
         "SIGINT",
-        "130",
     ],
     target_compatible_with = _POSIX_ONLY,
 )

--- a/js/private/test/launcher/signal_exit_driver.mjs
+++ b/js/private/test/launcher/signal_exit_driver.mjs
@@ -1,16 +1,16 @@
 // Spawns the target js_binary, waits for it to report READY, sends the signal
-// named by argv[3], and asserts the launcher exits with the code in argv[4].
-// When node is terminated by a signal it does not handle, the launcher must
-// surface that as exit code 128+N (e.g. 143 for SIGTERM, 130 for SIGINT).
+// named by argv[3], and asserts node is terminated by that signal. On the exec
+// path the launcher has replaced itself with node, so an unhandled fatal signal
+// kills node directly and it is reported as signal-terminated (code=null),
+// rather than the launcher surfacing a 128+N exit code.
 import { spawn } from 'node:child_process'
 import { runfiles } from '@bazel/runfiles'
 
 const targetRlocation = process.argv[2]
 const signal = process.argv[3]
-const expectedCode = Number(process.argv[4])
-if (!targetRlocation || !signal || Number.isNaN(expectedCode)) {
+if (!targetRlocation || !signal) {
     process.stderr.write(
-        'Usage: signal_exit_driver.mjs <target-rlocationpath> <signal> <expected-exit-code>\n'
+        'Usage: signal_exit_driver.mjs <target-rlocationpath> <signal>\n'
     )
     process.exit(1)
 }
@@ -39,11 +39,11 @@ child.stdout.on('data', (chunk) => {
 
 child.on('exit', (code, sig) => {
     clearTimeout(timeout)
-    if (code === expectedCode) {
+    if (code === null && sig === signal) {
         process.exit(0)
     }
     process.stderr.write(
-        `launcher exited with code=${code} signal=${sig}, expected exit code ${expectedCode}\n`
+        `expected node to be terminated by ${signal}, but exited with code=${code} signal=${sig}\n`
     )
     process.exit(1)
 })

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -567,6 +567,17 @@ export -n JS_BINARY__STDOUT_OUTPUT_FILE JS_BINARY__STDERR_OUTPUT_FILE JS_BINARY_
 
 set +e
 
+# Generate the lcov report for a passing test; empty when not collecting coverage. See #2901.
+coverage_entry_point=""
+
+if [ -z "${JS_BINARY__EXPECTED_EXIT_CODE:-}" ] && [ -z "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ] && [ -z "${STDOUT_CAPTURE:-}" ] && [ -z "${STDERR_CAPTURE:-}" ] && [ -z "$coverage_entry_point" ]; then
+    # Nothing must run after node exits, so replace this shell with node. Signals
+    # and terminal control are then delivered directly to node instead of being
+    # proxied through a backgrounded child.
+    exec "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"}
+    exit 127
+fi
+
 if [ "${STDOUT_CAPTURE:-}" ] && [ "${STDERR_CAPTURE:-}" ]; then
     "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" 2>>"$STDERR_CAPTURE" &
 elif [ "${STDOUT_CAPTURE:-}" ]; then
@@ -597,9 +608,6 @@ wait "$child"
 
 RESULT="$?"
 set -e
-
-# Generate the lcov report for a passing test; empty when not collecting coverage. See #2901.
-coverage_entry_point=""
 
 if [ -n "$coverage_entry_point" ] && [ "$RESULT" = "${JS_BINARY__EXPECTED_EXIT_CODE:-0}" ] && [ -n "${COVERAGE_DIR:-}" ] &&
     # A test reporting its own coverage owns it, except in split mode where bazel drops it.


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
