### PR TITLE
refactor(js_run_binary): support path mapping with use_execroot_entry_point

### DIFF
--- a/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
+++ b/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
@@ -2,8 +2,8 @@ load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 # Verifies that a js_run_binary target supports path mapping. This requires
-# use_execroot_entry_point and set_legacy_environment_variables to both be
-# disabled, and args must avoid Make variable and location expansion.
+# set_legacy_environment_variables to be disabled, and args must avoid Make
+# variable and location expansion.
 js_binary(
     name = "check",
     entry_point = "check.mjs",
@@ -17,7 +17,6 @@ js_run_binary(
     mnemonic = "JsRunBinaryPathMappingCheck",
     set_legacy_environment_variables = False,
     tool = ":check",
-    use_execroot_entry_point = False,
 )
 
 build_test(

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -494,16 +494,20 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
     if ctx.attr.include_npm:
         transitive_launcher_files = nodeinfo.npm_sources
 
-    runfiles = gather_runfiles(
+    # The subset of runfiles that make up the entry point and its data, as opposed to the
+    # js_binary's own launcher/node/npm/node-patches toolchain scaffolding. This is what
+    # js_run_binary hoists into the target-platform bin directory when use_execroot_entry_point
+    # is enabled: the launcher always resolves the entry point's data from disk relative to the
+    # entry point itself (Node module resolution), but it resolves the toolchain scaffolding via
+    # $JS_BINARY__RUNFILES regardless of use_execroot_entry_point, so that scaffolding never needs
+    # a target-platform copy.
+    data_runfiles = gather_runfiles(
         ctx = ctx,
         data = ctx.attr.data,
         data_files = [entry_point] + ctx.files.data,
         copy_data_files_to_bin = ctx.attr.copy_data_to_bin,
         no_copy_to_bin = ctx.files.no_copy_to_bin,
     ).merge(ctx.runfiles(
-        files = launcher_files,
-        transitive_files = transitive_launcher_files,
-    )).merge(ctx.runfiles(
         transitive_files = gather_files_from_js_infos(
             targets = ctx.attr.data,
             include_sources = ctx.attr.include_sources,
@@ -514,9 +518,15 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
         ),
     ))
 
+    runfiles = data_runfiles.merge(ctx.runfiles(
+        files = launcher_files,
+        transitive_files = transitive_launcher_files,
+    ))
+
     return struct(
         executable = launcher,
         runfiles = runfiles,
+        data_runfiles = data_runfiles,
     )
 
 def _js_binary_impl(ctx):
@@ -588,6 +598,15 @@ def _js_binary_impl(ctx):
         DefaultInfo(
             executable = launcher.executable,
             runfiles = runfiles,
+        ),
+        OutputGroupInfo(
+            # The entry point and its data, excluding the launcher/node/npm/node-patches
+            # toolchain scaffolding. Consumed by js_run_binary to hoist a js_binary tool's
+            # entry point and data into the target-platform bin directory when
+            # use_execroot_entry_point is enabled, without duplicating toolchain files that
+            # are never read from there (and whose content can differ across configurations,
+            # e.g. the generated launcher bakes in $(COMPILATION_MODE)).
+            execroot_data_files = launcher.data_runfiles.files,
         ),
     ]
 

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -495,12 +495,7 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
         transitive_launcher_files = nodeinfo.npm_sources
 
     # The subset of runfiles that make up the entry point and its data, as opposed to the
-    # js_binary's own launcher/node/npm/node-patches toolchain scaffolding. This is what
-    # js_run_binary hoists into the target-platform bin directory when use_execroot_entry_point
-    # is enabled: the launcher always resolves the entry point's data from disk relative to the
-    # entry point itself (Node module resolution), but it resolves the toolchain scaffolding via
-    # $JS_BINARY__RUNFILES regardless of use_execroot_entry_point, so that scaffolding never needs
-    # a target-platform copy.
+    # launcher and its other dependencies.
     data_runfiles = gather_runfiles(
         ctx = ctx,
         data = ctx.attr.data,
@@ -601,11 +596,8 @@ def _js_binary_impl(ctx):
         ),
         OutputGroupInfo(
             # The entry point and its data, excluding the launcher/node/npm/node-patches
-            # toolchain scaffolding. Consumed by js_run_binary to hoist a js_binary tool's
-            # entry point and data into the target-platform bin directory when
-            # use_execroot_entry_point is enabled, without duplicating toolchain files that
-            # are never read from there (and whose content can differ across configurations,
-            # e.g. the generated launcher bakes in $(COMPILATION_MODE)).
+            # toolchain scaffolding. Consumed by js_run_binary when
+            # use_execroot_entry_point is enabled.
             execroot_data_files = launcher.data_runfiles.files,
         ),
     ]

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -15,7 +15,6 @@ load("@bazel_lib//lib:run_binary.bzl", _run_binary = "run_binary")
 load("@bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load(":js_helpers.bzl", _envs_for_log_level = "envs_for_log_level")
 load(":js_info_files.bzl", _js_info_files = "js_info_files")
-load(":js_library.bzl", _js_library = "js_library")
 
 def js_run_binary(
         name,
@@ -383,20 +382,15 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
     # When use_execroot_entry_point is None, behavior is controlled by the //js:use_execroot_entry_point flag.
     execroot_extra_srcs = []
     if use_execroot_entry_point != False:
-        # hoist all runfiles to srcs when running from execroot
-        js_runfiles_lib_name = "{}_runfiles_lib".format(name)
-        _js_library(
-            name = js_runfiles_lib_name,
-            srcs = [tool],
-            # Always tag the target manual since we should only build it when the final target is built.
-            tags = kwargs.get("tags", []) + ["manual"],
-            testonly = kwargs.get("testonly"),
-        )
+        # Hoist the tool's entry point and data (but not its launcher/node/npm/node-patches
+        # toolchain scaffolding, which is never read from the target-platform bin directory;
+        # see the execroot_data_files output group docstring in js_binary.bzl) to srcs when
+        # running from execroot.
         js_runfiles_name = "{}_runfiles".format(name)
         native.filegroup(
             name = js_runfiles_name,
-            output_group = "runfiles",
-            srcs = [":{}".format(js_runfiles_lib_name)],
+            output_group = "execroot_data_files",
+            srcs = [tool],
             # Always tag the target manual since we should only build it when the final target is built.
             tags = kwargs.get("tags", []) + ["manual"],
             testonly = kwargs.get("testonly"),

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -382,10 +382,7 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
     # When use_execroot_entry_point is None, behavior is controlled by the //js:use_execroot_entry_point flag.
     execroot_extra_srcs = []
     if use_execroot_entry_point != False:
-        # Hoist the tool's entry point and data (but not its launcher/node/npm/node-patches
-        # toolchain scaffolding, which is never read from the target-platform bin directory;
-        # see the execroot_data_files output group docstring in js_binary.bzl) to srcs when
-        # running from execroot.
+        # Hoist the tool's entry point and data to srcs when running from execroot.
         js_runfiles_name = "{}_runfiles".format(name)
         native.filegroup(
             name = js_runfiles_name,


### PR DESCRIPTION
use_execroot_entry_point hoisted a js_binary tool's entire runfiles tree (including its generated launcher, node/npm wrappers, and node-patches bootstrap) into a target-configuration rebuild, so that the entry point could be resolved from the target-platform bin directory. The launcher script bakes `$(COMPILATION_MODE)/$(TARGET_CPU)/$(BINDIR)` into its content, so this hoisted copy differed between -c fastbuild and -c opt, defeating cross-config path mapping even though none of that toolchain scaffolding is ever read from the target-platform bin directory at runtime (only the entry point and its data are).

js_binary now exposes a leaner "execroot_data_files" output group (entry point + data, without the toolchain scaffolding), and js_run_binary hoists that instead of the tool's full runfiles.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Allow path mapping to work with js_run_binary even with use_execroot_entry_point enabled

### Test plan

- Covered by existing test cases
- New test cases added