### PR TITLE
fix: js_run_binary_action drops --bazel-bindir value when outputs[0] …

### DIFF
--- a/e2e/path_mapping/bindir_path_mapping_check/bindir_check.mjs
+++ b/e2e/path_mapping/bindir_path_mapping_check/bindir_check.mjs
@@ -22,4 +22,5 @@ if (leaked.length > 0) {
 }
 
 mkdirSync(outDir, { recursive: true })
-writeFileSync(join(outDir, 'ok'), 'OK\n')
+writeFileSync(join(outDir, 'file1'), 'OK\n')
+writeFileSync(join(outDir, 'file2'), 'OK\n')

--- a/e2e/path_mapping/bindir_path_mapping_check/bindir_check.mjs
+++ b/e2e/path_mapping/bindir_path_mapping_check/bindir_check.mjs
@@ -1,8 +1,9 @@
-import { writeFileSync } from 'fs'
+import { mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
 
-const outPath = process.argv[2]
-if (!outPath) {
-    process.stderr.write('Usage: bindir_check.mjs <output-path>\n')
+const outDir = process.argv[2]
+if (!outDir) {
+    process.stderr.write('Usage: bindir_check.mjs <output-dir>\n')
     process.exit(1)
 }
 
@@ -20,4 +21,5 @@ if (leaked.length > 0) {
     process.exit(1)
 }
 
-writeFileSync(outPath, 'OK\n')
+mkdirSync(outDir, { recursive: true })
+writeFileSync(join(outDir, 'ok'), 'OK\n')

--- a/e2e/path_mapping/bindir_path_mapping_check/bindir_path_mapping_check.bzl
+++ b/e2e/path_mapping/bindir_path_mapping_check/bindir_path_mapping_check.bzl
@@ -4,7 +4,7 @@
 load("@aspect_rules_js//js:libs.bzl", "js_run_binary_action")
 
 def _bindir_path_mapping_check_impl(ctx):
-    output = ctx.actions.declare_file(ctx.label.name + ".ok")
+    output = ctx.actions.declare_directory(ctx.label.name)
 
     # Baking the value of this env var (set via --action_env) into the action
     # allows test.sh to invalidate this one action without the need for a full

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -615,7 +615,10 @@ def js_run_binary_action(ctx, **kwargs):
         fail("js_run_binary_action requires at least one output")
     extra_args = ctx.actions.args()
     extra_args.add("--bazel-bindir")
-    extra_args.add_all([outputs[0]], map_each = _bazel_bindir_arg)
+
+    # Set expand_directories = False to ensure this works correctly if
+    # outputs[0] is a directory.
+    extra_args.add_all([outputs[0]], map_each = _bazel_bindir_arg, expand_directories = False)
 
     ctx.actions.run(
         arguments = [extra_args] + (kwargs.pop("arguments", None) or []),


### PR DESCRIPTION
…is a directory

Args.add_all's default expand_directories=True expands a declared directory into its (not-yet-known, empty at analysis time) contents before map_each runs, instead of calling map_each on the directory itself. This silently dropped the --bazel-bindir argument's value whenever outputs[0] was a directory output.

This change adds test coverage for directory outputs by updating the test rule in e2e/path_mapping to produce a directory instead of a file. We have test coverage elsewhere for rules that produce individual files, so we're not losing any coverage by tweaking the test this way.

---

### Changes are visible to end-users: no, because this fixes a bug that has not been released yet

### Test plan

- Covered by existing test cases
- New test cases added