### PR TITLE
revert: feat: use bazel-lib run_binary's native stdout/stderr/exit_co…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,10 +19,7 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Changes ensured by rules_js:
 # 3.2.2: https://github.com/bazel-contrib/bazel-lib/commit/cac2d7855949d1b222fa26888892fbbe1d31015d
-# 3.5.0: run_binary gained native stdout/stderr/exit_code_out/silent_on_success
-# support, which js_run_binary now uses directly instead of reimplementing
-# capture in the js_binary launcher script.
-bazel_dep(name = "bazel_lib", version = "3.5.0")
+bazel_dep(name = "bazel_lib", version = "3.2.2")
 
 # NB: LOWER BOUND on earliest BCR release of protobuf module, to avoid upgrading the root module by accident
 bazel_dep(name = "protobuf", version = "3.19.6")

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -15,42 +15,71 @@ set -o pipefail -o errexit -o nounset
 {{envs}}
 
 # ==============================================================================
-# Logging
+# Prepare stdout capture, stderr capture && logging
 # ==============================================================================
+
+if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ] || [ "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
+    STDOUT_CAPTURE=$(mktemp)
+fi
+
+if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ] || [ "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
+    STDERR_CAPTURE=$(mktemp)
+fi
 
 export JS_BINARY__LOG_PREFIX="{{log_prefix_rule_set}}[{{log_prefix_rule}}]"
 
 function logf_stderr {
     local format_string="$1\n"
     shift
-    # shellcheck disable=SC2059,SC2046
-    echo -e $(printf "$format_string" "$@") >&2
+    if [ "${STDERR_CAPTURE:-}" ]; then
+        # shellcheck disable=SC2059,SC2046
+        echo -e $(printf "$format_string" "$@") >>"$STDERR_CAPTURE"
+    else
+        # shellcheck disable=SC2059,SC2046
+        echo -e $(printf "$format_string" "$@") >&2
+    fi
 }
 
 function logf_fatal {
     if [ "${JS_BINARY__LOG_FATAL:-}" ]; then
-        printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        if [ "${STDERR_CAPTURE:-}" ]; then
+            printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
+        else
+            printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        fi
         logf_stderr "$@"
     fi
 }
 
 function logf_error {
     if [ "${JS_BINARY__LOG_ERROR:-}" ]; then
-        printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        if [ "${STDERR_CAPTURE:-}" ]; then
+            printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
+        else
+            printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        fi
         logf_stderr "$@"
     fi
 }
 
 function logf_info {
     if [ "${JS_BINARY__LOG_INFO:-}" ]; then
-        printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        if [ "${STDERR_CAPTURE:-}" ]; then
+            printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
+        else
+            printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        fi
         logf_stderr "$@"
     fi
 }
 
 function logf_debug {
     if [ "${JS_BINARY__LOG_DEBUG:-}" ]; then
-        printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        if [ "${STDERR_CAPTURE:-}" ]; then
+            printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
+        else
+            printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        fi
         logf_stderr "$@"
     fi
 }
@@ -76,6 +105,26 @@ function resolve_execroot_src_path {
 _exit() {
     EXIT_CODE=$?
 
+    if [ "${STDERR_CAPTURE:-}" ]; then
+        if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ]; then
+            cp -f "$STDERR_CAPTURE" "$JS_BINARY__STDERR_OUTPUT_FILE"
+        fi
+        if [ "$EXIT_CODE" != 0 ] || [ -z "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
+            cat "$STDERR_CAPTURE" >&2
+        fi
+        rm "$STDERR_CAPTURE"
+    fi
+
+    if [ "${STDOUT_CAPTURE:-}" ]; then
+        if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
+            cp -f "$STDOUT_CAPTURE" "$JS_BINARY__STDOUT_OUTPUT_FILE"
+        fi
+        if [ "$EXIT_CODE" != 0 ] || [ -z "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
+            cat "$STDOUT_CAPTURE"
+        fi
+        rm "$STDOUT_CAPTURE"
+    fi
+
     logf_debug "exit code: %s" "$EXIT_CODE"
 
     exit "$EXIT_CODE"
@@ -93,6 +142,17 @@ export JS_BINARY__RUNFILES
 # ==============================================================================
 # Prepare to run main program
 # ==============================================================================
+
+# Convert stdout, stderr and exit_code capture outputs paths to absolute paths
+if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
+    JS_BINARY__STDOUT_OUTPUT_FILE="$PWD/$JS_BINARY__STDOUT_OUTPUT_FILE"
+fi
+if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ]; then
+    JS_BINARY__STDERR_OUTPUT_FILE="$PWD/$JS_BINARY__STDERR_OUTPUT_FILE"
+fi
+if [ "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ]; then
+    JS_BINARY__EXIT_CODE_OUTPUT_FILE="$PWD/$JS_BINARY__EXIT_CODE_OUTPUT_FILE"
+fi
 
 if [[ "$PWD" == *"/bazel-out/"* ]]; then
     bazel_out_segment="/bazel-out/"
@@ -377,9 +437,25 @@ if [ "${JS_BINARY__LOG_INFO:-}" ]; then
     logf_info "$(echo -n "running" "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"})"
 fi
 
+# De-export capture-related vars so child processes (e.g. a nested js_binary)
+# do not inherit them. The bash script has already consumed them above to set up
+# STDOUT_CAPTURE / STDERR_CAPTURE; leaking them would cause a nested js_binary
+# to silently swallow its own stdout or write to the wrong output file.
+# export -n keeps the value accessible to the _exit trap while removing it from
+# the environment seen by node and any processes it spawns.
+export -n JS_BINARY__STDOUT_OUTPUT_FILE JS_BINARY__STDERR_OUTPUT_FILE JS_BINARY__EXIT_CODE_OUTPUT_FILE JS_BINARY__SILENT_ON_SUCCESS
+
 set +e
 
-"$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 &
+if [ "${STDOUT_CAPTURE:-}" ] && [ "${STDERR_CAPTURE:-}" ]; then
+    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" 2>>"$STDERR_CAPTURE" &
+elif [ "${STDOUT_CAPTURE:-}" ]; then
+    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" &
+elif [ "${STDERR_CAPTURE:-}" ]; then
+    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 2>>"$STDERR_CAPTURE" &
+else
+    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 &
+fi
 
 # ==============================================================================
 # Wait for program to finish
@@ -421,4 +497,10 @@ if [ "${JS_BINARY__EXPECTED_EXIT_CODE:-}" ]; then
     fi
 fi
 
-exit $RESULT
+if [ "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ]; then
+    # Exit zero if the exit code was captured
+    echo -n "$RESULT" >"$JS_BINARY__EXIT_CODE_OUTPUT_FILE"
+    exit 0
+else
+    exit $RESULT
+fi

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -328,6 +328,22 @@ def js_run_binary(
                 normalized_chdir = "external/{}/{}".format(repo, chdir)
         fixed_env["JS_BINARY__CHDIR"] = normalized_chdir
 
+    # Configure capturing stdout, stderr and/or the exit code
+    extra_outs = []
+    if stdout:
+        fixed_env["JS_BINARY__STDOUT_OUTPUT_FILE"] = "$(execpath {})".format(stdout)
+        extra_outs.append(stdout)
+    if stderr:
+        fixed_env["JS_BINARY__STDERR_OUTPUT_FILE"] = "$(execpath {})".format(stderr)
+        extra_outs.append(stderr)
+    if exit_code_out:
+        fixed_env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = "$(execpath {})".format(exit_code_out)
+        extra_outs.append(exit_code_out)
+
+    # Configure silent on success
+    if silent_on_success:
+        fixed_env["JS_BINARY__SILENT_ON_SUCCESS"] = "1"
+
     # Disable node patches if requested
     if patch_node_fs:
         fixed_env["JS_BINARY__PATCH_NODE_FS"] = "1"
@@ -404,13 +420,9 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
         tool = tool,
         env = fixed_env | execroot_env | env,
         srcs = srcs + extra_srcs + execroot_extra_srcs,
-        outs = outs,
+        outs = outs + extra_outs,
         out_dirs = out_dirs,
         args = args,
-        stdout = stdout,
-        stderr = stderr,
-        exit_code_out = exit_code_out,
-        silent_on_success = silent_on_success,
         mnemonic = mnemonic,
         progress_message = progress_message,
         execution_requirements = execution_requirements,

--- a/js/private/test/launcher/BUILD.bazel
+++ b/js/private/test/launcher/BUILD.bazel
@@ -109,90 +109,94 @@ js_test(
 # When node exits 0 but a non-zero code was expected, the launcher must report Bazel's "tests
 # failed" sentinel (exit 3). When node exits a different non-zero code, that code is propagated.
 # When node exits exactly the expected code, the launcher reports success (exit 0).
-
-js_binary(
-    name = "exit_zero_bin",
-    entry_point = "exit_with.mjs",
-    expected_exit_code = 42,
-    fixed_args = ["0"],
-)
-
-js_run_binary(
-    name = "exit_zero_run",
-    chdir = package_name(),
-    exit_code_out = "exit_zero_code.txt",
-    stderr = "exit_zero_stderr.txt",
-    stdout = "exit_zero_stdout.txt",
-    tool = ":exit_zero_bin",
-)
-
-write_file(
-    name = "exit_zero_expected",
-    out = "exit_zero_expected.txt",
-    content = ["3"],
-)
-
-diff_test(
-    name = "remap_unexpected_success_test",
-    file1 = ":exit_zero_expected.txt",
-    file2 = ":exit_zero_code.txt",
-)
-
-js_binary(
-    name = "exit_seven_bin",
-    entry_point = "exit_with.mjs",
-    expected_exit_code = 42,
-    fixed_args = ["7"],
-)
-
-js_run_binary(
-    name = "exit_seven_run",
-    chdir = package_name(),
-    exit_code_out = "exit_seven_code.txt",
-    stderr = "exit_seven_stderr.txt",
-    stdout = "exit_seven_stdout.txt",
-    tool = ":exit_seven_bin",
-)
-
-write_file(
-    name = "exit_seven_expected",
-    out = "exit_seven_expected.txt",
-    content = ["7"],
-)
-
-diff_test(
-    name = "remap_mismatch_test",
-    file1 = ":exit_seven_expected.txt",
-    file2 = ":exit_seven_code.txt",
-)
-
-js_binary(
-    name = "exit_expected_bin",
-    entry_point = "exit_with.mjs",
-    expected_exit_code = 42,
-    fixed_args = ["42"],
-)
-
-js_run_binary(
-    name = "exit_expected_run",
-    chdir = package_name(),
-    exit_code_out = "exit_expected_code.txt",
-    stderr = "exit_expected_stderr.txt",
-    stdout = "exit_expected_stdout.txt",
-    tool = ":exit_expected_bin",
-)
-
-write_file(
-    name = "exit_expected_expected",
-    out = "exit_expected_expected.txt",
-    content = ["0"],
-)
-
-diff_test(
-    name = "remap_expected_match_test",
-    file1 = ":exit_expected_expected.txt",
-    file2 = ":exit_expected_code.txt",
-)
+#
+# The tests below do not currently pass, because expected_exit_code and exit_code_out do not play
+# nicely with each other. If and when we start using the exit_code_out implementation built into
+# run_binary(), we can re-enable these tests.
+#
+# js_binary(
+#     name = "exit_zero_bin",
+#     entry_point = "exit_with.mjs",
+#     expected_exit_code = 42,
+#     fixed_args = ["0"],
+# )
+#
+# js_run_binary(
+#     name = "exit_zero_run",
+#     chdir = package_name(),
+#     exit_code_out = "exit_zero_code.txt",
+#     stderr = "exit_zero_stderr.txt",
+#     stdout = "exit_zero_stdout.txt",
+#     tool = ":exit_zero_bin",
+# )
+#
+# write_file(
+#     name = "exit_zero_expected",
+#     out = "exit_zero_expected.txt",
+#     content = ["3"],
+# )
+#
+# diff_test(
+#     name = "remap_unexpected_success_test",
+#     file1 = ":exit_zero_expected.txt",
+#     file2 = ":exit_zero_code.txt",
+# )
+#
+# js_binary(
+#     name = "exit_seven_bin",
+#     entry_point = "exit_with.mjs",
+#     expected_exit_code = 42,
+#     fixed_args = ["7"],
+# )
+#
+# js_run_binary(
+#     name = "exit_seven_run",
+#     chdir = package_name(),
+#     exit_code_out = "exit_seven_code.txt",
+#     stderr = "exit_seven_stderr.txt",
+#     stdout = "exit_seven_stdout.txt",
+#     tool = ":exit_seven_bin",
+# )
+#
+# write_file(
+#     name = "exit_seven_expected",
+#     out = "exit_seven_expected.txt",
+#     content = ["7"],
+# )
+#
+# diff_test(
+#     name = "remap_mismatch_test",
+#     file1 = ":exit_seven_expected.txt",
+#     file2 = ":exit_seven_code.txt",
+# )
+#
+# js_binary(
+#     name = "exit_expected_bin",
+#     entry_point = "exit_with.mjs",
+#     expected_exit_code = 42,
+#     fixed_args = ["42"],
+# )
+#
+# js_run_binary(
+#     name = "exit_expected_run",
+#     chdir = package_name(),
+#     exit_code_out = "exit_expected_code.txt",
+#     stderr = "exit_expected_stderr.txt",
+#     stdout = "exit_expected_stdout.txt",
+#     tool = ":exit_expected_bin",
+# )
+#
+# write_file(
+#     name = "exit_expected_expected",
+#     out = "exit_expected_expected.txt",
+#     content = ["0"],
+# )
+#
+# diff_test(
+#     name = "remap_expected_match_test",
+#     file1 = ":exit_expected_expected.txt",
+#     file2 = ":exit_expected_code.txt",
+# )
 
 # ==================================================================================================
 # Case 4: with no expected_exit_code the launcher propagates node's exit code verbatim.

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -26,42 +26,71 @@ if [[ -z "${JS_BINARY__LOG_FATAL:-}" ]]; then export JS_BINARY__LOG_FATAL="1"; f
 if [[ -z "${JS_BINARY__LOG_ERROR:-}" ]]; then export JS_BINARY__LOG_ERROR="1"; fi
 
 # ==============================================================================
-# Logging
+# Prepare stdout capture, stderr capture && logging
 # ==============================================================================
+
+if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ] || [ "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
+    STDOUT_CAPTURE=$(mktemp)
+fi
+
+if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ] || [ "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
+    STDERR_CAPTURE=$(mktemp)
+fi
 
 export JS_BINARY__LOG_PREFIX="aspect_rules_js[js_binary]"
 
 function logf_stderr {
     local format_string="$1\n"
     shift
-    # shellcheck disable=SC2059,SC2046
-    echo -e $(printf "$format_string" "$@") >&2
+    if [ "${STDERR_CAPTURE:-}" ]; then
+        # shellcheck disable=SC2059,SC2046
+        echo -e $(printf "$format_string" "$@") >>"$STDERR_CAPTURE"
+    else
+        # shellcheck disable=SC2059,SC2046
+        echo -e $(printf "$format_string" "$@") >&2
+    fi
 }
 
 function logf_fatal {
     if [ "${JS_BINARY__LOG_FATAL:-}" ]; then
-        printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        if [ "${STDERR_CAPTURE:-}" ]; then
+            printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
+        else
+            printf "FATAL: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        fi
         logf_stderr "$@"
     fi
 }
 
 function logf_error {
     if [ "${JS_BINARY__LOG_ERROR:-}" ]; then
-        printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        if [ "${STDERR_CAPTURE:-}" ]; then
+            printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
+        else
+            printf "ERROR: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        fi
         logf_stderr "$@"
     fi
 }
 
 function logf_info {
     if [ "${JS_BINARY__LOG_INFO:-}" ]; then
-        printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        if [ "${STDERR_CAPTURE:-}" ]; then
+            printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
+        else
+            printf "INFO: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        fi
         logf_stderr "$@"
     fi
 }
 
 function logf_debug {
     if [ "${JS_BINARY__LOG_DEBUG:-}" ]; then
-        printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        if [ "${STDERR_CAPTURE:-}" ]; then
+            printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >>"$STDERR_CAPTURE"
+        else
+            printf "DEBUG: %s: " "$JS_BINARY__LOG_PREFIX" >&2
+        fi
         logf_stderr "$@"
     fi
 }
@@ -86,6 +115,26 @@ function resolve_execroot_src_path {
 
 _exit() {
     EXIT_CODE=$?
+
+    if [ "${STDERR_CAPTURE:-}" ]; then
+        if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ]; then
+            cp -f "$STDERR_CAPTURE" "$JS_BINARY__STDERR_OUTPUT_FILE"
+        fi
+        if [ "$EXIT_CODE" != 0 ] || [ -z "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
+            cat "$STDERR_CAPTURE" >&2
+        fi
+        rm "$STDERR_CAPTURE"
+    fi
+
+    if [ "${STDOUT_CAPTURE:-}" ]; then
+        if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
+            cp -f "$STDOUT_CAPTURE" "$JS_BINARY__STDOUT_OUTPUT_FILE"
+        fi
+        if [ "$EXIT_CODE" != 0 ] || [ -z "${JS_BINARY__SILENT_ON_SUCCESS:-}" ]; then
+            cat "$STDOUT_CAPTURE"
+        fi
+        rm "$STDOUT_CAPTURE"
+    fi
 
     logf_debug "exit code: %s" "$EXIT_CODE"
 
@@ -213,6 +262,17 @@ export JS_BINARY__RUNFILES
 # ==============================================================================
 # Prepare to run main program
 # ==============================================================================
+
+# Convert stdout, stderr and exit_code capture outputs paths to absolute paths
+if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
+    JS_BINARY__STDOUT_OUTPUT_FILE="$PWD/$JS_BINARY__STDOUT_OUTPUT_FILE"
+fi
+if [ "${JS_BINARY__STDERR_OUTPUT_FILE:-}" ]; then
+    JS_BINARY__STDERR_OUTPUT_FILE="$PWD/$JS_BINARY__STDERR_OUTPUT_FILE"
+fi
+if [ "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ]; then
+    JS_BINARY__EXIT_CODE_OUTPUT_FILE="$PWD/$JS_BINARY__EXIT_CODE_OUTPUT_FILE"
+fi
 
 if [[ "$PWD" == *"/bazel-out/"* ]]; then
     bazel_out_segment="/bazel-out/"
@@ -497,9 +557,25 @@ if [ "${JS_BINARY__LOG_INFO:-}" ]; then
     logf_info "$(echo -n "running" "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"})"
 fi
 
+# De-export capture-related vars so child processes (e.g. a nested js_binary)
+# do not inherit them. The bash script has already consumed them above to set up
+# STDOUT_CAPTURE / STDERR_CAPTURE; leaking them would cause a nested js_binary
+# to silently swallow its own stdout or write to the wrong output file.
+# export -n keeps the value accessible to the _exit trap while removing it from
+# the environment seen by node and any processes it spawns.
+export -n JS_BINARY__STDOUT_OUTPUT_FILE JS_BINARY__STDERR_OUTPUT_FILE JS_BINARY__EXIT_CODE_OUTPUT_FILE JS_BINARY__SILENT_ON_SUCCESS
+
 set +e
 
-"$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 &
+if [ "${STDOUT_CAPTURE:-}" ] && [ "${STDERR_CAPTURE:-}" ]; then
+    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" 2>>"$STDERR_CAPTURE" &
+elif [ "${STDOUT_CAPTURE:-}" ]; then
+    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 >>"$STDOUT_CAPTURE" &
+elif [ "${STDERR_CAPTURE:-}" ]; then
+    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 2>>"$STDERR_CAPTURE" &
+else
+    "$JS_BINARY__NODE_WRAPPER" ${JS_BINARY__NODE_OPTIONS[@]+"${JS_BINARY__NODE_OPTIONS[@]}"} -- "$entry_point" ${ARGS[@]+"${ARGS[@]}"} <&0 &
+fi
 
 # ==============================================================================
 # Wait for program to finish
@@ -541,4 +617,10 @@ if [ "${JS_BINARY__EXPECTED_EXIT_CODE:-}" ]; then
     fi
 fi
 
-exit $RESULT
+if [ "${JS_BINARY__EXIT_CODE_OUTPUT_FILE:-}" ]; then
+    # Exit zero if the exit code was captured
+    echo -n "$RESULT" >"$JS_BINARY__EXIT_CODE_OUTPUT_FILE"
+    exit 0
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
…de_out/s… (#2921)

This reverts commit 266085205d0c4b085a3840c67e3c6204cd5f8b4b.

That commit broke some projects because it caused us to start ignoring environment variables such as `JS_BINARY__STDOUT_OUTPUT_FILE`. I had thought these variables were private, but it turns out that there is code outside our control setting them and expecting the launcher script to handle them.

I had to comment out some tests under `js/private/test/launcher`. These tests combine use of `expected_exit_code` and `exit_code_out`, which only works when we are using the `exit_code_out` implementation provided by `run_binary()`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Revert #2921 due to unexpected breakage from this.

### Test plan

- Covered by existing test cases
