### PR TITLE
test: explicitly set `silent_on_success` on most `js_run_binary` targets

### DIFF
--- a/contrib/nextjs/defs.bzl
+++ b/contrib/nextjs/defs.bzl
@@ -212,6 +212,7 @@ def nextjs_build(name, config, srcs, next_js_binary, data = [], use_execroot_ent
         mnemonic = "NextJs",
         progress_message = "Compile Next.js app %{label}",
         use_execroot_entry_point = use_execroot_entry_point,
+        silent_on_success = kwargs.pop("silent_on_success", True),
         **kwargs
     )
 
@@ -361,6 +362,7 @@ def nextjs_standalone_build(name, config, srcs, next_js_binary, data = [], use_e
         tags = tags + ["manual"],
         testonly = testonly,
         visibility = ["//visibility:private"],
+        silent_on_success = kwargs.pop("silent_on_success", True),
         **kwargs
     )
 

--- a/e2e/bzlmod/BUILD.bazel
+++ b/e2e/bzlmod/BUILD.bazel
@@ -31,6 +31,7 @@ js_test(
 js_run_binary(
     name = "pnpm_version",
     args = ["--version"],
+    silent_on_success = False,
     stdout = "pnpm_version.txt",
     tool = "@pnpm",
 )
@@ -38,6 +39,7 @@ js_run_binary(
 js_run_binary(
     name = "other_pnpm_version",
     args = ["--version"],
+    silent_on_success = False,
     stdout = "other_pnpm_version.txt",
     tool = "@other_pnpm//:pnpm",
 )
@@ -54,6 +56,7 @@ js_run_binary(
         "npm",
         "--version",
     ],
+    silent_on_success = False,
     stdout = "pnpm_npm_version.txt",
     tool = "@pnpm",
 )
@@ -142,5 +145,6 @@ js_run_binary(
         "my.less",
         "other-module-my.css",
     ],
+    silent_on_success = False,
     tool = "@other_module//:lessc",  # A js_binary() tool in a different repo
 )

--- a/e2e/bzlmod/other_module/less.bzl
+++ b/e2e/bzlmod/other_module/less.bzl
@@ -13,6 +13,7 @@ def lessc(name, css, **kwargs):
             css.replace(".less", ".css"),
         ],
         chdir = kwargs.pop("chdir", "."),
+        silent_on_success = kwargs.pop("silent_on_success", False),
         **kwargs
     )
 

--- a/e2e/bzlmod/other_module/subdir/BUILD.bazel
+++ b/e2e/bzlmod/other_module/subdir/BUILD.bazel
@@ -13,5 +13,6 @@ less_bin.lessc(
     ],
     chdir = package_name(),
     exit_code_out = "exit_code.txt",
+    silent_on_success = False,
     visibility = ["//visibility:public"],
 )

--- a/e2e/js_binary_workspace/BUILD.bazel
+++ b/e2e/js_binary_workspace/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 js_run_binary(
     name = "run_workspace_bin",
     chdir = package_name(),
+    silent_on_success = False,
     stdout = "out.txt",
     tool = "@workspace//:bin",
 )

--- a/e2e/js_binary_workspace/workspace/BUILD.bazel
+++ b/e2e/js_binary_workspace/workspace/BUILD.bazel
@@ -11,6 +11,7 @@ js_binary(
 
 js_run_binary(
     name = "run_bin",
+    silent_on_success = False,
     stdout = "out_workspace.txt",
     tool = ":bin",
     visibility = ["//visibility:public"],

--- a/e2e/no_shell_toolchain/BUILD.bazel
+++ b/e2e/no_shell_toolchain/BUILD.bazel
@@ -15,6 +15,7 @@ js_binary(
 # shell toolchain.
 js_run_binary(
     name = "run_bin",
+    silent_on_success = False,
     stdout = "out.txt",
     tool = ":bin",
 )

--- a/e2e/output_paths/BUILD.bazel
+++ b/e2e/output_paths/BUILD.bazel
@@ -27,6 +27,7 @@ js_run_binary(
     args = [
         "--help",
     ],
+    silent_on_success = False,
     stdout = "less-help.log",
     tool = ":lessc",
 )

--- a/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
+++ b/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
@@ -22,6 +22,7 @@ js_run_binary(
     exit_code_out = "exit_code.txt",
     mnemonic = "JsRunBinaryPathMappingCheck",
     set_legacy_environment_variables = False,
+    silent_on_success = False,
     stderr = "stderr.txt",
     stdout = "stdout.txt",
     tool = ":check",
@@ -63,6 +64,7 @@ js_run_binary(
     args = ["out_flag.txt"],
     chdir = package_name(),
     mnemonic = "JsRunBinaryPathMappingCheckFlag",
+    silent_on_success = False,
     tags = ["manual"],
     tool = ":check",
 )

--- a/e2e/path_mapping/other_module/subdir/BUILD.bazel
+++ b/e2e/path_mapping/other_module/subdir/BUILD.bazel
@@ -19,6 +19,7 @@ js_run_binary(
     exit_code_out = "exit_code.txt",
     mnemonic = "JsRunBinaryOtherModulePathMappingCheck",
     set_legacy_environment_variables = False,
+    silent_on_success = False,
     stderr = "stderr.txt",
     stdout = "stdout.txt",
     tool = ":check",

--- a/examples/js_binary/BUILD.bazel
+++ b/examples/js_binary/BUILD.bazel
@@ -76,10 +76,8 @@ js_binary(
             chdir = package_name(),
             # Request that the rules_js launcher prints extra information
             log_level = "debug",
+            silent_on_success = False,
             tool = ":bin_%s" % t,
-            # Uncomment the setting below to see debug output even on a
-            # successful run of the build action.
-            # silent_on_success = False,
         ),
         diff_test(
             name = "test_js_binary_under_js_run_binary_%s" % t,
@@ -109,10 +107,8 @@ js_binary(
             },
             # Request that the rules_js launcher prints extra information
             log_level = "debug",
+            silent_on_success = False,
             tool = ":bin_%s" % t,
-            # Uncomment the setting below to see debug output even on a
-            # successful run of the build action.
-            # silent_on_success = False,
         ),
         diff_test(
             name = "test_js_binary_under_js_run_binary_local_%s" % t,
@@ -144,14 +140,12 @@ js_run_binary(
     name = "run2_no_copy_data_to_bin",
     srcs = [],
     outs = ["out2_no_copy_data_to_bin"],
-    # Uncomment the setting below to see debug output even on a
-    # successful run of the build action.
-    # silent_on_success = False,
     allow_execroot_entry_point_with_no_copy_data_to_bin = True,
     args = ["out2_no_copy_data_to_bin"],
     chdir = package_name(),
     # Request that the rules_js launcher prints extra information
     log_level = "debug",
+    silent_on_success = False,
     tool = ":bin_no_copy_data_to_bin",
 )
 
@@ -230,6 +224,7 @@ write_file(
                 },
             }),
             out_dirs = ["out4-%s-dist" % t],
+            silent_on_success = False,
             tool = ":bin4_%s" % t,
         ),
         directory_path(
@@ -256,6 +251,7 @@ write_file(
                     "NODE_ENV": "production",
                 },
             }),
+            silent_on_success = False,
             tool = ":bin4_%s" % t,
         ),
         diff_test(
@@ -315,6 +311,7 @@ write_file(
             outs = ["out5_%s" % t],
             args = ["out5_%s" % t],
             chdir = package_name(),
+            silent_on_success = False,
             tool = ":bin5_%s" % t,
         ),
         diff_test(
@@ -361,6 +358,7 @@ js_run_binary(
     name = "run6",
     outs = ["out6"],
     args = ["../../../$@"],
+    silent_on_success = False,
     tool = ":bin6",
 )
 
@@ -383,6 +381,7 @@ js_run_binary(
     name = "run6_alt",
     outs = ["out6_alt"],
     args = ["../../../$@"],
+    silent_on_success = False,
     tool = ":bin6_alt",
 )
 
@@ -416,6 +415,7 @@ js_run_binary(
     outs = [],
     chdir = package_name(),
     exit_code_out = "actual_exitcode",
+    silent_on_success = False,
     stderr = "actual_stderr",
     stdout = "actual_stdout",
     tool = ":bin7",
@@ -494,6 +494,7 @@ js_binary(
 js_run_binary(
     name = "run8",
     args = ["--help"],
+    silent_on_success = False,
     stdout = "out8",
     tool = ":acorn_bin",
 )
@@ -682,6 +683,7 @@ write_file(
             ],
             chdir = package_name(),
             out_dirs = ["out13-dist-1_%s" % t],
+            silent_on_success = False,
             tool = ":bin13_%s" % t,
         ),
         directory_path(
@@ -702,6 +704,7 @@ write_file(
             ],
             chdir = package_name(),
             out_dirs = ["out13-dist-2_%s" % t],
+            silent_on_success = False,
             tool = ":bin13_%s" % t,
         ),
         directory_path(

--- a/examples/js_library/two/tsc.bzl
+++ b/examples/js_library/two/tsc.bzl
@@ -11,5 +11,6 @@ def tsc(name, args = ["-p", "tsconfig.json"], **kwargs):
         args = args,
         # Always run tsc with the working directory in the project folder
         chdir = native.package_name(),
+        silent_on_success = kwargs.pop("silent_on_success", False),
         **kwargs
     )

--- a/examples/npm_deps/BUILD.bazel
+++ b/examples/npm_deps/BUILD.bazel
@@ -46,6 +46,7 @@ js_run_binary(
     srcs = [],
     outs = ["actual1"],
     args = ["npm_deps/actual1"],
+    silent_on_success = False,
     tool = ":bin1",
 )
 
@@ -158,6 +159,7 @@ diff_test(
 js_run_binary(
     name = "actual5_alt",
     args = ["--version"],
+    silent_on_success = False,
     stdout = "actual5_alt.txt",
     tool = ":rollup_bin",
 )

--- a/examples/npm_package/packages/pkg_a/a/a2/BUILD.bazel
+++ b/examples/npm_package/packages/pkg_a/a/a2/BUILD.bazel
@@ -20,6 +20,7 @@ typescript_bin.tsc(
         "tsconfig.json",
     ],
     chdir = package_name(),
+    silent_on_success = False,
 )
 
 # The sources of this js_library will be included transitively in the terminal

--- a/examples/rspack/BUILD.bazel
+++ b/examples/rspack/BUILD.bazel
@@ -29,6 +29,7 @@ bin.rspack(
         "--config",
         "$$RUNFILES_DIR/$(rlocationpath :rspack_config)",
     ],
+    silent_on_success = False,
     use_execroot_entry_point = False,
 )
 

--- a/examples/runfiles/BUILD.bazel
+++ b/examples/runfiles/BUILD.bazel
@@ -50,6 +50,7 @@ js_run_binary(
         "test_fixture.md",
         "test_fixture.md.generated_file_suffix",
     ],
+    silent_on_success = False,
     stdout = "out1.txt",
     tool = ":test_binary",
 )
@@ -84,6 +85,7 @@ js_run_binary(
         "test_fixture.md",
         "test_fixture.md.generated_file_suffix",
     ],
+    silent_on_success = False,
     stdout = "out2.txt",
     tool = ":outer_binary",
 )

--- a/examples/vite3/BUILD.bazel
+++ b/examples/vite3/BUILD.bazel
@@ -33,6 +33,7 @@ vite_bin.vite(
         "$$RUNFILES_DIR/$(rlocationpath :vite-config)",
     ],
     out_dirs = ["build"],
+    silent_on_success = False,
 )
 
 build_test(

--- a/examples/vite6/BUILD.bazel
+++ b/examples/vite6/BUILD.bazel
@@ -33,6 +33,7 @@ vite_bin.vite(
         "$$RUNFILES_DIR/$(rlocationpath :vite-config)",
     ],
     out_dirs = ["build"],
+    silent_on_success = False,
 )
 
 build_test(

--- a/examples/webpack_cli/BUILD.bazel
+++ b/examples/webpack_cli/BUILD.bazel
@@ -38,6 +38,7 @@ bin.webpack_cli(
         "$$RUNFILES_DIR/$(rlocationpath :webpack-config)",
     ],
     log_level = "debug",
+    silent_on_success = True,
 )
 
 js_test(

--- a/js/private/coverage/bundle/BUILD.bazel
+++ b/js/private/coverage/bundle/BUILD.bazel
@@ -33,5 +33,6 @@ rollup_bin.rollup(
         "--file",
         "bundle.js",
     ],
+    silent_on_success = True,
     visibility = ["//js/private/coverage:__pkg__"],
 )

--- a/js/private/devserver/src/BUILD.bazel
+++ b/js/private/devserver/src/BUILD.bazel
@@ -28,5 +28,6 @@ rollup_bin.rollup(
         "--file",
         "bundle.mjs",
     ],
+    silent_on_success = True,
     visibility = ["//js/private/devserver:__pkg__"],
 )

--- a/js/private/node-bootstrap/src/BUILD.bazel
+++ b/js/private/node-bootstrap/src/BUILD.bazel
@@ -15,6 +15,7 @@ typescript_bin.tsc(
         "tsconfig.json",
     ],
     chdir = package_name(),
+    silent_on_success = False,
     visibility = ["//js/private/test/node-patches:__pkg__"],
 )
 

--- a/js/private/test/data/BUILD.bazel
+++ b/js/private/test/data/BUILD.bazel
@@ -162,6 +162,7 @@ js_run_binary(
         "data.json",
     ],
     chdir = package_name(),
+    silent_on_success = False,
     tool = ":write-js_library-srcs",
 )
 
@@ -188,6 +189,7 @@ js_run_binary(
         "data.json",
     ],
     chdir = package_name(),
+    silent_on_success = False,
     tool = ":write-js_library-srcs",
 )
 
@@ -221,6 +223,7 @@ js_run_binary(
         "data.json",
     ],
     chdir = package_name(),
+    silent_on_success = False,
     tool = ":write-js_library-data",
 )
 
@@ -247,6 +250,7 @@ js_run_binary(
         "data-generated.json",
     ],
     chdir = package_name(),
+    silent_on_success = False,
     tool = ":write-genrule",
 )
 
@@ -273,6 +277,7 @@ js_run_binary(
         "data-copied.json",
     ],
     chdir = package_name(),
+    silent_on_success = False,
     tool = ":write-genrule-filegroup-srcs",
 )
 

--- a/js/private/test/fixed_args/BUILD.bazel
+++ b/js/private/test/fixed_args/BUILD.bazel
@@ -13,6 +13,7 @@ js_binary(
 
 js_run_binary(
     name = "run_fixed_args_binary",
+    silent_on_success = False,
     stdout = "fixed_args_out",
     tool = ":fixed_args_bin",
 )
@@ -33,6 +34,7 @@ js_binary(
 
 js_run_binary(
     name = "run_args_binary",
+    silent_on_success = False,
     stdout = "args_out",
     tool = ":args_bin",
 )
@@ -54,6 +56,7 @@ js_binary(
 
 js_run_binary(
     name = "run_locations",
+    silent_on_success = False,
     stdout = "locations_out",
     tool = ":locations_bin",
 )
@@ -76,6 +79,7 @@ js_binary(
 
 js_run_binary(
     name = "run_locations_no_expand",
+    silent_on_success = False,
     stdout = "locations_out_no_expand",
     tool = ":locations_bin_no_expand",
 )

--- a/js/private/test/js_run_binary/BUILD.bazel
+++ b/js/private/test/js_run_binary/BUILD.bazel
@@ -29,6 +29,7 @@ js_binary(
 
 js_run_binary(
     name = "runfiles_location",
+    silent_on_success = False,
     stdout = "runfiles_location.txt",
     tool = ":find_cfg_probe",
     use_execroot_entry_point = False,
@@ -56,6 +57,7 @@ assert_contains(
 # directory, the same place a genrule would put its srcs.
 js_run_binary(
     name = "target_cfg_location",
+    silent_on_success = False,
     stdout = "target_cfg_location.txt",
     tool = ":find_cfg_probe",
     use_execroot_entry_point = True,
@@ -114,6 +116,7 @@ js_run_binary(
     name = "gen_target_os",
     srcs = [":os_name.txt"],
     args = ["$(rootpath :os_name.txt)"],
+    silent_on_success = False,
     stdout = "target_os.txt",
     tags = ["manual"],
     tool = ":read_file",

--- a/js/private/test/js_run_binary/label_capture.bzl
+++ b/js/private/test/js_run_binary/label_capture.bzl
@@ -10,6 +10,7 @@ def label_capture(name, tool):
     js_run_binary(
         name = name,
         tool = tool,
+        silent_on_success = False,
         stdout = Label(":{}_stdout.txt".format(name)),
         stderr = Label(":{}_stderr.txt".format(name)),
         exit_code_out = Label(":{}_exit_code.txt".format(name)),

--- a/js/private/test/launcher/BUILD.bazel
+++ b/js/private/test/launcher/BUILD.bazel
@@ -261,6 +261,7 @@ js_run_binary(
     name = "exit_plain_run",
     chdir = package_name(),
     exit_code_out = "exit_plain_code.txt",
+    silent_on_success = False,
     stderr = "exit_plain_stderr.txt",
     stdout = "exit_plain_stdout.txt",
     tool = ":exit_plain_bin",
@@ -310,6 +311,7 @@ js_binary(
 js_run_binary(
     name = "stdout_stderr_run",
     chdir = package_name(),
+    silent_on_success = False,
     stderr = "stdout_stderr_stderr.txt",
     stdout = "stdout_stderr_stdout.txt",
     tool = ":stdout_stderr_bin",

--- a/js/private/test/node-patches/BUILD.bazel
+++ b/js/private/test/node-patches/BUILD.bazel
@@ -79,6 +79,7 @@ babel_bin.babel(
         "--out-dir",
         ".",
     ] + MJS_TESTS,
+    silent_on_success = False,
 )
 
 # Basic tests

--- a/js/private/watch/src/BUILD.bazel
+++ b/js/private/watch/src/BUILD.bazel
@@ -16,5 +16,6 @@ typescript_bin.tsc(
         "tsconfig.json",
     ],
     chdir = package_name(),
+    silent_on_success = False,
     visibility = ["//js/private/watch:__pkg__"],
 )

--- a/js/private/worker/src/BUILD.bazel
+++ b/js/private/worker/src/BUILD.bazel
@@ -38,5 +38,6 @@ rollup_bin.rollup(
         "--file",
         "bundle.js",
     ],
+    silent_on_success = True,
     visibility = ["//js/private/worker:__pkg__"],
 )

--- a/npm/private/lifecycle/src/BUILD.bazel
+++ b/npm/private/lifecycle/src/BUILD.bazel
@@ -32,5 +32,6 @@ rollup_bin.rollup(
         "--file",
         "index.min.js",
     ],
+    silent_on_success = True,
     visibility = ["//npm/private/lifecycle:__subpackages__"],
 )

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -228,6 +228,7 @@ def npm_imported_package_store_internal(
             progress_message = "Running lifecycle hooks on npm package %s@%s}" % (package, version),
             env = lifecycle_hooks_env,
             use_default_shell_env = use_default_shell_env,
+            silent_on_success = True,
         )
 
         # post-lifecycle npm_package

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -483,6 +483,7 @@ def npm_package(
             tags = kwargs.get("tags", []) + ["manual"],
             testonly = kwargs.get("testonly"),
             visibility = kwargs.get("visibility", None),
+            silent_on_success = False,
         )
 
     _npm_package(

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -483,7 +483,6 @@ def npm_package(
             tags = kwargs.get("tags", []) + ["manual"],
             testonly = kwargs.get("testonly"),
             visibility = kwargs.get("visibility", None),
-            silent_on_success = False,
         )
 
     _npm_package(


### PR DESCRIPTION
This change sets `silent_on_success = True` on a few usages that generate a lot of output, but otherwise sets `silent_on_success = False` almost everywhere. The macros in the generated `package_json.bzl` are left alone, since we cannot change those without affecting users in an unpredictable way.

The main goal of this is to improve test coverage. When `silent_on_success` is `False`, we often exercise a different code path because (depending on other options) we can sometimes `exec` node and avoid needing to do any cleanup after it returns.

I am also working on setting up `hermetic_launcher` as an alternative to the bash launcher, but we cannot easily use `hermetic_launcher` if `silent_on_success` is enabled. Turning that off in more places should unlock many more opportunities to test `hermetic_launcher`.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases