### PR TITLE
feat(js_run_binary): add flag controlling default of set_legacy_envir…

### DIFF
--- a/docs/path_mapping.md
+++ b/docs/path_mapping.md
@@ -30,9 +30,10 @@ determines it is safe to do so, but you may need to explicitly opt in (see
 below). To set up a `js_run_binary` target for path mapping:
  - Pass `set_legacy_environment_variables = False`. This will disable the
    setting of environment variables such as `BAZEL_COMPILATION_MODE` that would
-   otherwise be problematic. Alternatively, you can turn off this behavior by
-   default globally by passing
-   `--@aspect_rules_js//js:set_legacy_environment_variables=False`.
+   otherwise be problematic. Alternatively, you can change the default for all
+   targets by passing `--@aspect_rules_js//js:set_legacy_environment_variables=False`
+   on the command line; individual targets can still override this default by
+   setting the attribute explicitly.
  - Avoid using [Make
    variables](https://bazel.build/reference/be/make-variables) or expressions
    such as `$(execpath :target)`. Such variables and expressions are not

--- a/docs/path_mapping.md
+++ b/docs/path_mapping.md
@@ -30,7 +30,9 @@ determines it is safe to do so, but you may need to explicitly opt in (see
 below). To set up a `js_run_binary` target for path mapping:
  - Pass `set_legacy_environment_variables = False`. This will disable the
    setting of environment variables such as `BAZEL_COMPILATION_MODE` that would
-   otherwise be problematic.
+   otherwise be problematic. Alternatively, you can turn off this behavior by
+   default globally by passing
+   `--@aspect_rules_js//js:set_legacy_environment_variables=False`.
  - Avoid using [Make
    variables](https://bazel.build/reference/be/make-variables) or expressions
    such as `$(execpath :target)`. Such variables and expressions are not

--- a/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
+++ b/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
@@ -23,3 +23,18 @@ build_test(
     name = "js_run_binary_path_mapping_check_test",
     targets = [":js_run_binary_path_mapping_check"],
 )
+
+# Same as js_run_binary_path_mapping_check, but leaves set_legacy_environment_variables
+# unset to verify that --@aspect_rules_js//js:set_legacy_environment_variables=False achieves
+# the same path-mapping-safe behavior as setting the attribute explicitly. Tagged manual
+# since this target only builds correctly with that flag passed on the command line; see
+# test.sh, which builds it explicitly with the flag set.
+js_run_binary(
+    name = "js_run_binary_path_mapping_check_flag",
+    outs = ["out_flag.txt"],
+    args = ["out_flag.txt"],
+    chdir = package_name(),
+    mnemonic = "JsRunBinaryPathMappingCheckFlag",
+    tags = ["manual"],
+    tool = ":check",
+)

--- a/e2e/path_mapping/test.sh
+++ b/e2e/path_mapping/test.sh
@@ -75,3 +75,35 @@ if [ "$cache_hit2" != "true" ]; then
 fi
 
 echo "PASS: js_run_binary action was cache-shared across -c fastbuild and -c opt"
+
+# Same as above, but exercising js_run_binary_path_mapping_check_flag, which does not set
+# set_legacy_environment_variables itself and instead relies on the
+# --@aspect_rules_js//js:set_legacy_environment_variables=False command-line flag to get the
+# same path-mapping-safe behavior.
+exec_log3="$scratch/exec_log3.json"
+
+bazel build -c fastbuild //js_run_binary_path_mapping_check:js_run_binary_path_mapping_check_flag \
+    --@aspect_rules_js//js:set_legacy_environment_variables=False \
+    --disk_cache="$disk_cache" \
+    --action_env="JS_RUN_BINARY_PATH_MAPPING_CHECK_FLAG_INVALIDATE=$invalidate"
+
+bazel build -c opt //js_run_binary_path_mapping_check:js_run_binary_path_mapping_check_flag \
+    --@aspect_rules_js//js:set_legacy_environment_variables=False \
+    --disk_cache="$disk_cache" \
+    --action_env="JS_RUN_BINARY_PATH_MAPPING_CHECK_FLAG_INVALIDATE=$invalidate" \
+    --execution_log_json_file="$exec_log3"
+
+matches3="$(jq -s '[.[] | select(.mnemonic == "JsRunBinaryPathMappingCheckFlag")]' "$exec_log3")"
+count3="$(echo "$matches3" | jq 'length')"
+if [ "$count3" -eq 0 ]; then
+    echo "FAIL: no JsRunBinaryPathMappingCheckFlag entry found in the -c opt execution log" >&2
+    exit 1
+fi
+
+cache_hit3="$(echo "$matches3" | jq -r '.[0].cacheHit')"
+if [ "$cache_hit3" != "true" ]; then
+    echo "FAIL: js_run_binary action (flag-controlled) was re-executed under -c opt (cacheHit=$cache_hit3); --@aspect_rules_js//js:set_legacy_environment_variables=False did not achieve the same path-mapping behavior as setting the attribute explicitly" >&2
+    exit 1
+fi
+
+echo "PASS: js_run_binary action controlled by --@aspect_rules_js//js:set_legacy_environment_variables=False was cache-shared across -c fastbuild and -c opt"

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -20,6 +20,23 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# This flag controls the default behavior of the set_legacy_environment_variables flag
+# on js_run_binary.
+bool_flag(
+    name = "set_legacy_environment_variables",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_set_legacy_environment_variables_true",
+    flag_values = {"set_legacy_environment_variables": "True"},
+    # Must be public: this is referenced by select() expressions that the js_run_binary
+    # macro expands into user packages, where visibility is checked from the use site.
+    # Without this, builds fail under --incompatible_config_setting_private_default_visibility.
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -310,25 +310,23 @@ def js_run_binary(
     # release; see the `set_legacy_environment_variables` docstring.
     # When set_legacy_environment_variables is None, behavior is controlled by the
     # //js:set_legacy_environment_variables flag.
-    legacy_env_values = {
-        "BAZEL_BINDIR": "$(BINDIR)",
-        "BAZEL_BUILD_FILE_PATH": "$(BUILD_FILE_PATH)",
-        "BAZEL_COMPILATION_MODE": "$(COMPILATION_MODE)",
-        "BAZEL_TARGET_CPU": "$(TARGET_CPU)",
-        "BAZEL_TARGET": "$(TARGET)",
-        "BAZEL_WORKSPACE": "$(WORKSPACE)",
-        "BAZEL_PACKAGE": native.package_name(),
-        "BAZEL_TARGET_NAME": name,
-    }
-    if set_legacy_environment_variables == True:
-        legacy_env = legacy_env_values
-    elif set_legacy_environment_variables == None:
-        legacy_env = select({
-            Label("//js:_set_legacy_environment_variables_true"): legacy_env_values,
-            "//conditions:default": {},
-        })
-    else:
-        legacy_env = {}
+    legacy_env = {}
+    if set_legacy_environment_variables != False:
+        legacy_env = {
+            "BAZEL_BINDIR": "$(BINDIR)",
+            "BAZEL_BUILD_FILE_PATH": "$(BUILD_FILE_PATH)",
+            "BAZEL_COMPILATION_MODE": "$(COMPILATION_MODE)",
+            "BAZEL_TARGET_CPU": "$(TARGET_CPU)",
+            "BAZEL_TARGET": "$(TARGET)",
+            "BAZEL_WORKSPACE": "$(WORKSPACE)",
+            "BAZEL_PACKAGE": native.package_name(),
+            "BAZEL_TARGET_NAME": name,
+        }
+        if set_legacy_environment_variables == None:
+            legacy_env = select({
+                Label("//js:_set_legacy_environment_variables_true"): legacy_env,
+                "//conditions:default": {},
+            })
 
     # Configure working directory to `chdir` is set
     if chdir != None:

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -44,7 +44,7 @@ def js_run_binary(
         patch_node_fs = True,
         allow_execroot_entry_point_with_no_copy_data_to_bin = False,
         use_default_shell_env = False,
-        set_legacy_environment_variables = True,
+        set_legacy_environment_variables = None,
         **kwargs):
     """Wrapper around @bazel_lib `run_binary` that adds convenience attributes for using a `js_binary` tool.
 
@@ -255,6 +255,9 @@ def js_run_binary(
             `BAZEL_TARGET`, `BAZEL_WORKSPACE`, `BAZEL_PACKAGE` and `BAZEL_TARGET_NAME`
             environment variables.
 
+            If `None` (the default), the behavior is controlled by the
+            `//js:set_legacy_environment_variables` build flag, which defaults to `True`.
+
             These variables are deprecated and setting them will default to False in a future
             release. Set this to False to opt out now.
 
@@ -305,15 +308,27 @@ def js_run_binary(
 
     # These environment variables are deprecated and will default to not being set in a future
     # release; see the `set_legacy_environment_variables` docstring.
-    if set_legacy_environment_variables:
-        fixed_env["BAZEL_BINDIR"] = "$(BINDIR)"
-        fixed_env["BAZEL_BUILD_FILE_PATH"] = "$(BUILD_FILE_PATH)"
-        fixed_env["BAZEL_COMPILATION_MODE"] = "$(COMPILATION_MODE)"
-        fixed_env["BAZEL_TARGET_CPU"] = "$(TARGET_CPU)"
-        fixed_env["BAZEL_TARGET"] = "$(TARGET)"
-        fixed_env["BAZEL_WORKSPACE"] = "$(WORKSPACE)"
-        fixed_env["BAZEL_PACKAGE"] = native.package_name()
-        fixed_env["BAZEL_TARGET_NAME"] = name
+    # When set_legacy_environment_variables is None, behavior is controlled by the
+    # //js:set_legacy_environment_variables flag.
+    legacy_env_values = {
+        "BAZEL_BINDIR": "$(BINDIR)",
+        "BAZEL_BUILD_FILE_PATH": "$(BUILD_FILE_PATH)",
+        "BAZEL_COMPILATION_MODE": "$(COMPILATION_MODE)",
+        "BAZEL_TARGET_CPU": "$(TARGET_CPU)",
+        "BAZEL_TARGET": "$(TARGET)",
+        "BAZEL_WORKSPACE": "$(WORKSPACE)",
+        "BAZEL_PACKAGE": native.package_name(),
+        "BAZEL_TARGET_NAME": name,
+    }
+    if set_legacy_environment_variables == True:
+        legacy_env = legacy_env_values
+    elif set_legacy_environment_variables == None:
+        legacy_env = select({
+            Label("//js:_set_legacy_environment_variables_true"): legacy_env_values,
+            "//conditions:default": {},
+        })
+    else:
+        legacy_env = {}
 
     # Configure working directory to `chdir` is set
     if chdir != None:
@@ -417,7 +432,7 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
     _run_binary(
         name = name,
         tool = tool,
-        env = fixed_env | execroot_env | env,
+        env = fixed_env | legacy_env | execroot_env | env,
         srcs = srcs + extra_srcs + execroot_extra_srcs,
         outs = outs + extra_outs,
         out_dirs = out_dirs,


### PR DESCRIPTION
…onment_variables

Adds the //js:set_legacy_environment_variables build flag, mirroring //js:use_execroot_entry_point, so users can flip the default for the legacy BAZEL_* env vars repo-wide via .bazelrc instead of per-target.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Adds the //js:set_legacy_environment_variables build flag

### Test plan

- Covered by existing test cases
- New test cases added
