### PR TITLE
refactor: expose js_run_binary_action as js_binary_lib.run_binary_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ This third approach has trade-offs.
     This forces users to pass a `BAZEL_BINDIR` in the environment of every node action.
     https://github.com/bazelbuild/bazel/issues/15470 suggests a way to improve that, avoiding that imposition on users.
     `js_run_binary` sets this automatically, and custom rules that invoke a `js_binary` directly should use the
-    `js_run_binary_action` helper (see `js/libs.bzl`) instead of calling `ctx.actions.run` themselves so this detail
-    stays hidden.
+    `js_binary_lib.run_binary_action` helper (see `js/libs.bzl`) instead of calling `ctx.actions.run` themselves so
+    this detail stays hidden.
 
 # Telemetry & privacy policy
 

--- a/e2e/path_mapping/bindir_path_mapping_check/bindir_path_mapping_check.bzl
+++ b/e2e/path_mapping/bindir_path_mapping_check/bindir_path_mapping_check.bzl
@@ -1,7 +1,7 @@
 """Test-only rule that drives a js_binary tool with a path-mapped --bazel-bindir arg.
 """
 
-load("@aspect_rules_js//js:libs.bzl", "js_run_binary_action")
+load("@aspect_rules_js//js:libs.bzl", "js_binary_lib")
 
 def _bindir_path_mapping_check_impl(ctx):
     output = ctx.actions.declare_directory(ctx.label.name)
@@ -14,7 +14,7 @@ def _bindir_path_mapping_check_impl(ctx):
     if invalidate != None:
         env["BINDIR_PATH_MAPPING_CHECK_INVALIDATE"] = invalidate
 
-    js_run_binary_action(
+    js_binary_lib.run_binary_action(
         ctx = ctx,
         executable = ctx.executable.tool,
         arguments = [output.short_path],

--- a/examples/js_binary/custom_rule.bzl
+++ b/examples/js_binary/custom_rule.bzl
@@ -1,12 +1,12 @@
 "A simple custom rule for testing js_binary used in a custom rule"
 
-load("@aspect_rules_js//js:libs.bzl", "js_run_binary_action")
+load("@aspect_rules_js//js:libs.bzl", "js_binary_lib")
 
 def _custom_rule_impl(ctx):
     out = ctx.actions.declare_file("{}.out".format(ctx.label.name))
     args = ctx.actions.args()
     args.add(out.short_path)
-    js_run_binary_action(
+    js_binary_lib.run_binary_action(
         ctx,
         arguments = [args],
         outputs = [out],

--- a/examples/worker/defs.bzl
+++ b/examples/worker/defs.bzl
@@ -1,6 +1,6 @@
 """A dummy pi rule for end-to-end testing of worker library"""
 
-load("@aspect_rules_js//js:libs.bzl", "js_run_binary_action")
+load("@aspect_rules_js//js:libs.bzl", "js_binary_lib")
 
 def _pi_impl(ctx):
     output = ctx.actions.declare_file(ctx.label.name)
@@ -10,7 +10,7 @@ def _pi_impl(ctx):
     arguments.set_param_file_format("multiline")
     arguments.add(output.short_path)
 
-    js_run_binary_action(
+    js_binary_lib.run_binary_action(
         ctx,
         executable = ctx.executable.worker,
         inputs = [],

--- a/js/libs.bzl
+++ b/js/libs.bzl
@@ -3,7 +3,6 @@
 load(
     "//js/private:js_binary.bzl",
     _js_binary_lib = "js_binary_lib",
-    _js_run_binary_action = "js_run_binary_action",
 )
 load(
     "//js/private:js_helpers.bzl",
@@ -23,7 +22,6 @@ load(
 
 js_binary_lib = _js_binary_lib
 js_library_lib = _js_library_lib
-js_run_binary_action = _js_run_binary_action
 
 js_lib_helpers = struct(
     envs_for_log_level = _envs_for_log_level,

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -594,7 +594,7 @@ def _js_binary_impl(ctx):
 def _bazel_bindir_arg(file):
     return file.root.path
 
-def js_run_binary_action(ctx, **kwargs):
+def _run_binary_action(ctx, **kwargs):
     """Runs a `js_binary` as a tool in a custom rule's action.
 
     This helper function handles internal implementation details related to invoking a
@@ -612,7 +612,7 @@ def js_run_binary_action(ctx, **kwargs):
     # an output here and then derive the bin directory from it in the map_each callback.
     outputs = kwargs.get("outputs")
     if not outputs:
-        fail("js_run_binary_action requires at least one output")
+        fail("run_binary_action requires at least one output")
     extra_args = ctx.actions.args()
     extra_args.add("--bazel-bindir")
 
@@ -629,6 +629,7 @@ js_binary_lib = struct(
     attrs = _ATTRS,
     create_launcher = _create_launcher,
     implementation = _js_binary_impl,
+    run_binary_action = _run_binary_action,
     toolchains = [
         # Optional: only referenced on Windows
         config_common.toolchain_type("@bazel_tools//tools/sh:toolchain_type", mandatory = False),

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -210,7 +210,7 @@ run in the execroot) so that build actions can change directories to always run 
 tree. See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables. This is automatically set \
 by 'js_run_binary' (https://github.com/aspect-build/rules_js/blob/main/docs/js_run_binary.md) which is the recommended \
 rule to use for using a js_binary as the tool of a build action. If you are invoking a js_binary directly from your own \
-custom rule implementation, use the 'js_run_binary_action' helper \
+custom rule implementation, use the 'js_binary_lib.run_binary_action' helper \
 (https://github.com/aspect-build/rules_js/blob/main/js/libs.bzl) instead of calling ctx.actions.run yourself so that \
 BAZEL_BINDIR is set correctly. If this is not a build action you can set the \
 BAZEL_BINDIR to '.' instead to supress this error. For more context on this design decision, please read the \

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -330,7 +330,7 @@ run in the execroot) so that build actions can change directories to always run 
 tree. See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables. This is automatically set \
 by 'js_run_binary' (https://github.com/aspect-build/rules_js/blob/main/docs/js_run_binary.md) which is the recommended \
 rule to use for using a js_binary as the tool of a build action. If you are invoking a js_binary directly from your own \
-custom rule implementation, use the 'js_run_binary_action' helper \
+custom rule implementation, use the 'js_binary_lib.run_binary_action' helper \
 (https://github.com/aspect-build/rules_js/blob/main/js/libs.bzl) instead of calling ctx.actions.run yourself so that \
 BAZEL_BINDIR is set correctly. If this is not a build action you can set the \
 BAZEL_BINDIR to '.' instead to supress this error. For more context on this design decision, please read the \


### PR DESCRIPTION
Moving it into the existing js_binary_lib struct lets consumers detect support via `hasattr(js_binary_lib, "run_binary_action")` instead of a bare top-level symbol that can't be probed for.

This is going to be important for enabling path mapping in rules_ts 3.x, which uses rules_js 2.x. Requiring rules_js 3.x would be a breaking change, so that is not an option. But instead we can opportunistically take advantage of a rules_js 3.x feature if it turns out to be available.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no, because `js_run_binary_action` has not been released yet
- Suggested release notes appear below: yes

Expose js_run_binary_action as js_binary_lib.run_binary_action

### Test plan

- Covered by existing test cases
