### PR TITLE
feat: add js_run_binary_action helper for invoking js_binary from custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ This third approach has trade-offs.
     and must ensure that sources are copied there first.
     This forces users to pass a `BAZEL_BINDIR` in the environment of every node action.
     https://github.com/bazelbuild/bazel/issues/15470 suggests a way to improve that, avoiding that imposition on users.
+    `js_run_binary` sets this automatically, and custom rules that invoke a `js_binary` directly should use the
+    `js_run_binary_action` helper (see `js/libs.bzl`) instead of calling `ctx.actions.run` themselves so this detail
+    stays hidden.
 
 # Telemetry & privacy policy
 

--- a/examples/js_binary/custom_rule.bzl
+++ b/examples/js_binary/custom_rule.bzl
@@ -1,15 +1,15 @@
 "A simple custom rule for testing js_binary used in a custom rule"
 
+load("@aspect_rules_js//js:libs.bzl", "js_run_binary_action")
+
 def _custom_rule_impl(ctx):
     out = ctx.actions.declare_file("{}.out".format(ctx.label.name))
     args = ctx.actions.args()
     args.add(out.short_path)
-    ctx.actions.run(
+    js_run_binary_action(
+        ctx,
         arguments = [args],
         outputs = [out],
-        env = {
-            "BAZEL_BINDIR": ctx.bin_dir.path,
-        },
         executable = ctx.executable.tool,
         execution_requirements = ctx.attr.execution_requirements,
     )

--- a/examples/worker/defs.bzl
+++ b/examples/worker/defs.bzl
@@ -1,5 +1,7 @@
 """A dummy pi rule for end-to-end testing of worker library"""
 
+load("@aspect_rules_js//js:libs.bzl", "js_run_binary_action")
+
 def _pi_impl(ctx):
     output = ctx.actions.declare_file(ctx.label.name)
 
@@ -8,7 +10,8 @@ def _pi_impl(ctx):
     arguments.set_param_file_format("multiline")
     arguments.add(output.short_path)
 
-    ctx.actions.run(
+    js_run_binary_action(
+        ctx,
         executable = ctx.executable.worker,
         inputs = [],
         arguments = [arguments],
@@ -17,9 +20,6 @@ def _pi_impl(ctx):
         execution_requirements = {
             "supports-workers": "1",
             "worker-key-mnemonic": "Pi",
-        },
-        env = {
-            "BAZEL_BINDIR": ctx.bin_dir.path,
         },
     )
 

--- a/js/libs.bzl
+++ b/js/libs.bzl
@@ -3,6 +3,7 @@
 load(
     "//js/private:js_binary.bzl",
     _js_binary_lib = "js_binary_lib",
+    _js_run_binary_action = "js_run_binary_action",
 )
 load(
     "//js/private:js_helpers.bzl",
@@ -22,6 +23,7 @@ load(
 
 js_binary_lib = _js_binary_lib
 js_library_lib = _js_library_lib
+js_run_binary_action = _js_run_binary_action
 
 js_lib_helpers = struct(
     envs_for_log_level = _envs_for_log_level,

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -591,6 +591,29 @@ def _js_binary_impl(ctx):
         ),
     ]
 
+def js_run_binary_action(ctx, **kwargs):
+    """Runs a `js_binary` as a tool in a custom rule's action.
+
+    `js_binary`'s launcher script requires the `BAZEL_BINDIR` environment variable to be
+    set to the root of the Bazel output tree whenever it is run as a build tool (as
+    opposed to via `bazel run`). This wraps `ctx.actions.run`, setting `BAZEL_BINDIR`
+    correctly so rule authors invoking a `js_binary` (or similar) executable don't have
+    to know this detail.
+
+    We recommend that rule authors use this helper function whenever possible, instead of
+    directly invoking a `js_binary`.
+
+    Args:
+        ctx: the rule context
+        **kwargs: additional arguments forwarded to `ctx.actions.run`, e.g. `executable`,
+            `arguments`, `inputs`, `outputs`, `mnemonic`, `execution_requirements`, `env`
+    """
+    env = kwargs.pop("env", None) or {}
+    ctx.actions.run(
+        env = dict(env) | {"BAZEL_BINDIR": ctx.bin_dir.path},
+        **kwargs
+    )
+
 js_binary_lib = struct(
     attrs = _ATTRS,
     create_launcher = _create_launcher,

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -594,14 +594,9 @@ def _js_binary_impl(ctx):
 def js_run_binary_action(ctx, **kwargs):
     """Runs a `js_binary` as a tool in a custom rule's action.
 
-    `js_binary`'s launcher script requires the `BAZEL_BINDIR` environment variable to be
-    set to the root of the Bazel output tree whenever it is run as a build tool (as
-    opposed to via `bazel run`). This wraps `ctx.actions.run`, setting `BAZEL_BINDIR`
-    correctly so rule authors invoking a `js_binary` (or similar) executable don't have
-    to know this detail.
-
-    We recommend that rule authors use this helper function whenever possible, instead of
-    directly invoking a `js_binary`.
+    This helper function handles internal implementation details related to invoking a
+    `js_binary`. We recommend that rule authors use this whenever possible, rather than
+    directly invoking the `js_binary`.
 
     Args:
         ctx: the rule context

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -192,7 +192,10 @@ else
 run in the execroot) so that build actions can change directories to always run out of the root of the Bazel output \
 tree. See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables. This is automatically set \
 by 'js_run_binary' (https://github.com/aspect-build/rules_js/blob/main/docs/js_run_binary.md) which is the recommended \
-rule to use for using a js_binary as the tool of a build action. If this is not a build action you can set the \
+rule to use for using a js_binary as the tool of a build action. If you are invoking a js_binary directly from your own \
+custom rule implementation, use the 'js_run_binary_action' helper \
+(https://github.com/aspect-build/rules_js/blob/main/js/libs.bzl) instead of calling ctx.actions.run yourself so that \
+BAZEL_BINDIR is set correctly. If this is not a build action you can set the \
 BAZEL_BINDIR to '.' instead to supress this error. For more context on this design decision, please read the \
 aspect_rules_js README https://github.com/aspect-build/rules_js/tree/dbb5af0d2a9a2bb50e4cf4a96dbc582b27567155#running-nodejs-programs."
             exit 1

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -312,7 +312,10 @@ else
 run in the execroot) so that build actions can change directories to always run out of the root of the Bazel output \
 tree. See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables. This is automatically set \
 by 'js_run_binary' (https://github.com/aspect-build/rules_js/blob/main/docs/js_run_binary.md) which is the recommended \
-rule to use for using a js_binary as the tool of a build action. If this is not a build action you can set the \
+rule to use for using a js_binary as the tool of a build action. If you are invoking a js_binary directly from your own \
+custom rule implementation, use the 'js_run_binary_action' helper \
+(https://github.com/aspect-build/rules_js/blob/main/js/libs.bzl) instead of calling ctx.actions.run yourself so that \
+BAZEL_BINDIR is set correctly. If this is not a build action you can set the \
 BAZEL_BINDIR to '.' instead to supress this error. For more context on this design decision, please read the \
 aspect_rules_js README https://github.com/aspect-build/rules_js/tree/dbb5af0d2a9a2bb50e4cf4a96dbc582b27567155#running-nodejs-programs."
             exit 1


### PR DESCRIPTION
js_binary's launcher requires BAZEL_BINDIR to be set when invoked as a build tool, but rule authors writing their own ctx.actions.run call currently have to deal with this implementation detail manually. Add js_run_binary_action() (js/libs.bzl, implemented in js/private/js_binary.bzl) to hide it, and update examples/js_binary/custom_rule.bzl and examples/worker/defs.bzl's pi_rule to use it.

The main motivation for this is that adding proper support for path mapping is going to require conveying the output bin directory via a `--bazel-bindir` command-line flag rather than an environment variable. Ideally we do not want users to specify that flag directly, but as long as they call our helper function we can set the flag there ourselves.

Another issue is that there are custom rules setting environment variables that we intended to be private, such as `JS_BINARY__STDOUT_OUTPUT_FILE`. If we can get all such rules to use our helper instead, then we can potentially have more flexibility to change how we handle these private variables.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add the `js_run_binary_action` helper for invoking a `js_binary` from a rule implementation

### Test plan

- Covered by existing test cases
