### PR TITLE
refactor: delegate js_run_binary output capture to run_binary

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,9 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Changes ensured by rules_js:
 # 3.2.2: https://github.com/bazel-contrib/bazel-lib/commit/cac2d7855949d1b222fa26888892fbbe1d31015d
+# 3.5.0: run_binary gained native stdout/stderr/exit_code_out/silent_on_success
+# support, which js_run_binary delegates to instead of implementing capture in
+# the js_binary launcher script.
 # 3.7.0: https://github.com/bazel-contrib/bazel-lib/commit/e5c0630270f70dd2c7b50471bb9c872781a55282
 bazel_dep(name = "bazel_lib", version = "3.7.0")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,9 +19,7 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Changes ensured by rules_js:
 # 3.2.2: https://github.com/bazel-contrib/bazel-lib/commit/cac2d7855949d1b222fa26888892fbbe1d31015d
-# 3.5.0: run_binary gained native stdout/stderr/exit_code_out/silent_on_success
-# support, which js_run_binary delegates to instead of implementing capture in
-# the js_binary launcher script.
+# 3.5.0: support for stdout/stderr/exit_code_out/silent_on_success in run_binary
 # 3.7.0: https://github.com/bazel-contrib/bazel-lib/commit/e5c0630270f70dd2c7b50471bb9c872781a55282
 bazel_dep(name = "bazel_lib", version = "3.7.0")
 

--- a/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
+++ b/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
@@ -7,8 +7,9 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 # variable and location expansion.
 #
 # stdout/stderr/exit_code_out are captured here to verify that they do not
-# defeat path mapping; their paths are passed to the launcher relative to the
-# bin directory rather than via $(execpath).
+# defeat path mapping. run_binary implements them, passing each path to its
+# spawn_binary wrapper as a File on an Args object, which is the only channel
+# Bazel rewrites; an $(execpath)-expanded env var would not be.
 js_binary(
     name = "check",
     entry_point = "check.mjs",

--- a/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
+++ b/e2e/path_mapping/js_run_binary_path_mapping_check/BUILD.bazel
@@ -7,9 +7,7 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 # variable and location expansion.
 #
 # stdout/stderr/exit_code_out are captured here to verify that they do not
-# defeat path mapping. run_binary implements them, passing each path to its
-# spawn_binary wrapper as a File on an Args object, which is the only channel
-# Bazel rewrites; an $(execpath)-expanded env var would not be.
+# defeat path mapping.
 js_binary(
     name = "check",
     entry_point = "check.mjs",

--- a/e2e/path_mapping/other_module/subdir/BUILD.bazel
+++ b/e2e/path_mapping/other_module/subdir/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 
 # Same as //js_run_binary_path_mapping_check in the root module, but in a
-# subpackage of an external module. The capture output paths are computed
-# relative to the bin directory, which for an external repository means an
+# subpackage of an external module, where the bin-directory layout gains an
 # "external/<repo>/" prefix; getting that wrong would leave the declared outputs
 # uncreated. The assertions live in the root module, see
 # //other_module_path_mapping_check.

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -47,6 +47,9 @@ function resolve_capture_path {
     esac
 }
 
+# TODO(4.0): remove support for capturing stderr, stdout, and exit code. The
+# js_run_binary macro now handles this in a way that does not require help from
+# the launcher.
 if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
     JS_BINARY__STDOUT_OUTPUT_FILE="$(resolve_capture_path "$JS_BINARY__STDOUT_OUTPUT_FILE")"
 fi

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -16,28 +16,6 @@ load("@bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load(":js_helpers.bzl", _envs_for_log_level = "envs_for_log_level")
 load(":js_info_files.bzl", _js_info_files = "js_info_files")
 
-def _bindir_relative_out(out):
-    """Path of a declared output relative to the bin directory.
-
-    `run_binary` declares `outs` with `attr.output_list`, so the label is always in the
-    current package and the path is fully computable here. Returning a literal keeps the
-    value free of `$(execpath)`, which would otherwise both disable path mapping in
-    `run_binary` and bake in a `bazel-out/<config>/bin` prefix that is wrong when path
-    mapping is active. The launcher recognizes the path as bin-relative because it does
-    not start with `bazel-out/`, and joins it with the path-mapped `--bazel-bindir`.
-    """
-
-    # `out` may be a string or a Label; str() normalizes both to a form ending in
-    # ":<name>" or, for a plain relative string, to the name itself.
-    path = str(out).split(":")[-1]
-    package = native.package_name()
-    if package:
-        path = "{}/{}".format(package, path)
-    repo = native.repo_name()
-    if repo:
-        path = "external/{}/{}".format(repo, path)
-    return path
-
 def js_run_binary(
         name,
         tool,
@@ -162,7 +140,7 @@ def js_run_binary(
         exit_code_out: Output file to capture the exit code of the binary to.
 
             This can later be used as an input to another target subject to the same semantics as `outs`. Note that
-            setting this will force the binary to exit 0.
+            setting this makes the action always succeed, whatever exit code the binary reports.
 
             If the binary creates outputs and these are declared, they must still be created.
 
@@ -171,7 +149,8 @@ def js_run_binary(
             This makes node binaries match the expected bazel paradigm.
 
             This only applies to streams that are not captured to an output file by `stdout` or
-            `stderr`; a captured stream never reaches the terminal to begin with.
+            `stderr`; a captured stream never reaches the terminal to begin with. Note that when
+            `exit_code_out` is set the action never fails, so buffered output is never replayed.
 
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.
@@ -373,22 +352,6 @@ def js_run_binary(
                 normalized_chdir = "external/{}/{}".format(repo, chdir)
         fixed_env["JS_BINARY__CHDIR"] = normalized_chdir
 
-    # Configure capturing stdout, stderr and/or the exit code
-    extra_outs = []
-    if stdout:
-        fixed_env["JS_BINARY__STDOUT_OUTPUT_FILE"] = _bindir_relative_out(stdout)
-        extra_outs.append(stdout)
-    if stderr:
-        fixed_env["JS_BINARY__STDERR_OUTPUT_FILE"] = _bindir_relative_out(stderr)
-        extra_outs.append(stderr)
-    if exit_code_out:
-        fixed_env["JS_BINARY__EXIT_CODE_OUTPUT_FILE"] = _bindir_relative_out(exit_code_out)
-        extra_outs.append(exit_code_out)
-
-    # Configure silent on success
-    if silent_on_success:
-        fixed_env["JS_BINARY__SILENT_ON_SUCCESS"] = "1"
-
     # Disable node patches if requested
     if patch_node_fs:
         fixed_env["JS_BINARY__PATCH_NODE_FS"] = "1"
@@ -457,9 +420,13 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
         tool = tool,
         env = fixed_env | legacy_env | execroot_env | env,
         srcs = srcs + extra_srcs + execroot_extra_srcs,
-        outs = outs + extra_outs,
+        outs = outs,
         out_dirs = out_dirs,
         args = ["--bazel-bindir", "$(BINDIR)"] + args,
+        stdout = stdout,
+        stderr = stderr,
+        exit_code_out = exit_code_out,
+        silent_on_success = silent_on_success,
         mnemonic = mnemonic,
         progress_message = progress_message,
         execution_requirements = execution_requirements,

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -140,7 +140,7 @@ def js_run_binary(
         exit_code_out: Output file to capture the exit code of the binary to.
 
             This can later be used as an input to another target subject to the same semantics as `outs`. Note that
-            setting this makes the action always succeed, whatever exit code the binary reports.
+            setting this will cause the action to succeed despite a nonzero exit code.
 
             If the binary creates outputs and these are declared, they must still be created.
 
@@ -149,8 +149,7 @@ def js_run_binary(
             This makes node binaries match the expected bazel paradigm.
 
             This only applies to streams that are not captured to an output file by `stdout` or
-            `stderr`; a captured stream never reaches the terminal to begin with. Note that when
-            `exit_code_out` is set the action never fails, so buffered output is never replayed.
+            `stderr`; a captured stream never reaches the terminal to begin with.
 
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.

--- a/js/private/test/launcher/BUILD.bazel
+++ b/js/private/test/launcher/BUILD.bazel
@@ -160,11 +160,6 @@ js_test(
 # When node exits 0 but a non-zero code was expected, the launcher must report Bazel's "tests
 # failed" sentinel (exit 3). When node exits a different non-zero code, that code is propagated.
 # When node exits exactly the expected code, the launcher reports success (exit 0).
-#
-# The launcher does the remapping and exits with the remapped code; `exit_code_out` is implemented
-# by `run_binary`, which captures that code without the launcher ever seeing
-# JS_BINARY__EXIT_CODE_OUTPUT_FILE. When the launcher handled both itself it checked
-# expected_exit_code first and exited before writing the code file, leaving the output uncreated.
 
 js_binary(
     name = "exit_zero_bin",

--- a/js/private/test/launcher/BUILD.bazel
+++ b/js/private/test/launcher/BUILD.bazel
@@ -332,11 +332,9 @@ assert_contains(
 # js_run_binary delegates stdout/stderr/exit_code_out/silent_on_success to bazel-lib's run_binary,
 # so it no longer sets JS_BINARY__STDOUT_OUTPUT_FILE and friends. Code outside rules_js does invoke
 # the launcher directly and set them, so the launcher still implements them and these cases keep
-# that path covered. See direct_capture.bzl.
+# that path covered.
 
-# A tool that writes to both streams and exits 0: the captures must land in the declared files even
-# though JS_BINARY__SILENT_ON_SUCCESS is set, because a stream with an output file is written
-# straight to it rather than buffered.
+# A tool that writes to both streams and exits 0: the captures must land in the declared files.
 direct_capture(
     name = "direct_capture_streams",
     tool = ":stdout_stderr_bin",
@@ -385,9 +383,8 @@ diff_test(
     file2 = ":direct_capture_exit_exit_code.txt",
 )
 
-# JS_BINARY__SILENT_ON_SUCCESS with no capture file for either stream: the launcher buffers both in
-# temp files and discards them because the program succeeded. A genrule is used rather than
-# direct_capture so the launcher's own stdout and stderr are what gets asserted on.
+# JS_BINARY__SILENT_ON_SUCCESS with no capture file for either stream should result in nothing
+# written to stdout or stderr.
 genrule(
     name = "direct_silent_run",
     outs = ["direct_silent_out.txt"],

--- a/js/private/test/launcher/BUILD.bazel
+++ b/js/private/test/launcher/BUILD.bazel
@@ -2,6 +2,7 @@ load("@bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@bazel_lib//lib:testing.bzl", "assert_contains")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
+load(":direct_capture.bzl", "direct_capture")
 
 package(default_testonly = True)
 
@@ -160,93 +161,94 @@ js_test(
 # failed" sentinel (exit 3). When node exits a different non-zero code, that code is propagated.
 # When node exits exactly the expected code, the launcher reports success (exit 0).
 #
-# The tests below do not currently pass, because expected_exit_code and exit_code_out do not play
-# nicely with each other. If and when we start using the exit_code_out implementation built into
-# run_binary(), we can re-enable these tests.
-#
-# js_binary(
-#     name = "exit_zero_bin",
-#     entry_point = "exit_with.mjs",
-#     expected_exit_code = 42,
-#     fixed_args = ["0"],
-# )
-#
-# js_run_binary(
-#     name = "exit_zero_run",
-#     chdir = package_name(),
-#     exit_code_out = "exit_zero_code.txt",
-#     stderr = "exit_zero_stderr.txt",
-#     stdout = "exit_zero_stdout.txt",
-#     tool = ":exit_zero_bin",
-# )
-#
-# write_file(
-#     name = "exit_zero_expected",
-#     out = "exit_zero_expected.txt",
-#     content = ["3"],
-# )
-#
-# diff_test(
-#     name = "remap_unexpected_success_test",
-#     file1 = ":exit_zero_expected.txt",
-#     file2 = ":exit_zero_code.txt",
-# )
-#
-# js_binary(
-#     name = "exit_seven_bin",
-#     entry_point = "exit_with.mjs",
-#     expected_exit_code = 42,
-#     fixed_args = ["7"],
-# )
-#
-# js_run_binary(
-#     name = "exit_seven_run",
-#     chdir = package_name(),
-#     exit_code_out = "exit_seven_code.txt",
-#     stderr = "exit_seven_stderr.txt",
-#     stdout = "exit_seven_stdout.txt",
-#     tool = ":exit_seven_bin",
-# )
-#
-# write_file(
-#     name = "exit_seven_expected",
-#     out = "exit_seven_expected.txt",
-#     content = ["7"],
-# )
-#
-# diff_test(
-#     name = "remap_mismatch_test",
-#     file1 = ":exit_seven_expected.txt",
-#     file2 = ":exit_seven_code.txt",
-# )
-#
-# js_binary(
-#     name = "exit_expected_bin",
-#     entry_point = "exit_with.mjs",
-#     expected_exit_code = 42,
-#     fixed_args = ["42"],
-# )
-#
-# js_run_binary(
-#     name = "exit_expected_run",
-#     chdir = package_name(),
-#     exit_code_out = "exit_expected_code.txt",
-#     stderr = "exit_expected_stderr.txt",
-#     stdout = "exit_expected_stdout.txt",
-#     tool = ":exit_expected_bin",
-# )
-#
-# write_file(
-#     name = "exit_expected_expected",
-#     out = "exit_expected_expected.txt",
-#     content = ["0"],
-# )
-#
-# diff_test(
-#     name = "remap_expected_match_test",
-#     file1 = ":exit_expected_expected.txt",
-#     file2 = ":exit_expected_code.txt",
-# )
+# The launcher does the remapping and exits with the remapped code; `exit_code_out` is implemented
+# by `run_binary`, which captures that code without the launcher ever seeing
+# JS_BINARY__EXIT_CODE_OUTPUT_FILE. When the launcher handled both itself it checked
+# expected_exit_code first and exited before writing the code file, leaving the output uncreated.
+
+js_binary(
+    name = "exit_zero_bin",
+    entry_point = "exit_with.mjs",
+    expected_exit_code = 42,
+    fixed_args = ["0"],
+)
+
+js_run_binary(
+    name = "exit_zero_run",
+    chdir = package_name(),
+    exit_code_out = "exit_zero_code.txt",
+    stderr = "exit_zero_stderr.txt",
+    stdout = "exit_zero_stdout.txt",
+    tool = ":exit_zero_bin",
+)
+
+write_file(
+    name = "exit_zero_expected",
+    out = "exit_zero_expected.txt",
+    content = ["3"],
+)
+
+diff_test(
+    name = "remap_unexpected_success_test",
+    file1 = ":exit_zero_expected.txt",
+    file2 = ":exit_zero_code.txt",
+)
+
+js_binary(
+    name = "exit_seven_bin",
+    entry_point = "exit_with.mjs",
+    expected_exit_code = 42,
+    fixed_args = ["7"],
+)
+
+js_run_binary(
+    name = "exit_seven_run",
+    chdir = package_name(),
+    exit_code_out = "exit_seven_code.txt",
+    stderr = "exit_seven_stderr.txt",
+    stdout = "exit_seven_stdout.txt",
+    tool = ":exit_seven_bin",
+)
+
+write_file(
+    name = "exit_seven_expected",
+    out = "exit_seven_expected.txt",
+    content = ["7"],
+)
+
+diff_test(
+    name = "remap_mismatch_test",
+    file1 = ":exit_seven_expected.txt",
+    file2 = ":exit_seven_code.txt",
+)
+
+js_binary(
+    name = "exit_expected_bin",
+    entry_point = "exit_with.mjs",
+    expected_exit_code = 42,
+    fixed_args = ["42"],
+)
+
+js_run_binary(
+    name = "exit_expected_run",
+    chdir = package_name(),
+    exit_code_out = "exit_expected_code.txt",
+    stderr = "exit_expected_stderr.txt",
+    stdout = "exit_expected_stdout.txt",
+    tool = ":exit_expected_bin",
+)
+
+write_file(
+    name = "exit_expected_expected",
+    out = "exit_expected_expected.txt",
+    content = ["0"],
+)
+
+diff_test(
+    name = "remap_expected_match_test",
+    file1 = ":exit_expected_expected.txt",
+    file2 = ":exit_expected_code.txt",
+)
 
 # ==================================================================================================
 # Case 4: with no expected_exit_code the launcher propagates node's exit code verbatim.
@@ -326,5 +328,107 @@ assert_contains(
 assert_contains(
     name = "stderr_passthrough_test",
     actual = ":stdout_stderr_stderr.txt",
+    expected = "ON_STDERR",
+)
+
+# ==================================================================================================
+# Case 7: the launcher honors its own capture environment variables when invoked directly.
+#
+# js_run_binary delegates stdout/stderr/exit_code_out/silent_on_success to bazel-lib's run_binary,
+# so it no longer sets JS_BINARY__STDOUT_OUTPUT_FILE and friends. Code outside rules_js does invoke
+# the launcher directly and set them, so the launcher still implements them and these cases keep
+# that path covered. See direct_capture.bzl.
+
+# A tool that writes to both streams and exits 0: the captures must land in the declared files even
+# though JS_BINARY__SILENT_ON_SUCCESS is set, because a stream with an output file is written
+# straight to it rather than buffered.
+direct_capture(
+    name = "direct_capture_streams",
+    tool = ":stdout_stderr_bin",
+)
+
+assert_contains(
+    name = "direct_capture_stdout_test",
+    actual = ":direct_capture_streams_stdout.txt",
+    expected = "ON_STDOUT",
+)
+
+assert_contains(
+    name = "direct_capture_stderr_test",
+    actual = ":direct_capture_streams_stderr.txt",
+    expected = "ON_STDERR",
+)
+
+write_file(
+    name = "direct_capture_streams_expected_code",
+    out = "direct_capture_streams_expected_code.txt",
+    content = ["0"],
+)
+
+diff_test(
+    name = "direct_capture_zero_exit_code_test",
+    file1 = ":direct_capture_streams_expected_code.txt",
+    file2 = ":direct_capture_streams_exit_code.txt",
+)
+
+# A tool that exits non-zero: the launcher must record the code and itself exit 0, so the action
+# still succeeds and all three declared outputs appear.
+direct_capture(
+    name = "direct_capture_exit",
+    tool = ":exit_plain_bin",
+)
+
+write_file(
+    name = "direct_capture_exit_expected_code",
+    out = "direct_capture_exit_expected_code.txt",
+    content = ["7"],
+)
+
+diff_test(
+    name = "direct_capture_exit_code_test",
+    file1 = ":direct_capture_exit_expected_code.txt",
+    file2 = ":direct_capture_exit_exit_code.txt",
+)
+
+# JS_BINARY__SILENT_ON_SUCCESS with no capture file for either stream: the launcher buffers both in
+# temp files and discards them because the program succeeded. A genrule is used rather than
+# direct_capture so the launcher's own stdout and stderr are what gets asserted on.
+genrule(
+    name = "direct_silent_run",
+    outs = ["direct_silent_out.txt"],
+    cmd = "JS_BINARY__SILENT_ON_SUCCESS=1 BAZEL_BINDIR=$(BINDIR) $(execpath :stdout_stderr_bin) > $@ 2>&1",
+    tools = [":stdout_stderr_bin"],
+)
+
+write_file(
+    name = "direct_silent_expected",
+    out = "direct_silent_expected.txt",
+    content = [],
+)
+
+diff_test(
+    name = "direct_silent_on_success_test",
+    file1 = ":direct_silent_expected.txt",
+    file2 = ":direct_silent_out.txt",
+)
+
+# The same invocation without JS_BINARY__SILENT_ON_SUCCESS, so the suppression above is
+# attributable to the variable rather than to the streams going missing some other way.
+genrule(
+    name = "direct_noisy_run",
+    outs = ["direct_noisy_out.txt"],
+    cmd = "BAZEL_BINDIR=$(BINDIR) $(execpath :stdout_stderr_bin) > $@ 2>&1",
+    tools = [":stdout_stderr_bin"],
+)
+
+assert_contains(
+    name = "direct_not_silent_stdout_test",
+    actual = ":direct_noisy_out.txt",
+    expected = "ON_STDOUT",
+)
+
+assert_contains(
+    name = "direct_not_silent_stderr_test",
+    actual = ":direct_noisy_out.txt",
     expected = "ON_STDERR",
 )

--- a/js/private/test/launcher/direct_capture.bzl
+++ b/js/private/test/launcher/direct_capture.bzl
@@ -1,0 +1,74 @@
+"""Test-only rule that drives the js_binary launcher's own capture support directly.
+
+`js_run_binary` delegates stdout/stderr/exit_code_out/silent_on_success to bazel-lib's
+`run_binary`, so nothing in this repo routes the JS_BINARY__*_OUTPUT_FILE and
+JS_BINARY__SILENT_ON_SUCCESS environment variables through the launcher any more. Code outside
+rules_js does invoke the launcher directly and set them (see #2955), so the launcher still honors
+them and this rule keeps that path covered.
+
+Both branches of the launcher's `resolve_capture_path` are exercised: a value starting with
+"bazel-out/" is execroot-relative, anything else is relative to BAZEL_BINDIR.
+"""
+
+load("@aspect_rules_js//js:libs.bzl", "js_binary_lib")
+
+def _direct_capture_impl(ctx):
+    stdout = ctx.outputs.stdout
+    stderr = ctx.outputs.stderr
+    exit_code = ctx.outputs.exit_code_out
+    outputs = [stdout, stderr, exit_code]
+
+    js_binary_lib.run_binary_action(
+        ctx = ctx,
+        executable = ctx.executable.tool,
+        outputs = outputs,
+        mnemonic = "DirectCapture",
+        env = {
+            # short_path is bin-relative and File.path is execroot-relative
+            # ("bazel-out/<cfg>/bin/..."), so using a different one per stream covers both
+            # resolve_capture_path branches in a single action.
+            "JS_BINARY__STDOUT_OUTPUT_FILE": stdout.short_path,
+            "JS_BINARY__STDERR_OUTPUT_FILE": stderr.path,
+            "JS_BINARY__EXIT_CODE_OUTPUT_FILE": exit_code.short_path,
+            # Set alongside the capture files, which is the case where the launcher writes each
+            # stream straight to its output file rather than buffering it in a temp file.
+            "JS_BINARY__SILENT_ON_SUCCESS": "1",
+        },
+    )
+
+    return [DefaultInfo(files = depset(outputs))]
+
+_direct_capture = rule(
+    doc = "Runs a js_binary tool with the launcher's capture environment variables set.",
+    implementation = _direct_capture_impl,
+    attrs = {
+        "tool": attr.label(
+            doc = "The js_binary to run.",
+            executable = True,
+            allow_files = True,
+            mandatory = True,
+            cfg = "exec",
+        ),
+        "stdout": attr.output(mandatory = True),
+        "stderr": attr.output(mandatory = True),
+        "exit_code_out": attr.output(mandatory = True),
+    },
+)
+
+def direct_capture(name, tool, **kwargs):
+    """Declares a _direct_capture target with conventionally named capture outputs.
+
+    Args:
+        name: Target name. The capture outputs are `<name>_stdout.txt`, `<name>_stderr.txt` and
+            `<name>_exit_code.txt`.
+        tool: The js_binary to run.
+        **kwargs: Additional arguments forwarded to the rule.
+    """
+    _direct_capture(
+        name = name,
+        tool = tool,
+        stdout = "{}_stdout.txt".format(name),
+        stderr = "{}_stderr.txt".format(name),
+        exit_code_out = "{}_exit_code.txt".format(name),
+        **kwargs
+    )

--- a/js/private/test/launcher/direct_capture.bzl
+++ b/js/private/test/launcher/direct_capture.bzl
@@ -2,12 +2,9 @@
 
 `js_run_binary` delegates stdout/stderr/exit_code_out/silent_on_success to bazel-lib's
 `run_binary`, so nothing in this repo routes the JS_BINARY__*_OUTPUT_FILE and
-JS_BINARY__SILENT_ON_SUCCESS environment variables through the launcher any more. Code outside
+JS_BINARY__SILENT_ON_SUCCESS environment variables through the launcher anymore. Code outside
 rules_js does invoke the launcher directly and set them (see #2955), so the launcher still honors
 them and this rule keeps that path covered.
-
-Both branches of the launcher's `resolve_capture_path` are exercised: a value starting with
-"bazel-out/" is execroot-relative, anything else is relative to BAZEL_BINDIR.
 """
 
 load("@aspect_rules_js//js:libs.bzl", "js_binary_lib")
@@ -25,8 +22,8 @@ def _direct_capture_impl(ctx):
         mnemonic = "DirectCapture",
         env = {
             # short_path is bin-relative and File.path is execroot-relative
-            # ("bazel-out/<cfg>/bin/..."), so using a different one per stream covers both
-            # resolve_capture_path branches in a single action.
+            # ("bazel-out/<cfg>/bin/..."), so using a different one per stream covers both in a
+            # single action.
             "JS_BINARY__STDOUT_OUTPUT_FILE": stdout.short_path,
             "JS_BINARY__STDERR_OUTPUT_FILE": stderr.path,
             "JS_BINARY__EXIT_CODE_OUTPUT_FILE": exit_code.short_path,

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -58,6 +58,9 @@ function resolve_capture_path {
     esac
 }
 
+# TODO(4.0): remove support for capturing stderr, stdout, and exit code. The
+# js_run_binary macro now handles this in a way that does not require help from
+# the launcher.
 if [ "${JS_BINARY__STDOUT_OUTPUT_FILE:-}" ]; then
     JS_BINARY__STDOUT_OUTPUT_FILE="$(resolve_capture_path "$JS_BINARY__STDOUT_OUTPUT_FILE")"
 fi


### PR DESCRIPTION
`run_binary` now has its own implementations of `stdout`, `stderr`, `exit_code_out` and `silent_on_success`, so we can have `js_run_binary` use them without reimplementing that functionality.

I previously attempted this and had to roll back the change, but that was because I deleted the corresponding logic from the bash launcher, and it turns out that some targets rely on that to work even when `js_run_binary` is not involved. This commit adds test coverage of that use case to ensure it keeps working.

This change will cause most `js_run_binary` invocations to be wrapped with `spawn_binary`, which is the tool `run_binary` uses to capture stdout, stderr, and the exit code. This is due to the fact that `silent_on_success` defaults to `True` on `js_run_binary`. Performance-wise, this is mostly a wash: we get the extra `spawn_binary` process but also allow the bash launcher to `exec` node instead of spawning a new process for it.

The main motivation here is to move toward having `js_run_binary` use `hermetic_launcher` instead of our bash launcher. Unlike the bash launcher, `hermetic_launcher` has no way to capture the output or exit code of the binary, but that problem goes away if we can let `spawn_binary` handle it.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
