### PR TITLE
feat(js_run_devserver): notify after runfiles sync

### DIFF
--- a/js/private/devserver/js_run_devserver.mjs
+++ b/js/private/devserver/js_run_devserver.mjs
@@ -390,7 +390,46 @@ function friendlyFileSize(bytes) {
     )
 }
 
-async function syncSymlink(file, src, dst, sandbox, exists) {
+const IBAZEL_EVENT_PREFIX = 'IBAZEL_EVENT ';
+const RUNFILES_SYNC_EVENT_PREFIX = 'JS_RUN_DEVSERVER_SYNCED ';
+
+function parseIBazelEvent(line) {
+    if (!line.startsWith(IBAZEL_EVENT_PREFIX)) {
+        return null
+    }
+
+    const event = JSON.parse(line.slice(IBAZEL_EVENT_PREFIX.length));
+    if (event.version !== 1 || event.type !== 'build_completed') {
+        return null
+    }
+    return event
+}
+
+function formatRunfilesSyncEvent(
+    sandbox,
+    syncedFiles,
+    deletedFiles,
+    trigger
+) {
+    const changes = [
+        ...syncedFiles.map(({ file, exists }) => ({
+            path: path.join(sandbox, file),
+            kind: exists ? 'changed' : 'added',
+        })),
+        ...deletedFiles.map((file) => ({
+            path: path.join(sandbox, file),
+            kind: 'deleted',
+        })),
+    ].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+    return `${RUNFILES_SYNC_EVENT_PREFIX}${JSON.stringify({
+        version: 1,
+        changes,
+        trigger,
+    })}\n`
+}
+
+async function syncSymlink(file, src, dst, sandbox, exists, syncedFiles) {
     let symlinkMeta = '';
     if (isNodeModulePath(file)) {
         let linkPath = await fs.promises.readlink(src);
@@ -428,10 +467,11 @@ async function syncSymlink(file, src, dst, sandbox, exists) {
         mkdirpSync(path.dirname(dst));
     }
     await fs.promises.symlink(src, dst);
+    syncedFiles.push({ file, exists });
     return 1
 }
 
-async function syncDirectory(file, src, sandbox, writePerm) {
+async function syncDirectory(file, src, sandbox, writePerm, syncedFiles) {
     if (JS_BINARY__LOG_DEBUG) {
         console.error(`Syncing directory ${file}...`);
     }
@@ -444,14 +484,23 @@ async function syncDirectory(file, src, sandbox, writePerm) {
                         file + path.sep + entry,
                         undefined,
                         sandbox,
-                        writePerm
+                        writePerm,
+                        syncedFiles
                     )
             )
         )
     ).reduce((s, t) => s + t, 0)
 }
 
-async function syncFile(file, src, dst, exists, lstat, writePerm) {
+async function syncFile(
+    file,
+    src,
+    dst,
+    exists,
+    lstat,
+    writePerm,
+    syncedFiles
+) {
     if (JS_BINARY__LOG_DEBUG) {
         console.error(
             `Syncing file ${file}${
@@ -483,6 +532,7 @@ async function syncFile(file, src, dst, exists, lstat, writePerm) {
         }
         await fs.promises.chmod(dst, mode);
     }
+    syncedFiles.push({ file, exists });
     return 1
 }
 
@@ -490,7 +540,7 @@ async function syncFile(file, src, dst, exists, lstat, writePerm) {
 // synced it is only re-copied if the file's last modified time has changed since the last time that
 // file was copied. Symlinks are not copied but instead a symlink is created under the destination
 // pointing to the source symlink.
-async function syncRecursive(file, _, sandbox, writePerm) {
+async function syncRecursive(file, _, sandbox, writePerm, syncedFiles) {
     const src = RUNFILES_ROOT + path.sep + file;
     const dst = sandbox + path.sep + file;
 
@@ -512,9 +562,9 @@ async function syncRecursive(file, _, sandbox, writePerm) {
         const exists = syncedTime.has(file) || fs.existsSync(dst);
         syncedTime.set(file, lstat.mtimeMs);
         if (lstat.isSymbolicLink()) {
-            return syncSymlink(file, src, dst, sandbox, exists)
+            return syncSymlink(file, src, dst, sandbox, exists, syncedFiles)
         } else if (lstat.isDirectory()) {
-            return syncDirectory(file, src, sandbox, writePerm)
+            return syncDirectory(file, src, sandbox, writePerm, syncedFiles)
         } else {
             const lastChecksum = syncedChecksum.get(file);
             const checksum = await generateChecksum(src);
@@ -529,7 +579,15 @@ async function syncRecursive(file, _, sandbox, writePerm) {
             }
             syncedChecksum.set(file, checksum);
 
-            return syncFile(file, src, dst, exists, lstat, writePerm)
+            return syncFile(
+                file,
+                src,
+                dst,
+                exists,
+                lstat,
+                writePerm,
+                syncedFiles
+            )
         }
     } catch (e) {
         console.error(e);
@@ -543,6 +601,7 @@ async function deleteFiles(previousFiles, updatedFiles, sandbox) {
     const startTime = perf_hooks.performance.now();
 
     const deletions = [];
+    const deletedFiles = [];
 
     // Remove files that were previously synced but are no longer in the updated list of files to sync
     const updatedFilesSet = new Set();
@@ -577,6 +636,7 @@ async function deleteFiles(previousFiles, updatedFiles, sandbox) {
         deletions.push(
             fs.promises
                 .rm(rmPath, { recursive: true, force: true })
+                .then(() => deletedFiles.push(f))
                 .catch((e) =>
                     console.error(
                         `An error has occurred while deleting the synced file ${rmPath}. Error: ${e}`
@@ -597,12 +657,14 @@ async function deleteFiles(previousFiles, updatedFiles, sandbox) {
             } deleted in ${Math.round(endTime - startTime)} ms`
         );
     }
+    return deletedFiles
 }
 
 // Sync list of files to the sandbox
 async function syncFiles(files, sandbox, writePerm, doSync) {
     console.error(`+ Syncing ${files.length} files & folders...`);
     const startTime = perf_hooks.performance.now();
+    const syncedFiles = [];
 
     // Partition files into node_modules and non-node_modules files
     const packageStore1pDeps = [];
@@ -635,7 +697,13 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     let totalSynced = (
         await Promise.all(
             otherFiles.map(async ([file, isDirectory]) => {
-                return await doSync(file, isDirectory, sandbox, writePerm)
+                return await doSync(
+                    file,
+                    isDirectory,
+                    sandbox,
+                    writePerm,
+                    syncedFiles
+                )
             })
         )
     ).reduce((s, t) => s + t, 0);
@@ -651,7 +719,13 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     totalSynced += (
         await Promise.all(
             packageStore1pDeps.map(async ([file, isDirectory]) => {
-                return await doSync(file, isDirectory, sandbox, writePerm)
+                return await doSync(
+                    file,
+                    isDirectory,
+                    sandbox,
+                    writePerm,
+                    syncedFiles
+                )
             })
         )
     ).reduce((s, t) => s + t, 0);
@@ -666,7 +740,13 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     totalSynced += (
         await Promise.all(
             otherNodeModulesFiles.map(async ([file, isDirectory]) => {
-                return await doSync(file, isDirectory, sandbox, writePerm)
+                return await doSync(
+                    file,
+                    isDirectory,
+                    sandbox,
+                    writePerm,
+                    syncedFiles
+                )
             })
         )
     ).reduce((s, t) => s + t, 0);
@@ -677,6 +757,7 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
             totalSynced > 1 ? 's' : ''
         } synced in ${Math.round(endTime - startTime)} ms`
     );
+    return syncedFiles
 }
 
 function isWindowsScript(tool) {
@@ -765,12 +846,16 @@ async function runIBazelProtocol(
     toolArgs,
     env
 ) {
+    const initialFiles = await fs.promises
+        .readFile(entriesPath)
+        .then(JSON.parse);
     await syncFiles(
-        await fs.promises.readFile(entriesPath).then(JSON.parse),
+        initialFiles,
         sandbox,
         config.grant_sandbox_write_permissions,
         syncRecursive
     );
+    config.previous_files = initialFiles;
 
     return new Promise((resolve) => {
         const proc = child_process.spawn(tool, toolArgs, {
@@ -797,6 +882,7 @@ async function runIBazelProtocol(
         // Process stdin data in order using a promise chain.
         let syncing = Promise.resolve();
         const rl = readline.createInterface({ input: process.stdin });
+        let pendingRunfilesChanges = null;
         rl.on('line', (line) => {
             syncing = syncing.then(() => processChunk(line));
         });
@@ -804,6 +890,7 @@ async function runIBazelProtocol(
         async function processChunk(chunk) {
             try {
                 const chunkString = chunk.toString();
+                const ibazelEvent = parseIBazelEvent(chunkString);
                 if (chunkString.includes('IBAZEL_BUILD_COMPLETED SUCCESS')) {
                     if (JS_BINARY__LOG_DEBUG) {
                         console.error('IBAZEL_BUILD_COMPLETED SUCCESS');
@@ -819,7 +906,7 @@ async function runIBazelProtocol(
                     // Await promises to catch any exceptions, and wait for the
                     // sync to be complete before writing to stdin of the child
                     // process
-                    await Promise.all([
+                    const [deletedFiles, syncedFiles] = await Promise.all([
                         // Remove files that were previously synced but are no longer in the updated list of files to sync
                         deleteFiles(oldFiles, updatedDataFiles, sandbox),
 
@@ -834,10 +921,30 @@ async function runIBazelProtocol(
 
                     // The latest state of copied data files
                     config.previous_files = updatedDataFiles;
+                    pendingRunfilesChanges = { deletedFiles, syncedFiles };
                 } else if (chunkString.includes('IBAZEL_BUILD_STARTED')) {
                     if (JS_BINARY__LOG_DEBUG) {
                         console.error('IBAZEL_BUILD_STARTED');
                     }
+                }
+
+                if (
+                    config.notify_runfiles_changes &&
+                    ibazelEvent?.success &&
+                    pendingRunfilesChanges
+                ) {
+                    await new Promise((resolve) => {
+                        proc.stdin.write(
+                            formatRunfilesSyncEvent(
+                                sandbox,
+                                pendingRunfilesChanges.syncedFiles,
+                                pendingRunfilesChanges.deletedFiles,
+                                ibazelEvent
+                            ),
+                            resolve
+                        );
+                    });
+                    pendingRunfilesChanges = null;
                 }
 
                 // Forward stdin to the subprocess. See comment about
@@ -846,7 +953,7 @@ async function runIBazelProtocol(
                 await new Promise((resolve) => {
                     // note: ignoring error - if this write to stdin fails,
                     // it's probably okay. Can add error handling later if needed
-                    proc.stdin.write(chunk, resolve);
+                    proc.stdin.write(`${chunk}\n`, resolve);
                 });
             } catch (e) {
                 console.error(
@@ -958,7 +1065,14 @@ async function watchProtocolCycle(config, entriesPath, sandbox, cycle) {
     ]);
 }
 
-async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
+async function cycleSyncRecurse(
+    cycle,
+    file,
+    isDirectory,
+    sandbox,
+    writePerm,
+    syncedFiles
+) {
     const src = RUNFILES_ROOT + path.sep + file;
     const dst = sandbox + path.sep + file;
 
@@ -978,13 +1092,21 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
     }
 
     if (srcRunfilesInfo.is_symlink) {
-        return syncSymlink(file, src, dst, sandbox, exists)
+        return syncSymlink(file, src, dst, sandbox, exists, syncedFiles)
     }
 
     if (isDirectory) {
-        return syncDirectory(file, src, sandbox, writePerm)
+        return syncDirectory(file, src, sandbox, writePerm, syncedFiles)
     } else {
-        return syncFile(file, src, dst, exists, null, writePerm)
+        return syncFile(
+            file,
+            src,
+            dst,
+            exists,
+            null,
+            writePerm,
+            syncedFiles
+        )
     }
 }
 (async () => {
@@ -1038,4 +1160,4 @@ function onProcessEnd(callback) {
     // Do not invoke on uncaught exception or errors to allow inspecting the sandbox
 }
 
-export { friendlyFileSize, is1pPackageStoreDep, isNodeModulePath };
+export { formatRunfilesSyncEvent, friendlyFileSize, is1pPackageStoreDep, isNodeModulePath, parseIBazelEvent };

--- a/js/private/devserver/js_run_devserver.mjs
+++ b/js/private/devserver/js_run_devserver.mjs
@@ -392,6 +392,11 @@ function friendlyFileSize(bytes) {
 
 const IBAZEL_EVENT_PREFIX = 'IBAZEL_EVENT ';
 const RUNFILES_SYNC_EVENT_PREFIX = 'JS_RUN_DEVSERVER_SYNCED ';
+const RUNFILES_NOTIFICATION_ENV = 'JS_RUN_DEVSERVER_NOTIFY_RUNFILES_CHANGES';
+
+function runfilesNotificationEnv(env, enabled) {
+    return enabled ? { ...env, [RUNFILES_NOTIFICATION_ENV]: '1' } : env
+}
 
 function parseIBazelEvent(line) {
     if (!line.startsWith(IBAZEL_EVENT_PREFIX)) {
@@ -939,7 +944,7 @@ async function runIBazelProtocol(
     return new Promise((resolve) => {
         const proc = child_process.spawn(tool, toolArgs, {
             cwd: cwd,
-            env: env,
+            env: runfilesNotificationEnv(env, config.notify_runfiles_changes),
 
             // `.cmd` and `.bat` are always executed in a shell on windows
             // and require the flag to be set per CVE-2024-27980
@@ -1218,4 +1223,4 @@ function onProcessEnd(callback) {
     // Do not invoke on uncaught exception or errors to allow inspecting the sandbox
 }
 
-export { createIBazelLineProcessor, formatRunfilesSyncEvent, friendlyFileSize, is1pPackageStoreDep, isNodeModulePath, parseIBazelEvent, selectRunfilesToSync };
+export { createIBazelLineProcessor, formatRunfilesSyncEvent, friendlyFileSize, is1pPackageStoreDep, isNodeModulePath, parseIBazelEvent, runfilesNotificationEnv, selectRunfilesToSync };

--- a/js/private/devserver/js_run_devserver.mjs
+++ b/js/private/devserver/js_run_devserver.mjs
@@ -405,6 +405,45 @@ function parseIBazelEvent(line) {
     return event
 }
 
+function selectRunfilesToSync(files, event, workspaceRoot) {
+    if (!workspaceRoot || event.changes.some(({ kind }) => kind === 'graph')) {
+        return files
+    }
+
+    const changedSources = new Set();
+    for (const { path: changedPath, kind } of event.changes) {
+        if (kind !== 'source') {
+            return files
+        }
+
+        const relativePath = path.relative(workspaceRoot, changedPath);
+        if (
+            !relativePath ||
+            relativePath === '..' ||
+            relativePath.startsWith(`..${path.sep}`) ||
+            path.isAbsolute(relativePath)
+        ) {
+            return files
+        }
+        changedSources.add(path.normalize(relativePath));
+    }
+
+    return files.filter(([file, isDirectory, isSource]) => {
+        if (!isSource) {
+            return true
+        }
+
+        const normalizedFile = path.normalize(file);
+        return (
+            changedSources.has(normalizedFile) ||
+            (isDirectory &&
+                [...changedSources].some((changedSource) =>
+                    changedSource.startsWith(`${normalizedFile}${path.sep}`)
+                ))
+        )
+    })
+}
+
 function formatRunfilesSyncEvent(
     sandbox,
     syncedFiles,
@@ -427,6 +466,46 @@ function formatRunfilesSyncEvent(
         changes,
         trigger,
     })}\n`
+}
+
+function createIBazelLineProcessor({
+    notifyRunfilesChanges,
+    sandbox,
+    syncBuild,
+    writeToChild,
+}) {
+    let pendingBuildCompleted = null;
+
+    return async (chunk) => {
+        const chunkString = chunk.toString();
+        const ibazelEvent = parseIBazelEvent(chunkString);
+
+        if (chunkString.includes('IBAZEL_BUILD_COMPLETED SUCCESS')) {
+            if (notifyRunfilesChanges) {
+                pendingBuildCompleted = chunkString;
+                return
+            }
+            await syncBuild(null);
+        }
+
+        if (notifyRunfilesChanges && ibazelEvent?.success) {
+            const { deletedFiles, syncedFiles } = await syncBuild(ibazelEvent);
+            if (pendingBuildCompleted) {
+                await writeToChild(`${pendingBuildCompleted}\n`);
+                pendingBuildCompleted = null;
+            }
+            await writeToChild(
+                formatRunfilesSyncEvent(
+                    sandbox,
+                    syncedFiles,
+                    deletedFiles,
+                    ibazelEvent
+                )
+            );
+        }
+
+        await writeToChild(`${chunk}\n`);
+    }
 }
 
 async function syncSymlink(file, src, dst, sandbox, exists, syncedFiles) {
@@ -882,86 +961,65 @@ async function runIBazelProtocol(
         // Process stdin data in order using a promise chain.
         let syncing = Promise.resolve();
         const rl = readline.createInterface({ input: process.stdin });
-        let pendingRunfilesChanges = null;
-        rl.on('line', (line) => {
-            syncing = syncing.then(() => processChunk(line));
+
+        async function syncBuild(ibazelEvent) {
+            const oldFiles = config.previous_files || [];
+
+            // Re-parse the config file to get the latest list of data files to copy
+            const updatedDataFiles = await fs.promises
+                .readFile(entriesPath)
+                .then(JSON.parse);
+            const filesToSync = ibazelEvent
+                ? selectRunfilesToSync(
+                      updatedDataFiles,
+                      ibazelEvent,
+                      process.env.BUILD_WORKSPACE_DIRECTORY
+                  )
+                : updatedDataFiles;
+
+            const [deletedFiles, syncedFiles] = await Promise.all([
+                // Remove files that were previously synced but are no longer in the updated list of files to sync
+                deleteFiles(oldFiles, updatedDataFiles, sandbox),
+
+                // Sync changed source files and scan generated outputs for changes.
+                syncFiles(
+                    filesToSync,
+                    sandbox,
+                    config.grant_sandbox_write_permissions,
+                    syncRecursive
+                ),
+            ]);
+
+            // The latest state of copied data files
+            config.previous_files = updatedDataFiles;
+            return { deletedFiles, syncedFiles }
+        }
+
+        async function writeToChild(line) {
+            await new Promise((resolve) => {
+                // note: ignoring error - if this write to stdin fails,
+                // it's probably okay. Can add error handling later if needed
+                proc.stdin.write(line, resolve);
+            });
+        }
+
+        const processChunk = createIBazelLineProcessor({
+            notifyRunfilesChanges: config.notify_runfiles_changes,
+            sandbox,
+            syncBuild,
+            writeToChild,
         });
-
-        async function processChunk(chunk) {
-            try {
-                const chunkString = chunk.toString();
-                const ibazelEvent = parseIBazelEvent(chunkString);
-                if (chunkString.includes('IBAZEL_BUILD_COMPLETED SUCCESS')) {
-                    if (JS_BINARY__LOG_DEBUG) {
-                        console.error('IBAZEL_BUILD_COMPLETED SUCCESS');
-                    }
-
-                    const oldFiles = config.previous_files || [];
-
-                    // Re-parse the config file to get the latest list of data files to copy
-                    const updatedDataFiles = await fs.promises
-                        .readFile(entriesPath)
-                        .then(JSON.parse);
-
-                    // Await promises to catch any exceptions, and wait for the
-                    // sync to be complete before writing to stdin of the child
-                    // process
-                    const [deletedFiles, syncedFiles] = await Promise.all([
-                        // Remove files that were previously synced but are no longer in the updated list of files to sync
-                        deleteFiles(oldFiles, updatedDataFiles, sandbox),
-
-                        // Sync changed files
-                        syncFiles(
-                            updatedDataFiles,
-                            sandbox,
-                            config.grant_sandbox_write_permissions,
-                            syncRecursive
-                        ),
-                    ]);
-
-                    // The latest state of copied data files
-                    config.previous_files = updatedDataFiles;
-                    pendingRunfilesChanges = { deletedFiles, syncedFiles };
-                } else if (chunkString.includes('IBAZEL_BUILD_STARTED')) {
-                    if (JS_BINARY__LOG_DEBUG) {
-                        console.error('IBAZEL_BUILD_STARTED');
-                    }
-                }
-
-                if (
-                    config.notify_runfiles_changes &&
-                    ibazelEvent?.success &&
-                    pendingRunfilesChanges
-                ) {
-                    await new Promise((resolve) => {
-                        proc.stdin.write(
-                            formatRunfilesSyncEvent(
-                                sandbox,
-                                pendingRunfilesChanges.syncedFiles,
-                                pendingRunfilesChanges.deletedFiles,
-                                ibazelEvent
-                            ),
-                            resolve
-                        );
-                    });
-                    pendingRunfilesChanges = null;
-                }
-
-                // Forward stdin to the subprocess. See comment about
-                // https://github.com/aspect-build/rules_js/issues/1242 where
-                // `proc` is spawned
-                await new Promise((resolve) => {
-                    // note: ignoring error - if this write to stdin fails,
-                    // it's probably okay. Can add error handling later if needed
-                    proc.stdin.write(`${chunk}\n`, resolve);
-                });
-            } catch (e) {
+        rl.on('line', (line) => {
+            if (JS_BINARY__LOG_DEBUG && line.startsWith('IBAZEL_')) {
+                console.error(line);
+            }
+            syncing = syncing.then(() => processChunk(line)).catch((e) => {
                 console.error(
                     `An error has occurred while incrementally syncing files. Error: ${e}`
                 );
                 process.exit(1);
-            }
-        }
+            });
+        });
     })
 }
 
@@ -1160,4 +1218,4 @@ function onProcessEnd(callback) {
     // Do not invoke on uncaught exception or errors to allow inspecting the sandbox
 }
 
-export { formatRunfilesSyncEvent, friendlyFileSize, is1pPackageStoreDep, isNodeModulePath, parseIBazelEvent };
+export { createIBazelLineProcessor, formatRunfilesSyncEvent, friendlyFileSize, is1pPackageStoreDep, isNodeModulePath, parseIBazelEvent, selectRunfilesToSync };

--- a/js/private/devserver/src/js_run_devserver.mjs
+++ b/js/private/devserver/src/js_run_devserver.mjs
@@ -142,7 +142,46 @@ export function friendlyFileSize(bytes) {
     )
 }
 
-async function syncSymlink(file, src, dst, sandbox, exists) {
+const IBAZEL_EVENT_PREFIX = 'IBAZEL_EVENT '
+const RUNFILES_SYNC_EVENT_PREFIX = 'JS_RUN_DEVSERVER_SYNCED '
+
+export function parseIBazelEvent(line) {
+    if (!line.startsWith(IBAZEL_EVENT_PREFIX)) {
+        return null
+    }
+
+    const event = JSON.parse(line.slice(IBAZEL_EVENT_PREFIX.length))
+    if (event.version !== 1 || event.type !== 'build_completed') {
+        return null
+    }
+    return event
+}
+
+export function formatRunfilesSyncEvent(
+    sandbox,
+    syncedFiles,
+    deletedFiles,
+    trigger
+) {
+    const changes = [
+        ...syncedFiles.map(({ file, exists }) => ({
+            path: path.join(sandbox, file),
+            kind: exists ? 'changed' : 'added',
+        })),
+        ...deletedFiles.map((file) => ({
+            path: path.join(sandbox, file),
+            kind: 'deleted',
+        })),
+    ].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+
+    return `${RUNFILES_SYNC_EVENT_PREFIX}${JSON.stringify({
+        version: 1,
+        changes,
+        trigger,
+    })}\n`
+}
+
+async function syncSymlink(file, src, dst, sandbox, exists, syncedFiles) {
     let symlinkMeta = ''
     if (isNodeModulePath(file)) {
         let linkPath = await fs.promises.readlink(src)
@@ -180,10 +219,11 @@ async function syncSymlink(file, src, dst, sandbox, exists) {
         mkdirpSync(path.dirname(dst))
     }
     await fs.promises.symlink(src, dst)
+    syncedFiles.push({ file, exists })
     return 1
 }
 
-async function syncDirectory(file, src, sandbox, writePerm) {
+async function syncDirectory(file, src, sandbox, writePerm, syncedFiles) {
     if (JS_BINARY__LOG_DEBUG) {
         console.error(`Syncing directory ${file}...`)
     }
@@ -196,14 +236,23 @@ async function syncDirectory(file, src, sandbox, writePerm) {
                         file + path.sep + entry,
                         undefined,
                         sandbox,
-                        writePerm
+                        writePerm,
+                        syncedFiles
                     )
             )
         )
     ).reduce((s, t) => s + t, 0)
 }
 
-async function syncFile(file, src, dst, exists, lstat, writePerm) {
+async function syncFile(
+    file,
+    src,
+    dst,
+    exists,
+    lstat,
+    writePerm,
+    syncedFiles
+) {
     if (JS_BINARY__LOG_DEBUG) {
         console.error(
             `Syncing file ${file}${
@@ -235,6 +284,7 @@ async function syncFile(file, src, dst, exists, lstat, writePerm) {
         }
         await fs.promises.chmod(dst, mode)
     }
+    syncedFiles.push({ file, exists })
     return 1
 }
 
@@ -242,7 +292,7 @@ async function syncFile(file, src, dst, exists, lstat, writePerm) {
 // synced it is only re-copied if the file's last modified time has changed since the last time that
 // file was copied. Symlinks are not copied but instead a symlink is created under the destination
 // pointing to the source symlink.
-async function syncRecursive(file, _, sandbox, writePerm) {
+async function syncRecursive(file, _, sandbox, writePerm, syncedFiles) {
     const src = RUNFILES_ROOT + path.sep + file
     const dst = sandbox + path.sep + file
 
@@ -264,9 +314,9 @@ async function syncRecursive(file, _, sandbox, writePerm) {
         const exists = syncedTime.has(file) || fs.existsSync(dst)
         syncedTime.set(file, lstat.mtimeMs)
         if (lstat.isSymbolicLink()) {
-            return syncSymlink(file, src, dst, sandbox, exists)
+            return syncSymlink(file, src, dst, sandbox, exists, syncedFiles)
         } else if (lstat.isDirectory()) {
-            return syncDirectory(file, src, sandbox, writePerm)
+            return syncDirectory(file, src, sandbox, writePerm, syncedFiles)
         } else {
             const lastChecksum = syncedChecksum.get(file)
             const checksum = await generateChecksum(src)
@@ -281,7 +331,15 @@ async function syncRecursive(file, _, sandbox, writePerm) {
             }
             syncedChecksum.set(file, checksum)
 
-            return syncFile(file, src, dst, exists, lstat, writePerm)
+            return syncFile(
+                file,
+                src,
+                dst,
+                exists,
+                lstat,
+                writePerm,
+                syncedFiles
+            )
         }
     } catch (e) {
         console.error(e)
@@ -295,6 +353,7 @@ async function deleteFiles(previousFiles, updatedFiles, sandbox) {
     const startTime = perf_hooks.performance.now()
 
     const deletions = []
+    const deletedFiles = []
 
     // Remove files that were previously synced but are no longer in the updated list of files to sync
     const updatedFilesSet = new Set()
@@ -329,6 +388,7 @@ async function deleteFiles(previousFiles, updatedFiles, sandbox) {
         deletions.push(
             fs.promises
                 .rm(rmPath, { recursive: true, force: true })
+                .then(() => deletedFiles.push(f))
                 .catch((e) =>
                     console.error(
                         `An error has occurred while deleting the synced file ${rmPath}. Error: ${e}`
@@ -349,12 +409,14 @@ async function deleteFiles(previousFiles, updatedFiles, sandbox) {
             } deleted in ${Math.round(endTime - startTime)} ms`
         )
     }
+    return deletedFiles
 }
 
 // Sync list of files to the sandbox
 async function syncFiles(files, sandbox, writePerm, doSync) {
     console.error(`+ Syncing ${files.length} files & folders...`)
     const startTime = perf_hooks.performance.now()
+    const syncedFiles = []
 
     // Partition files into node_modules and non-node_modules files
     const packageStore1pDeps = []
@@ -387,7 +449,13 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     let totalSynced = (
         await Promise.all(
             otherFiles.map(async ([file, isDirectory]) => {
-                return await doSync(file, isDirectory, sandbox, writePerm)
+                return await doSync(
+                    file,
+                    isDirectory,
+                    sandbox,
+                    writePerm,
+                    syncedFiles
+                )
             })
         )
     ).reduce((s, t) => s + t, 0)
@@ -403,7 +471,13 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     totalSynced += (
         await Promise.all(
             packageStore1pDeps.map(async ([file, isDirectory]) => {
-                return await doSync(file, isDirectory, sandbox, writePerm)
+                return await doSync(
+                    file,
+                    isDirectory,
+                    sandbox,
+                    writePerm,
+                    syncedFiles
+                )
             })
         )
     ).reduce((s, t) => s + t, 0)
@@ -418,7 +492,13 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     totalSynced += (
         await Promise.all(
             otherNodeModulesFiles.map(async ([file, isDirectory]) => {
-                return await doSync(file, isDirectory, sandbox, writePerm)
+                return await doSync(
+                    file,
+                    isDirectory,
+                    sandbox,
+                    writePerm,
+                    syncedFiles
+                )
             })
         )
     ).reduce((s, t) => s + t, 0)
@@ -429,6 +509,7 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
             totalSynced > 1 ? 's' : ''
         } synced in ${Math.round(endTime - startTime)} ms`
     )
+    return syncedFiles
 }
 
 function isWindowsScript(tool) {
@@ -517,12 +598,16 @@ async function runIBazelProtocol(
     toolArgs,
     env
 ) {
+    const initialFiles = await fs.promises
+        .readFile(entriesPath)
+        .then(JSON.parse)
     await syncFiles(
-        await fs.promises.readFile(entriesPath).then(JSON.parse),
+        initialFiles,
         sandbox,
         config.grant_sandbox_write_permissions,
         syncRecursive
     )
+    config.previous_files = initialFiles
 
     return new Promise((resolve) => {
         const proc = child_process.spawn(tool, toolArgs, {
@@ -549,6 +634,7 @@ async function runIBazelProtocol(
         // Process stdin data in order using a promise chain.
         let syncing = Promise.resolve()
         const rl = readline.createInterface({ input: process.stdin })
+        let pendingRunfilesChanges = null
         rl.on('line', (line) => {
             syncing = syncing.then(() => processChunk(line))
         })
@@ -556,6 +642,7 @@ async function runIBazelProtocol(
         async function processChunk(chunk) {
             try {
                 const chunkString = chunk.toString()
+                const ibazelEvent = parseIBazelEvent(chunkString)
                 if (chunkString.includes('IBAZEL_BUILD_COMPLETED SUCCESS')) {
                     if (JS_BINARY__LOG_DEBUG) {
                         console.error('IBAZEL_BUILD_COMPLETED SUCCESS')
@@ -571,7 +658,7 @@ async function runIBazelProtocol(
                     // Await promises to catch any exceptions, and wait for the
                     // sync to be complete before writing to stdin of the child
                     // process
-                    await Promise.all([
+                    const [deletedFiles, syncedFiles] = await Promise.all([
                         // Remove files that were previously synced but are no longer in the updated list of files to sync
                         deleteFiles(oldFiles, updatedDataFiles, sandbox),
 
@@ -586,10 +673,30 @@ async function runIBazelProtocol(
 
                     // The latest state of copied data files
                     config.previous_files = updatedDataFiles
+                    pendingRunfilesChanges = { deletedFiles, syncedFiles }
                 } else if (chunkString.includes('IBAZEL_BUILD_STARTED')) {
                     if (JS_BINARY__LOG_DEBUG) {
                         console.error('IBAZEL_BUILD_STARTED')
                     }
+                }
+
+                if (
+                    config.notify_runfiles_changes &&
+                    ibazelEvent?.success &&
+                    pendingRunfilesChanges
+                ) {
+                    await new Promise((resolve) => {
+                        proc.stdin.write(
+                            formatRunfilesSyncEvent(
+                                sandbox,
+                                pendingRunfilesChanges.syncedFiles,
+                                pendingRunfilesChanges.deletedFiles,
+                                ibazelEvent
+                            ),
+                            resolve
+                        )
+                    })
+                    pendingRunfilesChanges = null
                 }
 
                 // Forward stdin to the subprocess. See comment about
@@ -598,7 +705,7 @@ async function runIBazelProtocol(
                 await new Promise((resolve) => {
                     // note: ignoring error - if this write to stdin fails,
                     // it's probably okay. Can add error handling later if needed
-                    proc.stdin.write(chunk, resolve)
+                    proc.stdin.write(`${chunk}\n`, resolve)
                 })
             } catch (e) {
                 console.error(
@@ -710,7 +817,14 @@ async function watchProtocolCycle(config, entriesPath, sandbox, cycle) {
     ])
 }
 
-async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
+async function cycleSyncRecurse(
+    cycle,
+    file,
+    isDirectory,
+    sandbox,
+    writePerm,
+    syncedFiles
+) {
     const src = RUNFILES_ROOT + path.sep + file
     const dst = sandbox + path.sep + file
 
@@ -730,13 +844,21 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
     }
 
     if (srcRunfilesInfo.is_symlink) {
-        return syncSymlink(file, src, dst, sandbox, exists)
+        return syncSymlink(file, src, dst, sandbox, exists, syncedFiles)
     }
 
     if (isDirectory) {
-        return syncDirectory(file, src, sandbox, writePerm)
+        return syncDirectory(file, src, sandbox, writePerm, syncedFiles)
     } else {
-        return syncFile(file, src, dst, exists, null, writePerm)
+        return syncFile(
+            file,
+            src,
+            dst,
+            exists,
+            null,
+            writePerm,
+            syncedFiles
+        )
     }
 }
 

--- a/js/private/devserver/src/js_run_devserver.mjs
+++ b/js/private/devserver/src/js_run_devserver.mjs
@@ -157,6 +157,45 @@ export function parseIBazelEvent(line) {
     return event
 }
 
+export function selectRunfilesToSync(files, event, workspaceRoot) {
+    if (!workspaceRoot || event.changes.some(({ kind }) => kind === 'graph')) {
+        return files
+    }
+
+    const changedSources = new Set()
+    for (const { path: changedPath, kind } of event.changes) {
+        if (kind !== 'source') {
+            return files
+        }
+
+        const relativePath = path.relative(workspaceRoot, changedPath)
+        if (
+            !relativePath ||
+            relativePath === '..' ||
+            relativePath.startsWith(`..${path.sep}`) ||
+            path.isAbsolute(relativePath)
+        ) {
+            return files
+        }
+        changedSources.add(path.normalize(relativePath))
+    }
+
+    return files.filter(([file, isDirectory, isSource]) => {
+        if (!isSource) {
+            return true
+        }
+
+        const normalizedFile = path.normalize(file)
+        return (
+            changedSources.has(normalizedFile) ||
+            (isDirectory &&
+                [...changedSources].some((changedSource) =>
+                    changedSource.startsWith(`${normalizedFile}${path.sep}`)
+                ))
+        )
+    })
+}
+
 export function formatRunfilesSyncEvent(
     sandbox,
     syncedFiles,
@@ -179,6 +218,46 @@ export function formatRunfilesSyncEvent(
         changes,
         trigger,
     })}\n`
+}
+
+export function createIBazelLineProcessor({
+    notifyRunfilesChanges,
+    sandbox,
+    syncBuild,
+    writeToChild,
+}) {
+    let pendingBuildCompleted = null
+
+    return async (chunk) => {
+        const chunkString = chunk.toString()
+        const ibazelEvent = parseIBazelEvent(chunkString)
+
+        if (chunkString.includes('IBAZEL_BUILD_COMPLETED SUCCESS')) {
+            if (notifyRunfilesChanges) {
+                pendingBuildCompleted = chunkString
+                return
+            }
+            await syncBuild(null)
+        }
+
+        if (notifyRunfilesChanges && ibazelEvent?.success) {
+            const { deletedFiles, syncedFiles } = await syncBuild(ibazelEvent)
+            if (pendingBuildCompleted) {
+                await writeToChild(`${pendingBuildCompleted}\n`)
+                pendingBuildCompleted = null
+            }
+            await writeToChild(
+                formatRunfilesSyncEvent(
+                    sandbox,
+                    syncedFiles,
+                    deletedFiles,
+                    ibazelEvent
+                )
+            )
+        }
+
+        await writeToChild(`${chunk}\n`)
+    }
 }
 
 async function syncSymlink(file, src, dst, sandbox, exists, syncedFiles) {
@@ -634,86 +713,65 @@ async function runIBazelProtocol(
         // Process stdin data in order using a promise chain.
         let syncing = Promise.resolve()
         const rl = readline.createInterface({ input: process.stdin })
-        let pendingRunfilesChanges = null
-        rl.on('line', (line) => {
-            syncing = syncing.then(() => processChunk(line))
+
+        async function syncBuild(ibazelEvent) {
+            const oldFiles = config.previous_files || []
+
+            // Re-parse the config file to get the latest list of data files to copy
+            const updatedDataFiles = await fs.promises
+                .readFile(entriesPath)
+                .then(JSON.parse)
+            const filesToSync = ibazelEvent
+                ? selectRunfilesToSync(
+                      updatedDataFiles,
+                      ibazelEvent,
+                      process.env.BUILD_WORKSPACE_DIRECTORY
+                  )
+                : updatedDataFiles
+
+            const [deletedFiles, syncedFiles] = await Promise.all([
+                // Remove files that were previously synced but are no longer in the updated list of files to sync
+                deleteFiles(oldFiles, updatedDataFiles, sandbox),
+
+                // Sync changed source files and scan generated outputs for changes.
+                syncFiles(
+                    filesToSync,
+                    sandbox,
+                    config.grant_sandbox_write_permissions,
+                    syncRecursive
+                ),
+            ])
+
+            // The latest state of copied data files
+            config.previous_files = updatedDataFiles
+            return { deletedFiles, syncedFiles }
+        }
+
+        async function writeToChild(line) {
+            await new Promise((resolve) => {
+                // note: ignoring error - if this write to stdin fails,
+                // it's probably okay. Can add error handling later if needed
+                proc.stdin.write(line, resolve)
+            })
+        }
+
+        const processChunk = createIBazelLineProcessor({
+            notifyRunfilesChanges: config.notify_runfiles_changes,
+            sandbox,
+            syncBuild,
+            writeToChild,
         })
-
-        async function processChunk(chunk) {
-            try {
-                const chunkString = chunk.toString()
-                const ibazelEvent = parseIBazelEvent(chunkString)
-                if (chunkString.includes('IBAZEL_BUILD_COMPLETED SUCCESS')) {
-                    if (JS_BINARY__LOG_DEBUG) {
-                        console.error('IBAZEL_BUILD_COMPLETED SUCCESS')
-                    }
-
-                    const oldFiles = config.previous_files || []
-
-                    // Re-parse the config file to get the latest list of data files to copy
-                    const updatedDataFiles = await fs.promises
-                        .readFile(entriesPath)
-                        .then(JSON.parse)
-
-                    // Await promises to catch any exceptions, and wait for the
-                    // sync to be complete before writing to stdin of the child
-                    // process
-                    const [deletedFiles, syncedFiles] = await Promise.all([
-                        // Remove files that were previously synced but are no longer in the updated list of files to sync
-                        deleteFiles(oldFiles, updatedDataFiles, sandbox),
-
-                        // Sync changed files
-                        syncFiles(
-                            updatedDataFiles,
-                            sandbox,
-                            config.grant_sandbox_write_permissions,
-                            syncRecursive
-                        ),
-                    ])
-
-                    // The latest state of copied data files
-                    config.previous_files = updatedDataFiles
-                    pendingRunfilesChanges = { deletedFiles, syncedFiles }
-                } else if (chunkString.includes('IBAZEL_BUILD_STARTED')) {
-                    if (JS_BINARY__LOG_DEBUG) {
-                        console.error('IBAZEL_BUILD_STARTED')
-                    }
-                }
-
-                if (
-                    config.notify_runfiles_changes &&
-                    ibazelEvent?.success &&
-                    pendingRunfilesChanges
-                ) {
-                    await new Promise((resolve) => {
-                        proc.stdin.write(
-                            formatRunfilesSyncEvent(
-                                sandbox,
-                                pendingRunfilesChanges.syncedFiles,
-                                pendingRunfilesChanges.deletedFiles,
-                                ibazelEvent
-                            ),
-                            resolve
-                        )
-                    })
-                    pendingRunfilesChanges = null
-                }
-
-                // Forward stdin to the subprocess. See comment about
-                // https://github.com/aspect-build/rules_js/issues/1242 where
-                // `proc` is spawned
-                await new Promise((resolve) => {
-                    // note: ignoring error - if this write to stdin fails,
-                    // it's probably okay. Can add error handling later if needed
-                    proc.stdin.write(`${chunk}\n`, resolve)
-                })
-            } catch (e) {
+        rl.on('line', (line) => {
+            if (JS_BINARY__LOG_DEBUG && line.startsWith('IBAZEL_')) {
+                console.error(line)
+            }
+            syncing = syncing.then(() => processChunk(line)).catch((e) => {
                 console.error(
                     `An error has occurred while incrementally syncing files. Error: ${e}`
                 )
                 process.exit(1)
-            }
-        }
+            })
+        })
     })
 }
 

--- a/js/private/devserver/src/js_run_devserver.mjs
+++ b/js/private/devserver/src/js_run_devserver.mjs
@@ -144,6 +144,11 @@ export function friendlyFileSize(bytes) {
 
 const IBAZEL_EVENT_PREFIX = 'IBAZEL_EVENT '
 const RUNFILES_SYNC_EVENT_PREFIX = 'JS_RUN_DEVSERVER_SYNCED '
+const RUNFILES_NOTIFICATION_ENV = 'JS_RUN_DEVSERVER_NOTIFY_RUNFILES_CHANGES'
+
+export function runfilesNotificationEnv(env, enabled) {
+    return enabled ? { ...env, [RUNFILES_NOTIFICATION_ENV]: '1' } : env
+}
 
 export function parseIBazelEvent(line) {
     if (!line.startsWith(IBAZEL_EVENT_PREFIX)) {
@@ -691,7 +696,7 @@ async function runIBazelProtocol(
     return new Promise((resolve) => {
         const proc = child_process.spawn(tool, toolArgs, {
             cwd: cwd,
-            env: env,
+            env: runfilesNotificationEnv(env, config.notify_runfiles_changes),
 
             // `.cmd` and `.bat` are always executed in a shell on windows
             // and require the flag to be set per CVE-2024-27980

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -12,6 +12,7 @@ _attrs = js_binary_lib.attrs | {
         default = True,
     ),
     "grant_sandbox_write_permissions": attr.bool(),
+    "notify_runfiles_changes": attr.bool(),
     "allow_execroot_entry_point_with_no_copy_data_to_bin": attr.bool(),
     "command": attr.string(),
 }
@@ -90,6 +91,8 @@ def _js_run_devserver_impl(ctx):
         config["command"] = ctx.attr.command
     if ctx.attr.grant_sandbox_write_permissions:
         config["grant_sandbox_write_permissions"] = "1"
+    if ctx.attr.notify_runfiles_changes:
+        config["notify_runfiles_changes"] = "1"
 
     ctx.actions.write(config_file, json.encode(config))
 
@@ -126,6 +129,7 @@ def js_run_devserver(
         tool = None,
         command = None,
         grant_sandbox_write_permissions = False,
+        notify_runfiles_changes = False,
         use_execroot_entry_point = True,
         allow_execroot_entry_point_with_no_copy_data_to_bin = False,
         **kwargs):
@@ -232,6 +236,11 @@ def js_run_devserver(
 
             See https://github.com/aspect-build/rules_js/issues/935 for more context.
 
+        notify_runfiles_changes: Emit a versioned `JS_RUN_DEVSERVER_SYNCED` JSON event on the child process stdin
+            after each successful iBazel build has been synchronized into the custom sandbox. The event reports
+            exact added, changed, and deleted sandbox paths, and includes the triggering `IBAZEL_EVENT` from
+            iBazel's `ibazel_notify_changes_v1` protocol.
+
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.
 
@@ -273,10 +282,11 @@ def js_run_devserver(
             "ibazel_live_reload",
             "ibazel_notify_changes",
             "supports_incremental_build_protocol",
-        ],
+        ] + (["ibazel_notify_changes_v1"] if notify_runfiles_changes else []),
         tool = tool,
         command = command,
         grant_sandbox_write_permissions = grant_sandbox_write_permissions,
+        notify_runfiles_changes = notify_runfiles_changes,
         use_execroot_entry_point = use_execroot_entry_point,
         allow_execroot_entry_point_with_no_copy_data_to_bin = allow_execroot_entry_point_with_no_copy_data_to_bin,
         **kwargs

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -31,7 +31,8 @@ def _file_to_entry_json(f):
         if len(path_segments) <= package_name_segment or "@0.0.0" not in path_segments[package_name_segment]:
             return None
 
-    return json.encode([f.short_path, 1 if f.is_directory else 0])
+    # Source provenance lets notify_changes_v1 skip unchanged source runfiles while still scanning generated outputs.
+    return json.encode([f.short_path, 1 if f.is_directory else 0, 1 if f.is_source else 0])
 
 def _js_run_devserver_impl(ctx):
     config_file = ctx.actions.declare_file("{}_config.json".format(ctx.label.name))
@@ -239,7 +240,8 @@ def js_run_devserver(
         notify_runfiles_changes: Emit a versioned `JS_RUN_DEVSERVER_SYNCED` JSON event on the child process stdin
             after each successful iBazel build has been synchronized into the custom sandbox. The event reports
             exact added, changed, and deleted sandbox paths, and includes the triggering `IBAZEL_EVENT` from
-            iBazel's `ibazel_notify_changes_v1` protocol.
+            iBazel's `ibazel_notify_changes_v1` protocol. Source events synchronize matching source runfiles and
+            scan generated outputs. Build-graph events and source paths outside the workspace fall back to a full sync.
 
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.

--- a/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
+++ b/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
@@ -1,11 +1,13 @@
 import path from 'node:path'
 
 import {
+    createIBazelLineProcessor,
     formatRunfilesSyncEvent,
     isNodeModulePath,
     is1pPackageStoreDep,
     friendlyFileSize,
     parseIBazelEvent,
+    selectRunfilesToSync,
 } from '../../devserver/js_run_devserver.mjs'
 
 // isNodeModulePath
@@ -126,5 +128,134 @@ if (JSON.stringify(syncEventPayload.changes) !== JSON.stringify(expectedChanges)
 }
 if (JSON.stringify(syncEventPayload.trigger) !== JSON.stringify(ibazelEvent)) {
     console.error('ERROR: expected sync event to retain the parsed iBazel event')
+    process.exit(1)
+}
+
+const runfiles = [
+    ['src/app.ts', 0, 1],
+    ['src/other.ts', 0, 1],
+    ['src/assets', 1, 1],
+    ['generated/app.js', 0, 0],
+]
+const selectedRunfiles = selectRunfilesToSync(
+    runfiles,
+    ibazelEvent,
+    '/workspace'
+)
+const expectedSelectedRunfiles = [runfiles[0], runfiles[3]]
+if (
+    JSON.stringify(selectedRunfiles) !==
+    JSON.stringify(expectedSelectedRunfiles)
+) {
+    console.error(
+        `ERROR: expected selective source sync ${JSON.stringify(
+            expectedSelectedRunfiles
+        )} but got ${JSON.stringify(selectedRunfiles)}`
+    )
+    process.exit(1)
+}
+
+const directoryEvent = {
+    ...ibazelEvent,
+    changes: [{ path: '/workspace/src/assets/logo.svg', kind: 'source' }],
+}
+const expectedDirectoryRunfiles = [runfiles[2], runfiles[3]]
+const selectedDirectoryRunfiles = selectRunfilesToSync(
+    runfiles,
+    directoryEvent,
+    '/workspace'
+)
+if (
+    JSON.stringify(selectedDirectoryRunfiles) !==
+    JSON.stringify(expectedDirectoryRunfiles)
+) {
+    console.error(
+        `ERROR: expected changed source below directory input to sync ${JSON.stringify(
+            expectedDirectoryRunfiles
+        )} but got ${JSON.stringify(selectedDirectoryRunfiles)}`
+    )
+    process.exit(1)
+}
+
+const graphEvent = {
+    ...ibazelEvent,
+    changes: [{ path: '/workspace/BUILD.bazel', kind: 'graph' }],
+}
+if (selectRunfilesToSync(runfiles, graphEvent, '/workspace') !== runfiles) {
+    console.error('ERROR: expected graph changes to sync every runfile')
+    process.exit(1)
+}
+
+const unmappedEvent = {
+    ...ibazelEvent,
+    changes: [{ path: '/external/src/app.ts', kind: 'source' }],
+}
+if (selectRunfilesToSync(runfiles, unmappedEvent, '/workspace') !== runfiles) {
+    console.error('ERROR: expected unmapped source changes to sync every runfile')
+    process.exit(1)
+}
+
+const childInput = []
+const syncTriggers = []
+const processIBazelLine = createIBazelLineProcessor({
+    notifyRunfilesChanges: true,
+    sandbox: '/sandbox',
+    syncBuild: async (trigger) => {
+        syncTriggers.push(trigger)
+        return {
+            syncedFiles: [{ file: 'src/app.ts', exists: true }],
+            deletedFiles: [],
+        }
+    },
+    writeToChild: async (line) => childInput.push(line),
+})
+await processIBazelLine('IBAZEL_BUILD_COMPLETED SUCCESS')
+if (childInput.length !== 0) {
+    console.error('ERROR: expected build completion to wait for structured event')
+    process.exit(1)
+}
+const ibazelEventLine = `IBAZEL_EVENT ${JSON.stringify(ibazelEvent)}`
+await processIBazelLine(ibazelEventLine)
+const expectedChildInput = [
+    'IBAZEL_BUILD_COMPLETED SUCCESS\n',
+    formatRunfilesSyncEvent(
+        '/sandbox',
+        [{ file: 'src/app.ts', exists: true }],
+        [],
+        ibazelEvent
+    ),
+    `${ibazelEventLine}\n`,
+]
+if (JSON.stringify(childInput) !== JSON.stringify(expectedChildInput)) {
+    console.error(
+        `ERROR: expected ordered child input ${JSON.stringify(
+            expectedChildInput
+        )} but got ${JSON.stringify(childInput)}`
+    )
+    process.exit(1)
+}
+if (JSON.stringify(syncTriggers) !== JSON.stringify([ibazelEvent])) {
+    console.error('ERROR: expected structured event to drive sandbox sync')
+    process.exit(1)
+}
+
+const legacyChildInput = []
+const legacySyncTriggers = []
+const processLegacyLine = createIBazelLineProcessor({
+    notifyRunfilesChanges: false,
+    sandbox: '/sandbox',
+    syncBuild: async (trigger) => {
+        legacySyncTriggers.push(trigger)
+        return { syncedFiles: [], deletedFiles: [] }
+    },
+    writeToChild: async (line) => legacyChildInput.push(line),
+})
+await processLegacyLine('IBAZEL_BUILD_COMPLETED SUCCESS')
+if (
+    JSON.stringify(legacySyncTriggers) !== JSON.stringify([null]) ||
+    JSON.stringify(legacyChildInput) !==
+        JSON.stringify(['IBAZEL_BUILD_COMPLETED SUCCESS\n'])
+) {
+    console.error('ERROR: expected legacy protocol behavior to remain unchanged')
     process.exit(1)
 }

--- a/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
+++ b/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
@@ -7,6 +7,7 @@ import {
     is1pPackageStoreDep,
     friendlyFileSize,
     parseIBazelEvent,
+    runfilesNotificationEnv,
     selectRunfilesToSync,
 } from '../../devserver/js_run_devserver.mjs'
 
@@ -236,6 +237,21 @@ if (JSON.stringify(childInput) !== JSON.stringify(expectedChildInput)) {
 }
 if (JSON.stringify(syncTriggers) !== JSON.stringify([ibazelEvent])) {
     console.error('ERROR: expected structured event to drive sandbox sync')
+    process.exit(1)
+}
+
+const baseEnv = { EXISTING: 'value' }
+if (runfilesNotificationEnv(baseEnv, false) !== baseEnv) {
+    console.error('ERROR: expected disabled notification env to remain unchanged')
+    process.exit(1)
+}
+const notificationEnv = runfilesNotificationEnv(baseEnv, true)
+if (
+    notificationEnv === baseEnv ||
+    notificationEnv.EXISTING !== 'value' ||
+    notificationEnv.JS_RUN_DEVSERVER_NOTIFY_RUNFILES_CHANGES !== '1'
+) {
+    console.error('ERROR: expected enabled notification env to mark the child process')
     process.exit(1)
 }
 

--- a/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
+++ b/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
@@ -1,7 +1,11 @@
+import path from 'node:path'
+
 import {
+    formatRunfilesSyncEvent,
     isNodeModulePath,
     is1pPackageStoreDep,
     friendlyFileSize,
+    parseIBazelEvent,
 } from '../../devserver/js_run_devserver.mjs'
 
 // isNodeModulePath
@@ -77,4 +81,50 @@ for (const [k, v] of friendlyFileSize_cases) {
         )
         process.exit(1)
     }
+}
+
+// notify_changes_v1 post-sync event
+const ibazelEvent = parseIBazelEvent(
+    'IBAZEL_EVENT {"version":1,"type":"build_completed","success":true,"changes":[{"path":"/workspace/src/app.ts","kind":"source"}]}'
+)
+if (!ibazelEvent || !ibazelEvent.success) {
+    console.error('ERROR: expected a valid successful iBazel event')
+    process.exit(1)
+}
+if (parseIBazelEvent('IBAZEL_BUILD_COMPLETED SUCCESS') !== null) {
+    console.error('ERROR: expected legacy notification to be ignored')
+    process.exit(1)
+}
+
+const syncEventPrefix = 'JS_RUN_DEVSERVER_SYNCED '
+const syncEvent = formatRunfilesSyncEvent(
+    '/sandbox',
+    [
+        { file: 'b.js', exists: true },
+        { file: 'a.js', exists: false },
+    ],
+    ['c.js'],
+    ibazelEvent
+)
+if (!syncEvent.endsWith('\n')) {
+    console.error('ERROR: expected runfiles sync event to end with a newline')
+    process.exit(1)
+}
+const syncEventPayload = JSON.parse(syncEvent.slice(syncEventPrefix.length))
+const expectedChanges = [
+    { path: path.join('/sandbox', 'a.js'), kind: 'added' },
+    { path: path.join('/sandbox', 'b.js'), kind: 'changed' },
+    { path: path.join('/sandbox', 'c.js'), kind: 'deleted' },
+]
+if (JSON.stringify(syncEventPayload.changes) !== JSON.stringify(expectedChanges)) {
+    console.error(
+        `ERROR: expected runfiles changes ${JSON.stringify(
+            expectedChanges
+        )} but got ${JSON.stringify(syncEventPayload.changes)}`
+    )
+    process.exit(1)
+}
+if (JSON.stringify(syncEventPayload.trigger) !== JSON.stringify(ibazelEvent)) {
+    console.error('ERROR: expected sync event to retain the parsed iBazel event')
+    process.exit(1)
 }


### PR DESCRIPTION
## Why

`js_run_devserver` copies runfiles into a sandbox. iBazel's `notify_changes_v1` reports workspace changes before that copy finishes, so dev servers cannot safely use those paths for HMR.

## What

Adds opt-in `notify_runfiles_changes` support:

- requests `ibazel_notify_changes_v1`
- selectively syncs affected source runfiles while still scanning generated outputs
- falls back to a full sync for graph or unmappable changes
- emits `JS_RUN_DEVSERVER_SYNCED` after sync, with added, changed, and deleted sandbox paths plus the triggering iBazel event
- sets `JS_RUN_DEVSERVER_NOTIFY_RUNFILES_CHANGES=1` for the child process

Existing targets keep legacy behavior unless they opt in.

## Test

```
bazel test //js/private/test/js_run_devserver:all //js/private/devserver:watch_checked_tests --test_output=errors
```
