### PR TITLE
feat: set `silent_on_success = False` in more places

### DIFF
--- a/contrib/nextjs/defs.bzl
+++ b/contrib/nextjs/defs.bzl
@@ -212,7 +212,6 @@ def nextjs_build(name, config, srcs, next_js_binary, data = [], use_execroot_ent
         mnemonic = "NextJs",
         progress_message = "Compile Next.js app %{label}",
         use_execroot_entry_point = use_execroot_entry_point,
-        silent_on_success = kwargs.pop("silent_on_success", True),
         **kwargs
     )
 
@@ -362,7 +361,6 @@ def nextjs_standalone_build(name, config, srcs, next_js_binary, data = [], use_e
         tags = tags + ["manual"],
         testonly = testonly,
         visibility = ["//visibility:private"],
-        silent_on_success = kwargs.pop("silent_on_success", True),
         **kwargs
     )
 

--- a/examples/webpack_cli/BUILD.bazel
+++ b/examples/webpack_cli/BUILD.bazel
@@ -37,8 +37,7 @@ bin.webpack_cli(
         "--config",
         "$$RUNFILES_DIR/$(rlocationpath :webpack-config)",
     ],
-    log_level = "debug",
-    silent_on_success = True,
+    silent_on_success = False,
 )
 
 js_test(

--- a/examples/webpack_cli/webpack.config.js
+++ b/examples/webpack_cli/webpack.config.js
@@ -6,9 +6,8 @@ const out_path = path.resolve(process.cwd(), 'dist')
 
 module.exports = {
     entry: path.join(process.cwd(), 'index.js'),
-    stats: 'verbose',
     mode: 'development',
-    stats: 'detailed',
+    stats: 'errors-warnings',
     resolve: {
         extensions: ['.js', '.ts'],
     },

--- a/js/private/coverage/bundle/BUILD.bazel
+++ b/js/private/coverage/bundle/BUILD.bazel
@@ -33,6 +33,6 @@ rollup_bin.rollup(
         "--file",
         "bundle.js",
     ],
-    silent_on_success = True,
+    silent_on_success = False,
     visibility = ["//js/private/coverage:__pkg__"],
 )

--- a/js/private/devserver/src/BUILD.bazel
+++ b/js/private/devserver/src/BUILD.bazel
@@ -28,6 +28,6 @@ rollup_bin.rollup(
         "--file",
         "bundle.mjs",
     ],
-    silent_on_success = True,
+    silent_on_success = False,
     visibility = ["//js/private/devserver:__pkg__"],
 )

--- a/js/private/worker/src/BUILD.bazel
+++ b/js/private/worker/src/BUILD.bazel
@@ -38,6 +38,6 @@ rollup_bin.rollup(
         "--file",
         "bundle.js",
     ],
-    silent_on_success = True,
+    silent_on_success = False,
     visibility = ["//js/private/worker:__pkg__"],
 )

--- a/npm/private/lifecycle/src/BUILD.bazel
+++ b/npm/private/lifecycle/src/BUILD.bazel
@@ -32,6 +32,6 @@ rollup_bin.rollup(
         "--file",
         "index.min.js",
     ],
-    silent_on_success = True,
+    silent_on_success = False,
     visibility = ["//npm/private/lifecycle:__subpackages__"],
 )

--- a/npm/private/npm_import.bzl
+++ b/npm/private/npm_import.bzl
@@ -228,7 +228,6 @@ def npm_imported_package_store_internal(
             progress_message = "Running lifecycle hooks on npm package %s@%s}" % (package, version),
             env = lifecycle_hooks_env,
             use_default_shell_env = use_default_shell_env,
-            silent_on_success = True,
         )
 
         # post-lifecycle npm_package

--- a/npm/private/npm_package.bzl
+++ b/npm/private/npm_package.bzl
@@ -483,6 +483,7 @@ def npm_package(
             tags = kwargs.get("tags", []) + ["manual"],
             testonly = kwargs.get("testonly"),
             visibility = kwargs.get("visibility", None),
+            silent_on_success = False,
         )
 
     _npm_package(


### PR DESCRIPTION
Setting `silent_on_success = True` incurs a performance cost, because it requires us to save the stdout and stderr of the `node` process so that we can print it out in the event of a failure. Disabling it lets us `exec` Node and avoid an extra process.

This commit sets the option to `False` in a few more places. This may result in a little bit more build output, but it does not appear to be an excessive amount. I tweaked some options in `examples/webpack_cli` to cut down on the build output.

I also fixed a few places where we were setting `silent_on_success = True`--this is unnecessary since that is already the default.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
