### PR TITLE
fix: run npmrc tokenHelpers lazily and match auth registries on a path boundary

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -142,7 +142,7 @@ def _npm_translate_lock_bzlmod(module_ctx, mod, attr, exclude_package_contents_c
     npm_auth = {}
     if attr.npmrc:
         npmrc = parse_npmrc(module_ctx.read(attr.npmrc))
-        (registries, npm_auth) = npm_translate_lock_helpers.get_npm_auth(npmrc, module_ctx.path(attr.npmrc), module_ctx, allow_token_helper = True)
+        (registries, npm_auth) = npm_translate_lock_helpers.get_npm_auth(npmrc, module_ctx.path(attr.npmrc), module_ctx)
 
     if attr.use_home_npmrc:
         home_directory = repo_utils.get_home_directory(module_ctx)
@@ -151,7 +151,7 @@ def _npm_translate_lock_bzlmod(module_ctx, mod, attr, exclude_package_contents_c
             if module_ctx.path(home_npmrc_path).exists:
                 home_npmrc = parse_npmrc(module_ctx.read(home_npmrc_path))
 
-                (registries2, npm_auth2) = npm_translate_lock_helpers.get_npm_auth(home_npmrc, home_npmrc_path, module_ctx, allow_token_helper = True)
+                (registries2, npm_auth2) = npm_translate_lock_helpers.get_npm_auth(home_npmrc, home_npmrc_path, module_ctx)
                 registries.update(registries2)
                 npm_auth.update(npm_auth2)
         else:
@@ -167,6 +167,7 @@ WARNING: Cannot determine home directory in order to load home `.npmrc` file in 
         registries = registries,
         npm_auth = npm_auth,
         exclude_package_contents_config = exclude_package_contents_config,
+        rctx = module_ctx,
     )
 
     # attr.pnpm_lock.repo_name is a canonical repository name, so it needs to be qualified with an extra '@'.

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -197,7 +197,8 @@ For more about how to use npm_translate_lock, read [pnpm and rules_js](/docs/pnp
 
             A [`tokenHelper`](https://pnpm.io/npmrc#urltokenhelper) is also honored: rules_js runs the executable it
             names and uses the token it prints on stdout. The helper path may be absolute or relative to this
-            `.npmrc` file, and may reference environment variables.
+            `.npmrc` file, and may reference environment variables. A helper runs during repository setup,
+            only for a registry a package in the lockfile resolves to, and at most once per registry.
 
             SECURITY: unlike pnpm, which only runs a `tokenHelper` from user-level config, rules_js runs one declared
             in this `.npmrc` even when it is checked into the repository. A `tokenHelper` names an executable that

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -113,11 +113,14 @@ def _run_token_helper(helper, npmrc_path, rctx):
     # tokenHelper values may reference env vars, same as any other credential value
     helper = utils.replace_npmrc_token_envvar(helper, npmrc_path, rctx)
 
+    # An empty value would otherwise resolve to the `.npmrc`'s own directory and be executed
+    if not helper:
+        fail("tokenHelper in \"{npmrc}\" is empty; it must name an executable".format(npmrc = npmrc_path))
+
     # A relative helper is resolved against the directory of the `.npmrc` that declared it,
     # so a checked-in file can point at a script next to it.
     if not _is_absolute_path(helper):
-        npmrc_dir = str(rctx.path(str(npmrc_path)).dirname)
-        helper = str(rctx.path(npmrc_dir + "/" + helper))
+        helper = str(rctx.path(str(npmrc_path)).dirname) + "/" + helper
 
     result = rctx.execute([helper])
     if result.return_code != 0:
@@ -140,7 +143,7 @@ def _run_token_helper(helper, npmrc_path, rctx):
     return token
 
 ################################################################################
-def _get_npm_auth(npmrc, npmrc_path, rctx, allow_token_helper = False):
+def _get_npm_auth(npmrc, npmrc_path, rctx):
     """Parses npm tokens, registries and scopes from `.npmrc`.
 
     - creates a token by registry dict: {registry: token}
@@ -184,13 +187,13 @@ def _get_npm_auth(npmrc, npmrc_path, rctx, allow_token_helper = False):
         }
         ```
 
+        A `tokenHelper` yields a `"token_helper"` entry instead of a `"bearer"` one; it is not run
+        here, but by `_select_npm_auth` the first time it picks auth for that registry.
+
     Args:
         npmrc: The `.npmrc` file.
         npmrc_path: The file path to `.npmrc`.
         rctx: the repository_ctx or module_ctx to fetch environment vars from
-        allow_token_helper: whether to run `tokenHelper` executables found in `npmrc`.
-            True for the live auth parse; False (default) skips execution, used by the
-            unused state.bzl parse so a helper is not run twice.
 
     Returns:
         A tuple (registries, auth).
@@ -275,19 +278,25 @@ def _get_npm_auth(npmrc, npmrc_path, rctx, allow_token_helper = False):
             registry = k.removeprefix("//").removesuffix(_NPM_TOKEN_HELPER).removesuffix(":").removesuffix("/")
             token_helpers[registry] = v
 
-    # Run token helpers last so a helper wins over a static token for the same registry.
-    # allow_token_helper guards against the (unused) state.bzl auth parse executing helpers.
-    if allow_token_helper:
-        for (registry, helper) in token_helpers.items():
-            token = _run_token_helper(helper, npmrc_path, rctx)
-            if registry not in auth:
-                auth[registry] = {}
-            auth[registry]["bearer"] = token
+    # Record helpers rather than running them. _select_npm_auth runs one when it picks auth for a
+    # package URL, so a helper for a registry nothing in the lockfile resolves to never runs.
+    for (registry, helper) in token_helpers.items():
+        if registry not in auth:
+            auth[registry] = {}
+
+        # A helper wins over a static token, and must not shadow its own memoized result
+        auth[registry].pop("bearer", None)
+        auth[registry]["token_helper"] = struct(command = helper, npmrc_path = npmrc_path)
 
     return (registries, auth)
 
+def _registry_matches(registry, auth_registry):
+    # A plain prefix test would send credentials to a lookalike host, since
+    # "registry.corp.company.com" starts with "registry.corp.com". Require a path boundary.
+    return registry == auth_registry or registry.startswith(auth_registry + "/")
+
 ################################################################################
-def _select_npm_auth(url, npm_auth):
+def _select_npm_auth(url, npm_auth, rctx = None):
     registry = url.split("//", 1)[-1]
 
     # Get rid of the port number
@@ -302,26 +311,32 @@ def _select_npm_auth(url, npm_auth):
         else:
             registry_no_port = base
 
-    npm_auth_bearer = None
-    npm_auth_basic = None
-    npm_auth_username = None
-    npm_auth_password = None
+    matched = None
     match_len = 0
     for auth_registry, auth_info in npm_auth.items():
-        if auth_registry == "" and match_len == 0:
+        if auth_registry == "":
             # global auth applied to all registries; will be overridden by a registry scoped auth
-            npm_auth_bearer = auth_info.get("bearer")
-            npm_auth_basic = auth_info.get("basic")
-            npm_auth_username = auth_info.get("username")
-            npm_auth_password = auth_info.get("password")
-        if (registry.startswith(auth_registry) or registry_no_port.startswith(auth_registry)) and len(auth_registry) > match_len:
-            npm_auth_bearer = auth_info.get("bearer")
-            npm_auth_basic = auth_info.get("basic")
-            npm_auth_username = auth_info.get("username")
-            npm_auth_password = auth_info.get("password")
+            if matched == None:
+                matched = auth_info
+        elif len(auth_registry) > match_len and (_registry_matches(registry, auth_registry) or _registry_matches(registry_no_port, auth_registry)):
+            # keep the longest match, not the first one the dict happens to yield
+            matched = auth_info
             match_len = len(auth_registry)
 
-    return npm_auth_bearer, npm_auth_basic, npm_auth_username, npm_auth_password
+    if matched == None:
+        return None, None, None, None
+
+    # Memoized into the auth entry so a helper runs once per registry, not once per package
+    helper = matched.get("token_helper")
+    if helper and "bearer" not in matched:
+        matched["bearer"] = _run_token_helper(helper.command, helper.npmrc_path, rctx)
+
+    return (
+        matched.get("bearer"),
+        matched.get("basic"),
+        matched.get("username"),
+        matched.get("password"),
+    )
 
 ################################################################################
 def _lifecycle_attrs(attr):
@@ -359,7 +374,7 @@ def _lifecycle_attrs(attr):
     return all_lifecycle_hooks, all_lifecycle_hooks_execution_requirements, all_lifecycle_hooks_use_default_shell_env
 
 ################################################################################
-def _get_npm_imports(state, replace_packages, attr, registries, npm_auth, exclude_package_contents_config):
+def _get_npm_imports(state, replace_packages, attr, registries, npm_auth, exclude_package_contents_config, rctx = None):
     "Converts packages from the lockfile to a struct of attributes for npm_import"
 
     importers = state.importers()
@@ -537,7 +552,7 @@ ERROR: can not apply both `pnpm.patchedDependencies` and `npm_translate_lock(pat
         else:
             url = utils.npm_registry_download_url(name, friendly_version, registries, default_registry)
 
-        npm_auth_bearer, npm_auth_basic, npm_auth_username, npm_auth_password = _select_npm_auth(url, npm_auth)
+        npm_auth_bearer, npm_auth_basic, npm_auth_username, npm_auth_password = _select_npm_auth(url, npm_auth, rctx)
 
         deps_oss, deps_cpus = _collect_dep_constraints(packages, package_info)
 
@@ -756,7 +771,6 @@ helpers = struct(
     gather_values_from_matching_names = _gather_values_from_matching_names,
     get_npm_auth = _get_npm_auth,
     get_npm_imports = _get_npm_imports,
-    is_absolute_path = _is_absolute_path,
     link_package = _link_package,
     to_apparent_repo_name = _to_apparent_repo_name,
     verify_node_modules_ignored = _verify_node_modules_ignored,
@@ -768,5 +782,6 @@ helpers = struct(
 helpers_testonly = struct(
     find_missing_bazel_ignores = _find_missing_bazel_ignores,
     gather_package_content_excludes = _gather_package_content_excludes,
+    is_absolute_path = _is_absolute_path,
     select_npm_auth = _select_npm_auth,
 )

--- a/npm/private/test/BUILD.bazel
+++ b/npm/private/test/BUILD.bazel
@@ -4,7 +4,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(":generated_pkg_json_test.bzl", "generated_pkg_json_test")
-load(":npm_auth_test.bzl", "npm_auth_test_suite")
+load(":npm_auth_test.bzl", "npm_auth_failure_test_suite", "npm_auth_test_suite")
 load(":npm_package_visibility_test.bzl", "npm_package_visibility_tests")
 load(":npmrc_test.bzl", "npmrc_tests")
 load(":parse_pnpm_lock_tests.bzl", "parse_pnpm_lock_tests")
@@ -33,6 +33,8 @@ generated_pkg_json_test(name = "test_generated_pkg_json")
 npm_package_visibility_tests(name = "test_npm_package_visibility")
 
 npm_auth_test_suite()
+
+npm_auth_failure_test_suite(name = "npm_auth_failure_tests")
 
 write_source_files(
     name = "write_npm_translate_lock",

--- a/npm/private/test/npm_auth_test.bzl
+++ b/npm/private/test/npm_auth_test.bzl
@@ -3,7 +3,7 @@ See https://docs.bazel.build/versions/main/skylark/testing.html#for-testing-star
 """
 
 load("@bazel_skylib//lib:partial.bzl", "partial")
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("//npm/private:npm_translate_lock_helpers.bzl", "helpers", "helpers_testonly")
 
 def _no_npmrc_test_impl(ctx):
@@ -170,25 +170,35 @@ def _plain_username_password_test_impl(ctx):
 
     return unittest.end(env)
 
-def _fake_auth_rctx(stdout = "HELPER_TOKEN\n", return_code = 0, env = {}, fail_on_execute = False):
-    def _execute(_args, **_kwargs):
-        if fail_on_execute:
-            fail("rctx.execute should not be called")
-        return struct(return_code = return_code, stdout = stdout, stderr = "")
+def _fake_auth_rctx(stdout = "HELPER_TOKEN\n", stderr = "", return_code = 0, env = {}, executed = None):
+    def _execute(args, **_kwargs):
+        if executed != None:
+            executed.append(args)
+        return struct(return_code = return_code, stdout = stdout, stderr = stderr)
+
+    def _path(p):
+        # Only `.dirname` is exercised, and it is immediately str()'d, so a plain string works.
+        return struct(dirname = p.rpartition("/")[0])
 
     return struct(
         getenv = env.get,
         execute = _execute,
+        path = _path,
     )
+
+# Resolves the bearer token an npmrc grants for `url`, the way get_npm_imports does.
+def _bearer_for(npmrc, url, rctx, npmrc_path = "/work/.npmrc"):
+    (_, auth) = helpers.get_npm_auth(npmrc, npmrc_path, rctx)
+    return helpers_testonly.select_npm_auth(url, auth, rctx)[0]
 
 def _is_absolute_path_test_impl(ctx):
     env = unittest.begin(ctx)
 
     for path in ["/abs/token-helper", "C:\\helper", "C:/helper", "\\\\net\\share\\helper"]:
-        asserts.true(env, helpers.is_absolute_path(path), msg = "expected %r to be absolute" % path)
+        asserts.true(env, helpers_testonly.is_absolute_path(path), msg = "expected %r to be absolute" % path)
 
     for path in ["./relative", "relative/path", "token-helper", ""]:
-        asserts.false(env, helpers.is_absolute_path(path), msg = "expected %r to be relative" % path)
+        asserts.false(env, helpers_testonly.is_absolute_path(path), msg = "expected %r to be relative" % path)
 
     return unittest.end(env)
 
@@ -197,21 +207,11 @@ def _token_helper_global_test_impl(ctx):
 
     asserts.equals(
         env,
-        (
-            {},
-            {
-                "": {
-                    "bearer": "HELPER_TOKEN",
-                },
-            },
-        ),
-        helpers.get_npm_auth(
-            {
-                "tokenHelper": "/abs/token-helper",
-            },
-            "",
+        "HELPER_TOKEN",
+        _bearer_for(
+            {"tokenHelper": "/abs/token-helper"},
+            "https://registry1/pkg/-/pkg-1.0.0.tgz",
             _fake_auth_rctx(),
-            allow_token_helper = True,
         ),
     )
 
@@ -222,21 +222,11 @@ def _token_helper_registry_test_impl(ctx):
 
     asserts.equals(
         env,
-        (
-            {},
-            {
-                "registry1": {
-                    "bearer": "HELPER_TOKEN",
-                },
-            },
-        ),
-        helpers.get_npm_auth(
-            {
-                "//registry1/:tokenHelper": "/abs/token-helper",
-            },
-            "",
+        "HELPER_TOKEN",
+        _bearer_for(
+            {"//registry1/:tokenHelper": "/abs/token-helper"},
+            "https://registry1/pkg/-/pkg-1.0.0.tgz",
             _fake_auth_rctx(),
-            allow_token_helper = True,
         ),
     )
 
@@ -247,41 +237,79 @@ def _token_helper_env_path_test_impl(ctx):
 
     asserts.equals(
         env,
-        (
-            {},
-            {
-                "registry1": {
-                    "bearer": "HELPER_TOKEN",
-                },
-            },
-        ),
-        helpers.get_npm_auth(
-            {
-                "//registry1/:tokenHelper": "${HELPER}",
-            },
-            "",
+        "HELPER_TOKEN",
+        _bearer_for(
+            {"//registry1/:tokenHelper": "${HELPER}"},
+            "https://registry1/pkg/-/pkg-1.0.0.tgz",
             _fake_auth_rctx(env = {"HELPER": "/abs/token-helper"}),
-            allow_token_helper = True,
         ),
     )
 
     return unittest.end(env)
 
-def _token_helper_disallowed_test_impl(ctx):
+def _token_helper_relative_path_test_impl(ctx):
     env = unittest.begin(ctx)
 
+    executed = []
     asserts.equals(
         env,
-        ({}, {}),
-        helpers.get_npm_auth(
-            {
-                "//registry1/:tokenHelper": "/abs/token-helper",
-            },
-            "",
-            _fake_auth_rctx(fail_on_execute = True),
-            allow_token_helper = False,
+        "HELPER_TOKEN",
+        _bearer_for(
+            {"//registry1/:tokenHelper": "token-helper.sh"},
+            "https://registry1/pkg/-/pkg-1.0.0.tgz",
+            _fake_auth_rctx(executed = executed),
+            npmrc_path = "/work/nested/.npmrc",
         ),
     )
+
+    # A relative helper resolves against the directory of the declaring `.npmrc`
+    asserts.equals(env, [["/work/nested/token-helper.sh"]], executed)
+
+    return unittest.end(env)
+
+def _token_helper_not_run_when_unused_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    executed = []
+    rctx = _fake_auth_rctx(executed = executed)
+    (_, auth) = helpers.get_npm_auth(
+        {
+            "//registry1/:tokenHelper": "/abs/token-helper",
+            "//registry2/:_authToken": "STATIC",
+        },
+        "/work/.npmrc",
+        rctx,
+    )
+
+    # Parsing alone must not run anything
+    asserts.equals(env, [], executed)
+
+    # Nor must picking auth for a registry the helper does not cover
+    asserts.equals(
+        env,
+        "STATIC",
+        helpers_testonly.select_npm_auth("https://registry2/pkg/-/pkg-1.0.0.tgz", auth, rctx)[0],
+    )
+    asserts.equals(env, [], executed)
+
+    return unittest.end(env)
+
+def _token_helper_memoized_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    executed = []
+    rctx = _fake_auth_rctx(executed = executed)
+    (_, auth) = helpers.get_npm_auth({"//registry1/:tokenHelper": "/abs/token-helper"}, "/work/.npmrc", rctx)
+
+    for _ in range(3):
+        asserts.equals(
+            env,
+            "HELPER_TOKEN",
+            helpers_testonly.select_npm_auth("https://registry1/pkg/-/pkg-1.0.0.tgz", auth, rctx)[0],
+        )
+
+    # One run per registry, not one per package
+    asserts.equals(env, 1, len(executed))
 
     return unittest.end(env)
 
@@ -290,22 +318,14 @@ def _token_helper_precedence_test_impl(ctx):
 
     asserts.equals(
         env,
-        (
-            {},
-            {
-                "registry1": {
-                    "bearer": "HELPER_TOKEN",
-                },
-            },
-        ),
-        helpers.get_npm_auth(
+        "HELPER_TOKEN",
+        _bearer_for(
             {
                 "//registry1/:_authToken": "STATIC",
                 "//registry1/:tokenHelper": "/abs/token-helper",
             },
-            "",
+            "https://registry1/pkg/-/pkg-1.0.0.tgz",
             _fake_auth_rctx(),
-            allow_token_helper = True,
         ),
     )
 
@@ -548,8 +568,8 @@ def _pkg_scope_test_impl(ctx):
 def _select_npm_auth_longest_prefix_test_impl(ctx):
     env = unittest.begin(ctx)
 
-    # A broad registry token and a narrower one for a path below it. Selection must return
-    # the narrower match regardless of dict order, not the first one that happens to match.
+    # A broad registry token and a narrower one for a path below it, in the insertion order that
+    # makes the broad entry match first. Selection must still return the narrower match.
     npm_auth = {
         "registry.corp.com": {"bearer": "BROAD"},
         "registry.corp.com/private": {"bearer": "NARROW"},
@@ -570,6 +590,33 @@ def _select_npm_auth_longest_prefix_test_impl(ctx):
 
     return unittest.end(env)
 
+def _select_npm_auth_boundary_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    npm_auth = {"registry.corp.com": {"bearer": "TOKEN"}}
+
+    # "registry.corp.company.com" starts with "registry.corp.com", but is a different host and
+    # must not be handed the token.
+    asserts.equals(
+        env,
+        (None, None, None, None),
+        helpers_testonly.select_npm_auth("https://registry.corp.company.com/pkg/-/pkg-1.0.0.tgz", npm_auth),
+    )
+
+    # The host itself, with and without a port, still matches.
+    asserts.equals(
+        env,
+        ("TOKEN", None, None, None),
+        helpers_testonly.select_npm_auth("https://registry.corp.com/pkg/-/pkg-1.0.0.tgz", npm_auth),
+    )
+    asserts.equals(
+        env,
+        ("TOKEN", None, None, None),
+        helpers_testonly.select_npm_auth("https://registry.corp.com:8443/pkg/-/pkg-1.0.0.tgz", npm_auth),
+    )
+
+    return unittest.end(env)
+
 no_npmrc_test = unittest.make(_no_npmrc_test_impl)
 plain_basic_auth_test = unittest.make(_plain_basic_auth_test_impl)
 plain_username_password_test = unittest.make(_plain_username_password_test_impl)
@@ -581,9 +628,12 @@ is_absolute_path_test = unittest.make(_is_absolute_path_test_impl)
 token_helper_global_test = unittest.make(_token_helper_global_test_impl)
 token_helper_registry_test = unittest.make(_token_helper_registry_test_impl)
 token_helper_env_path_test = unittest.make(_token_helper_env_path_test_impl)
-token_helper_disallowed_test = unittest.make(_token_helper_disallowed_test_impl)
+token_helper_relative_path_test = unittest.make(_token_helper_relative_path_test_impl)
+token_helper_not_run_when_unused_test = unittest.make(_token_helper_not_run_when_unused_test_impl)
+token_helper_memoized_test = unittest.make(_token_helper_memoized_test_impl)
 token_helper_precedence_test = unittest.make(_token_helper_precedence_test_impl)
 select_npm_auth_longest_prefix_test = unittest.make(_select_npm_auth_longest_prefix_test_impl)
+select_npm_auth_boundary_test = unittest.make(_select_npm_auth_boundary_test_impl)
 
 def npm_auth_test_suite():
     unittest.suite(
@@ -599,7 +649,87 @@ def npm_auth_test_suite():
         partial.make(token_helper_global_test, timeout = "short"),
         partial.make(token_helper_registry_test, timeout = "short"),
         partial.make(token_helper_env_path_test, timeout = "short"),
-        partial.make(token_helper_disallowed_test, timeout = "short"),
+        partial.make(token_helper_relative_path_test, timeout = "short"),
+        partial.make(token_helper_not_run_when_unused_test, timeout = "short"),
+        partial.make(token_helper_memoized_test, timeout = "short"),
         partial.make(token_helper_precedence_test, timeout = "short"),
         partial.make(select_npm_auth_longest_prefix_test, timeout = "short"),
+        partial.make(select_npm_auth_boundary_test, timeout = "short"),
+    )
+
+# A failing tokenHelper aborts analysis, which unittest.make cannot observe, so these drive the
+# same code from a rule implementation and let analysistest assert on the failure message.
+# `want` must all appear in it; `unwanted`, if set, must not.
+_TOKEN_HELPER_FAILURES = {
+    "empty_helper_fails_test": struct(
+        helper = "",
+        rctx = _fake_auth_rctx(),
+        want = ["tokenHelper in \"/work/.npmrc\" is empty; it must name an executable"],
+        unwanted = "",
+    ),
+    # stderr diagnoses the failure so it is reported, but stdout carries the token and must never
+    # reach the terminal or CI logs
+    "helper_failure_does_not_leak_token_test": struct(
+        helper = "/abs/token-helper",
+        rctx = _fake_auth_rctx(stdout = "SECRET_TOKEN\n", stderr = "helper could not reach the STS", return_code = 3),
+        want = ["exited with 3", "helper could not reach the STS"],
+        unwanted = "SECRET_TOKEN",
+    ),
+    "helper_without_output_fails_test": struct(
+        helper = "/abs/token-helper",
+        rctx = _fake_auth_rctx(stdout = "  \n"),
+        want = ["produced no output"],
+        unwanted = "",
+    ),
+}
+
+def _token_helper_failure_subject_impl(ctx):
+    case = _TOKEN_HELPER_FAILURES[ctx.attr.case]
+    (_, auth) = helpers.get_npm_auth({"//registry1/:tokenHelper": case.helper}, "/work/.npmrc", case.rctx)
+    helpers_testonly.select_npm_auth("https://registry1/pkg/-/pkg-1.0.0.tgz", auth, case.rctx)
+    return [DefaultInfo()]
+
+_token_helper_failure_subject = rule(
+    implementation = _token_helper_failure_subject_impl,
+    attrs = {"case": attr.string(mandatory = True, values = _TOKEN_HELPER_FAILURES.keys())},
+)
+
+def _token_helper_failure_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    case = _TOKEN_HELPER_FAILURES[ctx.attr.case]
+
+    for want in case.want:
+        asserts.expect_failure(env, want)
+
+    if case.unwanted:
+        # expect_failure can only assert presence, so read the failure message to assert absence
+        causes = analysistest.target_under_test(env)[AnalysisFailureInfo].causes.to_list()
+        message = "\n".join([cause.message for cause in causes])
+        asserts.true(
+            env,
+            message.find(case.unwanted) < 0,
+            msg = "%r leaked into the failure message: %s" % (case.unwanted, message),
+        )
+
+    return analysistest.end(env)
+
+_token_helper_failure_test = analysistest.make(
+    _token_helper_failure_test_impl,
+    expect_failure = True,
+    attrs = {"case": attr.string(mandatory = True, values = _TOKEN_HELPER_FAILURES.keys())},
+)
+
+def npm_auth_failure_test_suite(name):
+    """Analysis tests for `tokenHelper` invocations that must abort the build.
+
+    Args:
+        name: The name of the test_suite target.
+    """
+    for case in _TOKEN_HELPER_FAILURES.keys():
+        _token_helper_failure_subject(name = case + "_subject", case = case, tags = ["manual"])
+        _token_helper_failure_test(name = case, case = case, target_under_test = ":" + case + "_subject")
+
+    native.test_suite(
+        name = name,
+        tests = [":" + case for case in _TOKEN_HELPER_FAILURES.keys()],
     )


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
