### PR TITLE
ci: do not let a cached test result stand in for a coverage run

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,9 @@ common --check_direct_dependencies=off
 # generated due to `coverage --build_runfile_links`
 coverage --deleted_packages=js/private/test/image/non_ascii
 
+# js/private/test/coverage instruments the test's own entry_point; matches what CI passes.
+coverage --instrument_test_targets
+
 # Build without the bytes
 common:ci --remote_download_outputs=minimal
 common:ci --nobuild_runfile_links

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -235,9 +235,12 @@ jobs:
             # coverage behavior but only exercise it when run in coverage mode. Not //...:
             # instrumentation changes launcher env/output, breaking golden-output tests
             # (js_binary_sh, fixed_args, ...) that were never run instrumented.
+            # --nocache_test_results: the coverage flags do not invalidate a cached test
+            # result, so a cached run would republish an earlier coverage.dat and the
+            # mergers' assertions would never execute.
             - name: Coverage
               if: matrix.workspace.path == '.' && matrix.bazel.id == 'bazel-7'
-              run: aspect test --task-key=coverage-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} --bazel-flag=--collect_code_coverage --bazel-flag=--instrument_test_targets -- //js/private/test/coverage/...
+              run: aspect test --task-key=coverage-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} --bazel-flag=--collect_code_coverage --bazel-flag=--instrument_test_targets --bazel-flag=--nocache_test_results -- //js/private/test/coverage/...
 
             # Skipped on the no-execroot-entry-point variant: test.sh scripts invoke plain
             # `bazel` without matrix.bazel.flags, so that leg wouldn't exercise the flag —


### PR DESCRIPTION
The coverage job differs from the ordinary test job only in post-processing flags, which do not invalidate a cached test result. It could therefore republish the coverage.dat of an earlier run, and the custom lcov mergers in js/private/test/coverage -- the only thing asserting coverage behavior -- would never execute.

Also set --instrument_test_targets for `bazel coverage` in .bazelrc: those tests instrument their own entry_point, so a bare `bazel coverage //js/private/test/coverage/...` fails without the flag CI passes explicitly.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
