### PR TITLE
test: e2e coverage workspace covering the supported scenarios

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -62,6 +62,7 @@ jobs:
                   paths=(
                     .
                     e2e/bzlmod
+                    e2e/coverage
                     e2e/gyp_no_install_script
                     e2e/js_binary_workspace
                     e2e/js_image_oci

--- a/e2e/coverage/.bazelrc
+++ b/e2e/coverage/.bazelrc
@@ -1,0 +1,2 @@
+import %workspace%/../../tools/preset.bazelrc
+import %workspace%/../e2e.bazelrc

--- a/e2e/coverage/.bazelversion
+++ b/e2e/coverage/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/coverage/BUILD.bazel
+++ b/e2e/coverage/BUILD.bazel
@@ -1,0 +1,56 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library", "js_test")
+load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
+
+js_library(
+    name = "lib",
+    srcs = ["lib.js"],
+)
+
+# Relative import (require("./lib.js")): source resolves inside the test's
+# runfiles src root.
+js_test(
+    name = "test",
+    data = [":lib"],
+    entry_point = "test.js",
+)
+
+# A passing test whose exit status is non-zero (matches expected_exit_code).
+# Coverage must still be generated for it. See #2932.
+js_test(
+    name = "expected_exit_test",
+    data = [":lib"],
+    entry_point = "expected_exit.js",
+    expected_exit_code = 42,
+)
+
+# First-party code repackaged with npm_package and imported by name
+# (require("@repro/lib")): resolves through the .aspect_rules_js store to a copy with
+# no link back to source. Coverage of this is UNSUPPORTED (use js_library linking
+# instead, as first_party_jslib_test does) — see docs/troubleshooting.md, test.sh,
+# and https://github.com/aspect-build/rules_js/issues/2933.
+npm_link_package(
+    name = "node_modules/@repro/lib",
+    src = "//pkg:lib",
+)
+
+js_test(
+    name = "first_party_npmpkg_test",
+    data = [":node_modules/@repro/lib"],
+    entry_point = "first_party.js",
+)
+
+# js_library linked directly (no npm_package repackaging) — mirrors a
+# pnpm-workspace first-party package: store symlinks to the library's natural
+# directory in bin.
+npm_link_package(
+    name = "node_modules/@repro/jslib",
+    src = "//pkg:src",
+    package = "@repro/jslib",
+    version = "0.0.0",
+)
+
+js_test(
+    name = "first_party_jslib_test",
+    data = [":node_modules/@repro/jslib"],
+    entry_point = "first_party_jslib.js",
+)

--- a/e2e/coverage/MODULE.bazel
+++ b/e2e/coverage/MODULE.bazel
@@ -1,0 +1,7 @@
+module(name = "e2e_coverage")
+
+bazel_dep(name = "aspect_rules_js", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "aspect_rules_js",
+    path = "../..",
+)

--- a/e2e/coverage/expected_exit.js
+++ b/e2e/coverage/expected_exit.js
@@ -1,0 +1,8 @@
+const assert = require('node:assert')
+const lib = require('./lib.js')
+
+assert.strictEqual(lib.covered(), 'covered')
+
+// Exit non-zero on purpose; the js_test's expected_exit_code matches, so the test
+// passes and coverage must still be produced for it. See #2932.
+process.exit(42)

--- a/e2e/coverage/first_party.js
+++ b/e2e/coverage/first_party.js
@@ -1,0 +1,6 @@
+const assert = require('node:assert')
+// Import first-party code by package name so it resolves through the
+// .aspect_rules_js store (realpath outside the test's runfiles src root).
+const lib = require('@repro/lib')
+
+assert.strictEqual(lib.covered(), 'covered')

--- a/e2e/coverage/first_party_jslib.js
+++ b/e2e/coverage/first_party_jslib.js
@@ -1,0 +1,4 @@
+const assert = require('node:assert')
+const lib = require('@repro/jslib')
+
+assert.strictEqual(lib.covered(), 'covered')

--- a/e2e/coverage/lib.js
+++ b/e2e/coverage/lib.js
@@ -1,0 +1,9 @@
+function covered() {
+    return 'covered'
+}
+
+function uncovered() {
+    return 'uncovered'
+}
+
+module.exports = { covered, uncovered }

--- a/e2e/coverage/pkg/BUILD.bazel
+++ b/e2e/coverage/pkg/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+js_library(
+    name = "src",
+    srcs = [
+        "lib.js",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "lib",
+    srcs = [":src"],
+    package = "@repro/lib",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/coverage/pkg/lib.js
+++ b/e2e/coverage/pkg/lib.js
@@ -1,0 +1,9 @@
+function covered() {
+    return 'covered'
+}
+
+function uncovered() {
+    return 'uncovered'
+}
+
+module.exports = { covered, uncovered }

--- a/e2e/coverage/pkg/package.json
+++ b/e2e/coverage/pkg/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "@repro/lib",
+    "version": "0.0.0",
+    "main": "lib.js"
+}

--- a/e2e/coverage/test.js
+++ b/e2e/coverage/test.js
@@ -1,0 +1,4 @@
+const assert = require('node:assert')
+const lib = require('./lib.js')
+
+assert.strictEqual(lib.covered(), 'covered')

--- a/e2e/coverage/test.sh
+++ b/e2e/coverage/test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+# Coverage behavior for `bazel test` / `bazel coverage`.
+#
+# Every target executes the same covered()/uncovered() code and differs only in how
+# the source is provided or the test exits — see BUILD.bazel for what each exercises.
+#
+# //:first_party_npmpkg_test is an UNSUPPORTED scenario, kept as executable
+# documentation: first-party code repackaged with npm_package runs from a copy in
+# the .aspect_rules_js store with no link back to source, so coverage comes out
+# empty. Use js_library linking (//:first_party_jslib_test) for first-party
+# coverage. See docs/troubleshooting.md and
+# https://github.com/aspect-build/rules_js/issues/2933.
+#
+# Coverage is checked twice: inline (the _lcov_merger runs in the test action) and
+# split (--experimental_split_coverage_postprocessing, required for remote
+# execution), where the merger runs as its own action without the test's runfiles.
+#
+# Split mode currently reports empty coverage for every target -- the merger runs
+# where neither the V8 data nor the instrumented sources are reachable. That is
+# https://github.com/aspect-build/rules_js/issues/2901, asserted here as BROKEN so
+# the fix for it shows up as a change to this file.
+
+readonly WORKING_TARGETS=(//:test //:expected_exit_test //:first_party_jslib_test)
+readonly UNSUPPORTED_TARGETS=(//:first_party_npmpkg_test)
+readonly ALL_TARGETS=("${WORKING_TARGETS[@]}" "${UNSUPPORTED_TARGETS[@]}")
+
+testlogs="$(bazel info bazel-testlogs)"
+
+# Prints nothing and returns 0 if the report is real; otherwise prints the reason and
+# returns 1. Keyed off the function names rather than the SF: path so it is agnostic
+# to how the source resolves.
+coverage_is_real() {
+    local dat="$1"
+    [[ -s "$dat" ]] || {
+        echo "coverage.dat is missing or empty"
+        return 1
+    }
+    grep -q '^FNDA:1,covered$' "$dat" || {
+        echo "covered() not marked as executed"
+        return 1
+    }
+    grep -q '^FNDA:0,uncovered$' "$dat" || {
+        echo "uncovered() not marked as unexecuted"
+        return 1
+    }
+    grep -Eq '^DA:[0-9]+,[1-9]' "$dat" || {
+        echo "all line execution counts are zero"
+        return 1
+    }
+}
+
+assert_coverage() {
+    local target="$1" mode="$2" dat="$testlogs/${1#//:}/coverage.dat" reason
+    if reason="$(coverage_is_real "$dat")"; then
+        echo "PASS($target, $mode)"
+    else
+        echo "FAIL($target, $mode): $reason"
+        cat "$dat" 2>/dev/null || true
+        exit 1
+    fi
+}
+
+# The unsupported case must report empty coverage, the documented behavior. If it
+# ever produces a real report the script fails, so the docs get revisited rather than
+# the stale expectation rotting unnoticed in a green log.
+check_unsupported() {
+    local target="$1" mode="$2" dat="$testlogs/${1#//:}/coverage.dat" reason
+    if reason="$(coverage_is_real "$dat")"; then
+        echo "UNSUPPORTED($target, $mode) now produces coverage — update docs/troubleshooting.md and https://github.com/aspect-build/rules_js/issues/2933."
+        exit 1
+    else
+        echo "UNSUPPORTED($target, $mode): empty coverage, as documented ($reason)"
+    fi
+}
+
+# A scenario that should work but does not yet; fails once it starts working so the
+# expectation is updated with the fix rather than left behind.
+check_broken() {
+    local target="$1" mode="$2" issue="$3" dat="$testlogs/${1#//:}/coverage.dat" reason
+    if reason="$(coverage_is_real "$dat")"; then
+        echo "BROKEN($target, $mode) now produces coverage — $issue is fixed, assert it instead."
+        exit 1
+    else
+        echo "BROKEN($target, $mode): empty coverage, see $issue ($reason)"
+    fi
+}
+
+# The code under test executes in every scenario. If this passes but coverage below
+# is empty, the failure is in coverage reporting, not test execution.
+bazel test --nocache_test_results "${ALL_TARGETS[@]}"
+
+# --nocache_test_results on the coverage runs below: they differ only in
+# post-processing flags, which do not invalidate a cached test result — without it a
+# later run would just republish an earlier run's coverage.dat.
+#
+# No --instrument_test_targets: every covered source here lives in a js_library the
+# test depends on, so the default instrumentation already picks it up.
+
+bazel coverage --nocache_test_results "${ALL_TARGETS[@]}"
+for t in "${WORKING_TARGETS[@]}"; do assert_coverage "$t" inline; done
+for t in "${UNSUPPORTED_TARGETS[@]}"; do check_unsupported "$t" inline; done
+
+bazel coverage --nocache_test_results \
+    --experimental_split_coverage_postprocessing \
+    --experimental_fetch_all_coverage_outputs \
+    "${ALL_TARGETS[@]}"
+readonly ISSUE_2901=https://github.com/aspect-build/rules_js/issues/2901
+for t in "${WORKING_TARGETS[@]}"; do check_broken "$t" split "$ISSUE_2901"; done
+for t in "${UNSUPPORTED_TARGETS[@]}"; do check_unsupported "$t" split; done


### PR DESCRIPTION
Records what `bazel coverage` produces today for a js_test: a relative import, a first-party js_library linked by name, and a passing test with a non-zero expected_exit_code. Reports are checked by looking for the covered/uncovered function names rather than an SF: path, so the assertions survive changes to how sources resolve.

Two scenarios are asserted as not working, so that fixing either one has to touch this file:

- Split post-processing (--experimental_split_coverage_postprocessing, required for remote execution) reports empty coverage for every target, #2901.
- First-party code repackaged with npm_package and imported by name resolves to a copy in the store with no link back to source, #2933. That one is a documented limitation rather than a bug; use js_library linking instead.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
