### PR TITLE
feat: expose yq_linux_riscv64 for native RISC-V Linux hosts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -75,8 +75,8 @@ use_repo(
     "yq_linux_amd64",
     "yq_linux_arm64",
     "yq_linux_ppc64le",
-    "yq_linux_s390x",
     "yq_linux_riscv64",
+    "yq_linux_s390x",
     "yq_windows_amd64",
     "yq_windows_arm64",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -76,6 +76,7 @@ use_repo(
     "yq_linux_arm64",
     "yq_linux_ppc64le",
     "yq_linux_s390x",
+    "yq_linux_riscv64",
     "yq_windows_amd64",
     "yq_windows_arm64",
 )


### PR DESCRIPTION
npm_translate_lock parses pnpm-lock.yaml by invoking the host yq binary via Label("@yq_{platform}//:yq"). yq.bzl already fetches a mikefarah/yq linux_riscv64 artifact, but MODULE.bazel did not use_repo() it, so a native riscv64 build fails with:

```text
No repository visible as '@yq_linux_riscv64' from repository '@@aspect_rules_js+'
```

Add yq_linux_riscv64 next to the other Linux yq platform repos.

---
