### PR TITLE
fix(coverage): sh toolchain is optional for the merger

### DIFF
--- a/js/private/coverage/merger.bzl
+++ b/js/private/coverage/merger.bzl
@@ -39,6 +39,10 @@ def _coverage_merger_impl(ctx):
 
     runfiles = [ctx.file.entry_point]
 
+    if is_windows:
+        # The .bat launcher resolves the bash script through its own runfiles.
+        runfiles.append(bash_launcher)
+
     if nodeinfo.node:
         runfiles.append(nodeinfo.node)
 
@@ -52,7 +56,8 @@ coverage_merger = rule(
     attrs = _ATTRS,
     executable = True,
     toolchains = [
-        "@bazel_tools//tools/sh:toolchain_type",
+        # Optional: only referenced on Windows, to wrap the bash script in a .bat launcher.
+        config_common.toolchain_type("@bazel_tools//tools/sh:toolchain_type", mandatory = False),
         "@rules_nodejs//nodejs:toolchain_type",
     ],
 )

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -1,7 +1,10 @@
 load("//js/private/coverage:merger.bzl", "coverage_merger")
+load(":merger_test.bzl", "merger_test_suite")
 load(":test.bzl", "coverage_fail_test", "coverage_pass_test")
 
 package(default_testonly = True)
+
+merger_test_suite(name = "merger_test")
 
 FAIL_CMD = """\
 echo "require('fs').writeFileSync(process.env.COVERAGE_OUTPUT_FILE, '# no coverage');" >> $@

--- a/js/private/test/coverage/merger_test.bzl
+++ b/js/private/test/coverage/merger_test.bzl
@@ -1,0 +1,75 @@
+"""Analysis tests for the coverage merger launcher."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//js/private/coverage:merger.bzl", "coverage_merger")
+
+def _launcher_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    executable = target_under_test[DefaultInfo].files_to_run.executable
+    runfiles = [
+        f.short_path
+        for f in target_under_test[DefaultInfo].default_runfiles.files.to_list()
+    ]
+
+    if not ctx.attr.is_windows:
+        asserts.false(
+            env,
+            executable.short_path.endswith(".bat"),
+            "Expected the bash launcher to be the executable, got {}".format(executable.short_path),
+        )
+        return analysistest.end(env)
+
+    asserts.true(
+        env,
+        executable.short_path.endswith(".bat"),
+        "Expected a .bat launcher on Windows but got {}".format(executable.short_path),
+    )
+
+    # The .bat launcher rlocation()s the bash script it wraps, so that script
+    # must be in the runfiles or the launcher fails with
+    # "ERROR: <path> not found in runfiles manifest".
+    bash_launcher = executable.short_path[:-len(".bat")]
+    asserts.true(
+        env,
+        bash_launcher in runfiles,
+        "Expected {} in the runfiles of the .bat launcher, got {}".format(bash_launcher, runfiles),
+    )
+
+    return analysistest.end(env)
+
+_launcher_test = analysistest.make(
+    _launcher_test_impl,
+    attrs = {
+        "is_windows": attr.bool(
+            doc = "Whether the target platform is Windows, where the bash script is wrapped in a .bat launcher.",
+        ),
+    },
+)
+
+def merger_test_suite(name):
+    """Tests for the coverage_merger launcher.
+
+    Args:
+        name: Name of the test suite
+    """
+
+    coverage_merger(
+        name = name + "_subject",
+        tags = ["manual"],
+    )
+
+    _launcher_test(
+        name = name + "_launcher_test",
+        target_under_test = ":" + name + "_subject",
+        is_windows = select({
+            "@platforms//os:windows": True,
+            "//conditions:default": False,
+        }),
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [":" + name + "_launcher_test"],
+    )


### PR DESCRIPTION
The merger only references the shell toolchain on Windows, where it wraps the bash script in a .bat launcher, so requiring it unconditionally breaks platforms that have no such toolchain registered. Same fix as #2926 and #2930 made for js_binary.

Also add the bash script to the .bat launcher's runfiles, which is where that launcher resolves the script it wraps from.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; see #2932
