### PR TITLE
feat(nextjs): allow passing additional args to next build

### DIFF
--- a/contrib/nextjs/defs.bzl
+++ b/contrib/nextjs/defs.bzl
@@ -174,7 +174,7 @@ def nextjs(
         **kwargs
     )
 
-def nextjs_build(name, config, srcs, next_js_binary, data = [], use_execroot_entry_point = True, **kwargs):
+def nextjs_build(name, config, srcs, next_js_binary, data = [], use_execroot_entry_point = True, args = [], **kwargs):
     """Build the Next.js production artifact.
 
     See https://nextjs.org/docs/pages/api-reference/cli/next#build
@@ -193,12 +193,19 @@ def nextjs_build(name, config, srcs, next_js_binary, data = [], use_execroot_ent
             See main docstring above for example usage.
 
         use_execroot_entry_point: passed directly to js_run_binary
+
+        args: Additional arguments to pass to `next build`, appended after the
+            `build` subcommand. For example `["--webpack"]` to opt out of
+            Turbopack, which cannot run under a Bazel sandbox.
+
+            The `build` subcommand itself is not overridable.
+
         **kwargs: Other attributes passed to all targets such as `tags`, env
     """
     js_run_binary(
         name = name,
         tool = next_js_binary,
-        args = ["build"],
+        args = ["build"] + args,
         srcs = srcs + data + [config],
         out_dirs = [_next_build_out],
         chdir = native.package_name(),
@@ -271,7 +278,7 @@ def nextjs_dev(name, config, srcs, data, next_js_binary, **kwargs):
 # Standalone Next.js build & server binary.
 # ---------------------------------------------------------------------------------------------
 
-def nextjs_standalone_build(name, config, srcs, next_js_binary, data = [], use_execroot_entry_point = True, **kwargs):
+def nextjs_standalone_build(name, config, srcs, next_js_binary, data = [], use_execroot_entry_point = True, args = [], **kwargs):
     """Compile a standalone Next.js application.
 
     See https://nextjs.org/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files
@@ -294,6 +301,13 @@ def nextjs_standalone_build(name, config, srcs, next_js_binary, data = [], use_e
         next_js_binary: the Next.js binary to use for building
         data: the data files to include in the build
         use_execroot_entry_point: passed directly to js_run_binary
+
+        args: Additional arguments to pass to `next build`, appended after the
+            `build` subcommand. For example `["--webpack"]` to opt out of
+            Turbopack, which cannot run under a Bazel sandbox.
+
+            The `build` subcommand itself is not overridable.
+
         **kwargs: Other attributes passed to all targets such as `tags`, env
     """
 
@@ -337,7 +351,7 @@ def nextjs_standalone_build(name, config, srcs, next_js_binary, data = [], use_e
         name = "_%s.next_build" % name,
         tool = next_js_binary,
         env = env,
-        args = ["build"],
+        args = ["build"] + args,
         srcs = srcs + data + [":_%s.standalone_config_file" % name, ":_%s.original_config_file" % name],
         out_dirs = [_next_build_out],
         chdir = native.package_name(),

--- a/contrib/nextjs/test/BUILD.bazel
+++ b/contrib/nextjs/test/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//js:defs.bzl", "js_binary")
+
+# The stand-in `next` binary shared by all test packages. The tests only inspect the
+# generated actions, so `next` is never actually run.
+js_binary(
+    name = "fake_next_binary",
+    entry_point = "fake_next.js",
+    visibility = ["//contrib/nextjs/test:__subpackages__"],
+)

--- a/contrib/nextjs/test/args_test.bzl
+++ b/contrib/nextjs/test/args_test.bzl
@@ -1,0 +1,90 @@
+"""Tests that the `args` of the Next.js build macros reach the `next` command line.
+
+Each `nextjs_build` / `nextjs_standalone_build` target declares the `.next` output
+directory of its own package, so each target under test must be in its own package,
+alongside its own Next.js config file.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//contrib/nextjs:defs.bzl", "nextjs_build", "nextjs_standalone_build")
+
+# The stand-in `next` binary shared by all test packages. The tests only inspect the
+# generated actions, so `next` is never actually run.
+_NEXT_JS_BINARY = "//contrib/nextjs/test:fake_next_binary"
+
+def _args_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    actions = [a for a in analysistest.target_actions(env) if a.mnemonic == "NextJs"]
+    asserts.equals(env, 1, len(actions), "expected a single NextJs action")
+    argv = actions[0].argv
+
+    build_indexes = [i for i, arg in enumerate(argv) if arg == "build"]
+    asserts.equals(env, 1, len(build_indexes), "expected a single `build` argument in {}".format(argv))
+
+    # The `build` subcommand must come first, followed by `args` in the given order.
+    asserts.equals(
+        env,
+        ["build"] + ctx.attr.expected_args,
+        argv[build_indexes[0]:],
+        "unexpected `next` arguments",
+    )
+
+    return analysistest.end(env)
+
+_args_test = analysistest.make(
+    _args_test_impl,
+    attrs = {
+        "expected_args": attr.string_list(
+            doc = "The arguments expected after the `build` subcommand.",
+        ),
+    },
+)
+
+def nextjs_build_args_test(name, args = [], config = "next.config.mjs"):
+    """Assert `nextjs_build(args)` is appended after the `build` subcommand.
+
+    Args:
+        name: Target name of the test target.
+        args: The `args` to pass to `nextjs_build`.
+        config: The Next.js config file, which must be in this package.
+    """
+    nextjs_build(
+        name = "_{}.app".format(name),
+        config = config,
+        srcs = [],
+        next_js_binary = _NEXT_JS_BINARY,
+        args = args,
+        tags = ["manual"],
+    )
+
+    _args_test(
+        name = name,
+        target_under_test = "_{}.app".format(name),
+        expected_args = args,
+    )
+
+def nextjs_standalone_build_args_test(name, args = [], config = "next.standalone.mjs"):
+    """Assert `nextjs_standalone_build(args)` is appended after the `build` subcommand.
+
+    Args:
+        name: Target name of the test target.
+        args: The `args` to pass to `nextjs_standalone_build`.
+        config: The Next.js config file, which must be in this package and must not be
+            named `next.config.mjs`, which `nextjs_standalone_build` generates.
+    """
+    nextjs_standalone_build(
+        name = "_{}.app".format(name),
+        config = config,
+        srcs = [],
+        next_js_binary = _NEXT_JS_BINARY,
+        args = args,
+        tags = ["manual"],
+    )
+
+    _args_test(
+        name = name,
+        # The private `js_run_binary` running `next build` within `nextjs_standalone_build`.
+        target_under_test = "__{}.app.next_build".format(name),
+        expected_args = args,
+    )

--- a/contrib/nextjs/test/build_args/BUILD.bazel
+++ b/contrib/nextjs/test/build_args/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//contrib/nextjs/test:args_test.bzl", "nextjs_build_args_test")
+
+nextjs_build_args_test(
+    name = "nextjs_build_args_test",
+    args = ["--webpack"],
+)

--- a/contrib/nextjs/test/build_args/next.config.mjs
+++ b/contrib/nextjs/test/build_args/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+export default {
+    output: 'standalone',
+}

--- a/contrib/nextjs/test/build_default_args/BUILD.bazel
+++ b/contrib/nextjs/test/build_default_args/BUILD.bazel
@@ -1,0 +1,4 @@
+load("//contrib/nextjs/test:args_test.bzl", "nextjs_build_args_test")
+
+# The default `args = []` must produce `next build` with no additional arguments.
+nextjs_build_args_test(name = "nextjs_build_default_args_test")

--- a/contrib/nextjs/test/build_default_args/next.config.mjs
+++ b/contrib/nextjs/test/build_default_args/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+export default {
+    output: 'standalone',
+}

--- a/contrib/nextjs/test/fake_next.js
+++ b/contrib/nextjs/test/fake_next.js
@@ -1,0 +1,4 @@
+// A stand-in for the `next` CLI used by analysis-phase tests, which only inspect
+// the generated action and never execute it.
+console.error('fake next:', process.argv.slice(2).join(' '))
+process.exit(1)

--- a/contrib/nextjs/test/standalone_build_args/BUILD.bazel
+++ b/contrib/nextjs/test/standalone_build_args/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//contrib/nextjs/test:args_test.bzl", "nextjs_standalone_build_args_test")
+
+nextjs_standalone_build_args_test(
+    name = "nextjs_standalone_build_args_test",
+    args = [
+        "--webpack",
+        "--no-lint",
+    ],
+)

--- a/contrib/nextjs/test/standalone_build_args/next.standalone.mjs
+++ b/contrib/nextjs/test/standalone_build_args/next.standalone.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+export default {
+    output: 'standalone',
+}

--- a/e2e/nextjs/v15/esm/BUILD.bazel
+++ b/e2e/nextjs/v15/esm/BUILD.bazel
@@ -20,9 +20,12 @@ js_library(
     ],
 )
 
+# Also covers passing additional `next build` arguments. `--webpack` (the motivating
+# use case) is a Next.js 16 flag, so a v15-supported flag is used here instead.
 nextjs_standalone_build(
     name = "standalone",
     srcs = [":lib"],
+    args = ["--no-lint"],
     config = "next.config.js",
     next_js_binary = ":next_js_binary",
 )


### PR DESCRIPTION
`nextjs_build` and `nextjs_standalone_build` hardcode `args = ["build"]`, and `args` cannot be passed through `**kwargs` (Starlark raises "got multiple values for keyword argument 'args'"), so there is no way to pass a flag to `next build` through these macros.

Add an `args` parameter, defaulting to `[]`, appended after the `build` subcommand. The default produces an identical `js_run_binary` invocation, so existing callers are unaffected.

The motivating case is `next build --webpack`: Next.js 16 defaults to Turbopack, which cannot run under a Bazel sandbox, and there is no config-file or env-var equivalent for selecting webpack.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Allow arbitrary args to be passed through to `nextjs build ...`.

### Test plan

- Covered by existing test cases
- New test cases added
