### PR TITLE
fix: sandbox npm package store for devservers

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -138,6 +138,45 @@ eslint_bin.eslint_test(
 > NB: We plan to add support for the `.npmrc` `public-hoist-pattern` setting to `rules_js` in a future release.
 > For now, you must emulate public-hoist-pattern in `rules_js` using the `public_hoist_packages` attribute shown above.
 
+## Devserver bundler refuses to compile files "outside of the project directory"
+
+`js_run_devserver` runs the devserver in a custom sandbox under the OS temp directory. By default the
+`node_modules` symlinks in that sandbox point back at the npm package store in the Bazel execroot, so
+third-party packages are resolved without being copied into the sandbox.
+
+Bundlers that resolve modules through `realpath()` and then enforce a project root boundary reject
+that layout, because every third party package physically lives outside the sandbox. Next.js with
+Turbopack (the default since Next.js 16) fails like this:
+
+```
+Error: Next.js inferred your workspace root, but it may not be correct.
+    We couldn't find the Next.js package (next/package.json) from the project directory: ...
+    Note: For security and performance reasons, files outside of the project directory
+    will not be compiled.
+```
+
+Setting `turbopack.root` does not help: no directory contains both the sandbox and the execroot.
+
+The fix is to materialize the package store inside the sandbox so that `realpath()` of every
+`node_modules` entry stays under the sandbox root:
+
+```python
+js_run_devserver(
+    name = "dev",
+    args = ["dev"],
+    chdir = package_name(),
+    data = [...],
+    package_store_mode = "sandbox",
+    tool = ":next_js_binary",
+)
+```
+
+Package store files use copy-on-write filesystem clones where possible, with a regular copy
+fallback. This keeps devserver writes isolated from Bazel outputs while avoiding duplicate disk
+usage on filesystems that support cloning. Set the `JS_RUN_DEVSERVER_SANDBOX_DIR` environment
+variable to place the sandbox alongside the execroot and increase the chance that cloning is
+available.
+
 ## Ugly stack traces
 
 Bazel's sandboxing and runfiles directory layouts can make stack traces and logs hard to read. This issue is common in many

--- a/e2e/js_run_devserver/src/BUILD.bazel
+++ b/e2e/js_run_devserver/src/BUILD.bazel
@@ -67,6 +67,28 @@ command(
     command = ":devserver_alt",
 )
 
+# Same as :devserver_alt but with the npm package store materialized inside the custom sandbox so
+# that node_modules symlinks resolve within it. Covers that incremental ibazel syncing still works
+# in that mode.
+js_run_devserver(
+    name = "devserver_sandbox",
+    chdir = package_name(),
+    command = "../node_modules/.bin/http-server",
+    data = [
+        ":http_root",
+        ":web_files",
+        "//:node_modules/http-server",
+    ],
+    log_level = "debug",
+    package_store_mode = "sandbox",
+)
+
+command(
+    name = "serve_sandbox",
+    arguments = ["."],
+    command = ":devserver_sandbox",
+)
+
 # Use command to bake-in the arguments into the runnable binary so that the target
 # can be used with `multirun` below.
 command(

--- a/e2e/js_run_devserver/test.sh
+++ b/e2e/js_run_devserver/test.sh
@@ -7,6 +7,7 @@ bazel run -- @pnpm --dir "$PWD" install
 
 ./serve_test.sh //src:serve
 ./serve_test.sh //src:serve_alt
+./serve_test.sh //src:serve_sandbox
 ./serve_test.sh //src:serve_simple
 ./serve_test.sh //src:serve_simple_bin
 ./serve_test.sh //src:serve_naughty

--- a/js/private/devserver/js_run_devserver.mjs
+++ b/js/private/devserver/js_run_devserver.mjs
@@ -275,6 +275,19 @@ const syncedTime = new Map();
 const syncedChecksum = new Map();
 const mkdirs = new Set();
 
+// Set of all data file paths (workspace-relative, posix separators) that the sandbox is expected to
+// contain after the current sync. Used to resolve node_modules symlinks to their in-sandbox targets
+// without depending on the order in which entries happen to be synced.
+const entryPaths = new Set();
+
+// When true the package store is materialized inside the sandbox and node_modules symlinks are
+// pointed at it instead of at the execroot. Set from the rule config in main().
+let sandboxPackageStore = false;
+
+// How many levels of symlinked directories will be dereferenced into the sandbox before giving up.
+// Guards against symlinked directories that point at one another, which would recurse forever.
+const MAX_DEREF_DEPTH = 32;
+
 // Ensure that a directory exists. If it has not been previously created or does not exist then it
 // creates the directory, first recursively ensuring that its parent directory exists. Intentionally
 // synchronous to avoid race conditions between async promises. If we use `await fs.promises.mkdir(p)`
@@ -314,16 +327,76 @@ function isNodeModulePath(p) {
     return false
 }
 
-// Determines if a file path is a 1p dep in the package store.
+// Determines if a file path is within the rules_js package store.
 // See js/private/test/js_run_devserver/js_run_devserver.spec.mjs for examples.
-function is1pPackageStoreDep(p) {
-    // unscoped1p: https://regex101.com/r/hBR08J/1
-    const unscoped1p =
-        /^.+\/\.aspect_rules_js\/([^@\/]+)@0\.0\.0\/node_modules\/\1$/;
-    // scoped1p: https://regex101.com/r/bWS7Hl/1
-    const scoped1p =
-        /^.+\/\.aspect_rules_js\/@([^@+\/]+)\+([^@+\/]+)@0\.0\.0\/node_modules\/@\1\/\2$/;
-    return unscoped1p.test(p) || scoped1p.test(p)
+function isPackageStorePath(p) {
+    return p.includes('/.aspect_rules_js/')
+}
+
+// Determines if a file path is anywhere under a node_modules tree, including paths such as
+// node_modules/.bin/next and files within the contents of a package, which isNodeModulePath does
+// not match since it only matches the package directory itself.
+// See js/private/test/js_run_devserver/js_run_devserver.spec.mjs for examples.
+function isUnderNodeModules(p) {
+    return /(^|\/)node_modules\//.test(toPosix(p))
+}
+
+function toPosix(p) {
+    return path.sep === '/' ? p : p.split(path.sep).join('/')
+}
+
+// Records the full set of data files that the current sync will place in the sandbox.
+function updateEntryPaths(files) {
+    entryPaths.clear();
+    for (const [file] of files) {
+        entryPaths.add(toPosix(file));
+    }
+}
+
+// Reads a symlink in the runfiles tree and resolves it to the equivalent path inside the sandbox,
+// or undefined when the target is not something this devserver syncs into the sandbox.
+async function readSandboxSymlinkTarget(file, src, sandbox) {
+    let linkPath = await fs.promises.readlink(src);
+    const linkAbs = path.resolve(path.dirname(src), linkPath);
+    linkPath = path.relative(src, linkAbs) || '.';
+    return resolveSandboxSymlinkTarget(sandbox, file, linkPath, entryPaths)
+}
+
+// Resolves the target of a symlink to a path inside the sandbox, or returns undefined
+// if the target is not something this devserver syncs into the sandbox. `linkPath` is the symlink
+// target relative to the link itself, as computed by readSandboxSymlinkTarget.
+function resolveSandboxSymlinkTarget(sandbox, file, linkPath, entries) {
+    const target = path.join(sandbox, file, linkPath);
+    let rel = toPosix(path.relative(sandbox, target));
+    if (!rel || rel === '..' || rel.startsWith('../')) {
+        // Escapes the sandbox root; nothing we can point at.
+        return undefined
+    }
+    // The target is in the sandbox if it, or a directory entry containing it, is synced.
+    while (rel && rel !== '.') {
+        if (entries.has(rel)) {
+            return target
+        }
+        const parent = path.posix.dirname(rel);
+        if (parent === rel) {
+            break
+        }
+        rel = parent;
+    }
+    return undefined
+}
+
+// Stats a path following symlinks, or returns null for a broken link so that the caller can
+// recreate it as a symlink rather than failing the sync.
+async function statFollowingLinks(src, file) {
+    try {
+        return await fs.promises.stat(src)
+    } catch (e) {
+        if (JS_BINARY__LOG_DEBUG) {
+            console.error(`Could not follow symlink ${file}: ${e.message}`);
+        }
+        return null
+    }
 }
 
 // Utility function to retry an async operation with backoff
@@ -402,9 +475,15 @@ function friendlyFileSize(bytes) {
     )
 }
 
-async function syncSymlink(file, src, dst, sandbox, exists) {
+async function syncSymlink(file, src, dst, sandbox, exists, sandboxSrc) {
     let symlinkMeta = '';
-    if (isNodeModulePath(file)) {
+    if (sandboxSrc) {
+        // The target is synced into the sandbox, so point at it rather than at the execroot. This
+        // keeps realpath() of the link inside the sandbox root, which bundlers that enforce a
+        // project-root boundary (e.g. Turbopack) require.
+        src = sandboxSrc;
+        symlinkMeta = 'sandbox';
+    } else if (isNodeModulePath(file)) {
         let linkPath = await fs.promises.readlink(src);
         const linkAbs = path.resolve(path.dirname(src), linkPath);
         linkPath = path.relative(src, linkAbs) || '.';
@@ -443,7 +522,7 @@ async function syncSymlink(file, src, dst, sandbox, exists) {
     return 1
 }
 
-async function syncDirectory(file, src, sandbox, writePerm) {
+async function syncDirectory(file, src, sandbox, writePerm, derefDepth = 0) {
     if (JS_BINARY__LOG_DEBUG) {
         console.error(`Syncing directory ${file}...`);
     }
@@ -456,11 +535,19 @@ async function syncDirectory(file, src, sandbox, writePerm) {
                         file + path.sep + entry,
                         undefined,
                         sandbox,
-                        writePerm
+                        writePerm,
+                        derefDepth
                     )
             )
         )
     ).reduce((s, t) => s + t, 0)
+}
+
+// Materializes src at dst using a copy-on-write clone when possible. Node falls back to a regular
+// copy when the filesystem does not support cloning. Unlike a hardlink, both forms create a new
+// inode, so a devserver can chmod or modify the sandbox file without mutating the Bazel output.
+async function materializeFile(src, dst) {
+    await fs.promises.copyFile(src, dst, fs.constants.COPYFILE_FICLONE);
 }
 
 async function syncFile(file, src, dst, exists, lstat, writePerm) {
@@ -479,7 +566,7 @@ async function syncFile(file, src, dst, exists, lstat, writePerm) {
     }
 
     await withRetry(
-        () => fs.promises.copyFile(src, dst),
+        () => materializeFile(src, dst),
         `copyFile from ${src} to ${dst}`
     );
 
@@ -501,8 +588,9 @@ async function syncFile(file, src, dst, exists, lstat, writePerm) {
 // Recursively copies a file, symlink or directory to a destination. If the file has been previously
 // synced it is only re-copied if the file's last modified time has changed since the last time that
 // file was copied. Symlinks are not copied but instead a symlink is created under the destination
-// pointing to the source symlink.
-async function syncRecursive(file, _, sandbox, writePerm) {
+// pointing to the source symlink; the exception is sandbox package store mode, where a node_modules
+// symlink that would point out of the sandbox is dereferenced and its contents materialized.
+async function syncRecursive(file, _, sandbox, writePerm, derefDepth = 0) {
     const src = RUNFILES_ROOT + path.sep + file;
     const dst = sandbox + path.sep + file;
 
@@ -511,8 +599,48 @@ async function syncRecursive(file, _, sandbox, writePerm) {
             () => fs.promises.lstat(src),
             `lstat for ${src}`
         );
+
+        // Runfiles entries for npm packages are symlinks pointing at the package store in the
+        // execroot. Recreating them as symlinks would put the package contents outside the sandbox
+        // root, so in sandbox package store mode a node_modules symlink whose target is not itself
+        // synced into the sandbox is dereferenced and its contents materialized instead.
+        let sandboxSrc;
+        let deref = false;
+        let followed = null;
+        if (
+            sandboxPackageStore &&
+            lstat.isSymbolicLink() &&
+            isUnderNodeModules(file)
+        ) {
+            sandboxSrc = await readSandboxSymlinkTarget(file, src, sandbox);
+            deref = !sandboxSrc;
+            if (deref) {
+                followed = await statFollowingLinks(src, file);
+                // A broken link has nothing to dereference; recreate it as a symlink.
+                deref = !!followed;
+            }
+        }
+
+        // A dereferenced directory is re-walked on every sync; the files within it do their own
+        // up-to-date checks. The symlink's own mtime says nothing about its contents.
+        const derefDirectory = deref && followed.isDirectory();
+
+        if (derefDirectory && derefDepth >= MAX_DEREF_DEPTH) {
+            // Symlinked directories that point at each other would otherwise recurse forever.
+            console.error(
+                `Not dereferencing ${file}: more than ${MAX_DEREF_DEPTH} levels of symlinked directories`
+            );
+            const exists = syncedTime.has(file) || fs.existsSync(dst);
+            return syncSymlink(file, src, dst, sandbox, exists)
+        }
+
         const last = syncedTime.get(file);
-        if (!lstat.isDirectory() && last && lstat.mtimeMs == last) {
+        if (
+            !lstat.isDirectory() &&
+            !derefDirectory &&
+            last &&
+            lstat.mtimeMs == last
+        ) {
             // this file is already up-to-date
             if (JS_BINARY__LOG_DEBUG) {
                 console.error(
@@ -523,11 +651,21 @@ async function syncRecursive(file, _, sandbox, writePerm) {
         }
         const exists = syncedTime.has(file) || fs.existsSync(dst);
         syncedTime.set(file, lstat.mtimeMs);
-        if (lstat.isSymbolicLink()) {
-            return syncSymlink(file, src, dst, sandbox, exists)
+        if (derefDirectory) {
+            if (JS_BINARY__LOG_DEBUG) {
+                console.error(`Dereferencing symlinked directory ${file}`);
+            }
+            return syncDirectory(file, src, sandbox, writePerm, derefDepth + 1)
+        } else if (lstat.isSymbolicLink() && !deref) {
+            return syncSymlink(file, src, dst, sandbox, exists, sandboxSrc)
         } else if (lstat.isDirectory()) {
-            return syncDirectory(file, src, sandbox, writePerm)
+            return syncDirectory(file, src, sandbox, writePerm, derefDepth)
         } else {
+            if (sandboxPackageStore && isPackageStorePath(file)) {
+                // Package store files are immutable Bazel outputs, so the mtime check above is
+                // sufficient. Skip hashing them; there can be a very large number of them.
+                return syncFile(file, src, dst, exists, lstat, writePerm)
+            }
             const lastChecksum = syncedChecksum.get(file);
             const checksum = await generateChecksum(src);
             if (lastChecksum && checksum == lastChecksum) {
@@ -617,20 +755,17 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     const startTime = perf_hooks.performance.now();
 
     // Partition files into node_modules and non-node_modules files
-    const packageStore1pDeps = [];
+    const packageStoreDeps = [];
     const otherNodeModulesFiles = [];
     const otherFiles = [];
     for (const fileInfo of files) {
         const file = fileInfo[0];
-        if (isNodeModulePath(file)) {
-            // Node module file
-            if (is1pPackageStoreDep(file)) {
-                // 1p package store dep
-                packageStore1pDeps.push(fileInfo);
-            } else {
-                // Other node_modules file
-                otherNodeModulesFiles.push(fileInfo);
-            }
+        if (isPackageStorePath(file)) {
+            // Package store deps must land before the direct node_modules symlinks that point at
+            // them. The entries list is filtered by the rule according to package_store_mode.
+            packageStoreDeps.push(fileInfo);
+        } else if (isNodeModulePath(file)) {
+            otherNodeModulesFiles.push(fileInfo);
         } else {
             otherFiles.push(fileInfo);
         }
@@ -652,17 +787,17 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
         )
     ).reduce((s, t) => s + t, 0);
 
-    // Sync first-party package store files before other node_modules files since correctly syncing
-    // direct 1p node_modules symlinks depends on checking if the package store synced files exist.
-    if (JS_BINARY__LOG_DEBUG && packageStore1pDeps.length > 0) {
+    // Sync package store files before other node_modules files since correctly syncing direct
+    // node_modules symlinks depends on the package store files they point at being in place.
+    if (JS_BINARY__LOG_DEBUG && packageStoreDeps.length > 0) {
         console.error(
-            `+ Syncing ${packageStore1pDeps.length} first party package store dep(s)`
+            `+ Syncing ${packageStoreDeps.length} package store dep(s)`
         );
     }
 
     totalSynced += (
         await Promise.all(
-            packageStore1pDeps.map(async ([file, isDirectory]) => {
+            packageStoreDeps.map(async ([file, isDirectory]) => {
                 return await doSync(file, isDirectory, sandbox, writePerm)
             })
         )
@@ -703,6 +838,8 @@ async function main(args, sandbox, config) {
     );
 
     const entriesPath = path.join(RUNFILES_ROOT, args[1]);
+
+    sandboxPackageStore = config.package_store_mode === 'sandbox';
 
     const cwd = path.join(sandbox, sandboxRelativeChdir(config.chdir));
 
@@ -771,8 +908,13 @@ async function runIBazelProtocol(
     toolArgs,
     env
 ) {
+    const initialFiles = await fs.promises
+        .readFile(entriesPath)
+        .then(JSON.parse);
+    updateEntryPaths(initialFiles);
+
     await syncFiles(
-        await fs.promises.readFile(entriesPath).then(JSON.parse),
+        initialFiles,
         sandbox,
         config.grant_sandbox_write_permissions,
         syncRecursive
@@ -821,6 +963,7 @@ async function runIBazelProtocol(
                     const updatedDataFiles = await fs.promises
                         .readFile(entriesPath)
                         .then(JSON.parse);
+                    updateEntryPaths(updatedDataFiles);
 
                     // Await promises to catch any exceptions, and wait for the
                     // sync to be complete before writing to stdin of the child
@@ -925,6 +1068,7 @@ async function runWatchProtocol(
 async function watchProtocolCycle(config, entriesPath, sandbox, cycle) {
     // Re-parse the config file to get the latest list of data files to copy
     const newFiles = await fs.promises.readFile(entriesPath).then(JSON.parse);
+    updateEntryPaths(newFiles);
 
     const oldFiles = config.previous_files || [];
     config.previous_files = newFiles;
@@ -984,6 +1128,24 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
     }
 
     if (srcRunfilesInfo.is_symlink) {
+        // See the equivalent handling in syncRecursive.
+        if (sandboxPackageStore && isUnderNodeModules(file)) {
+            const sandboxSrc = await readSandboxSymlinkTarget(
+                file,
+                src,
+                sandbox
+            );
+            if (!sandboxSrc) {
+                const followed = await statFollowingLinks(src, file);
+                if (followed && followed.isDirectory()) {
+                    return syncDirectory(file, src, sandbox, writePerm, 1)
+                }
+                if (followed) {
+                    return syncFile(file, src, dst, exists, followed, writePerm)
+                }
+            }
+            return syncSymlink(file, src, dst, sandbox, exists, sandboxSrc)
+        }
         return syncSymlink(file, src, dst, sandbox, exists)
     }
 
@@ -1003,8 +1165,15 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
     onProcessEnd(() => sandbox && removeSandbox(sandbox) && (sandbox = null));
 
     try {
+        // The sandbox lives under the OS temp dir by default. JS_RUN_DEVSERVER_SANDBOX_DIR moves it
+        // elsewhere; placing it on the same filesystem as the execroot may allow package-store
+        // files to use copy-on-write clones rather than full copies.
+        const sandboxParent =
+            process.env.JS_RUN_DEVSERVER_SANDBOX_DIR || os.tmpdir();
+        // Intentionally synchronous; see comment on mkdirpSync
+        mkdirpSync(sandboxParent);
         sandbox = await fs.promises.mkdtemp(
-            path.join(os.tmpdir(), 'js_run_devserver-')
+            path.join(sandboxParent, 'js_run_devserver-')
         );
         const sandboxMain = path.join(sandbox, JS_BINARY__WORKSPACE);
 
@@ -1050,4 +1219,4 @@ function onProcessEnd(callback) {
     // Do not invoke on uncaught exception or errors to allow inspecting the sandbox
 }
 
-export { friendlyFileSize, is1pPackageStoreDep, isNodeModulePath, sandboxRelativeChdir };
+export { friendlyFileSize, isNodeModulePath, isPackageStorePath, isUnderNodeModules, resolveSandboxSymlinkTarget, sandboxRelativeChdir };

--- a/js/private/devserver/src/js_run_devserver.mjs
+++ b/js/private/devserver/src/js_run_devserver.mjs
@@ -27,6 +27,19 @@ const syncedTime = new Map()
 const syncedChecksum = new Map()
 const mkdirs = new Set()
 
+// Set of all data file paths (workspace-relative, posix separators) that the sandbox is expected to
+// contain after the current sync. Used to resolve node_modules symlinks to their in-sandbox targets
+// without depending on the order in which entries happen to be synced.
+const entryPaths = new Set()
+
+// When true the package store is materialized inside the sandbox and node_modules symlinks are
+// pointed at it instead of at the execroot. Set from the rule config in main().
+let sandboxPackageStore = false
+
+// How many levels of symlinked directories will be dereferenced into the sandbox before giving up.
+// Guards against symlinked directories that point at one another, which would recurse forever.
+const MAX_DEREF_DEPTH = 32
+
 // Ensure that a directory exists. If it has not been previously created or does not exist then it
 // creates the directory, first recursively ensuring that its parent directory exists. Intentionally
 // synchronous to avoid race conditions between async promises. If we use `await fs.promises.mkdir(p)`
@@ -66,16 +79,76 @@ export function isNodeModulePath(p) {
     return false
 }
 
-// Determines if a file path is a 1p dep in the package store.
+// Determines if a file path is within the rules_js package store.
 // See js/private/test/js_run_devserver/js_run_devserver.spec.mjs for examples.
-export function is1pPackageStoreDep(p) {
-    // unscoped1p: https://regex101.com/r/hBR08J/1
-    const unscoped1p =
-        /^.+\/\.aspect_rules_js\/([^@\/]+)@0\.0\.0\/node_modules\/\1$/
-    // scoped1p: https://regex101.com/r/bWS7Hl/1
-    const scoped1p =
-        /^.+\/\.aspect_rules_js\/@([^@+\/]+)\+([^@+\/]+)@0\.0\.0\/node_modules\/@\1\/\2$/
-    return unscoped1p.test(p) || scoped1p.test(p)
+export function isPackageStorePath(p) {
+    return p.includes('/.aspect_rules_js/')
+}
+
+// Determines if a file path is anywhere under a node_modules tree, including paths such as
+// node_modules/.bin/next and files within the contents of a package, which isNodeModulePath does
+// not match since it only matches the package directory itself.
+// See js/private/test/js_run_devserver/js_run_devserver.spec.mjs for examples.
+export function isUnderNodeModules(p) {
+    return /(^|\/)node_modules\//.test(toPosix(p))
+}
+
+function toPosix(p) {
+    return path.sep === '/' ? p : p.split(path.sep).join('/')
+}
+
+// Records the full set of data files that the current sync will place in the sandbox.
+function updateEntryPaths(files) {
+    entryPaths.clear()
+    for (const [file] of files) {
+        entryPaths.add(toPosix(file))
+    }
+}
+
+// Reads a symlink in the runfiles tree and resolves it to the equivalent path inside the sandbox,
+// or undefined when the target is not something this devserver syncs into the sandbox.
+async function readSandboxSymlinkTarget(file, src, sandbox) {
+    let linkPath = await fs.promises.readlink(src)
+    const linkAbs = path.resolve(path.dirname(src), linkPath)
+    linkPath = path.relative(src, linkAbs) || '.'
+    return resolveSandboxSymlinkTarget(sandbox, file, linkPath, entryPaths)
+}
+
+// Resolves the target of a symlink to a path inside the sandbox, or returns undefined
+// if the target is not something this devserver syncs into the sandbox. `linkPath` is the symlink
+// target relative to the link itself, as computed by readSandboxSymlinkTarget.
+export function resolveSandboxSymlinkTarget(sandbox, file, linkPath, entries) {
+    const target = path.join(sandbox, file, linkPath)
+    let rel = toPosix(path.relative(sandbox, target))
+    if (!rel || rel === '..' || rel.startsWith('../')) {
+        // Escapes the sandbox root; nothing we can point at.
+        return undefined
+    }
+    // The target is in the sandbox if it, or a directory entry containing it, is synced.
+    while (rel && rel !== '.') {
+        if (entries.has(rel)) {
+            return target
+        }
+        const parent = path.posix.dirname(rel)
+        if (parent === rel) {
+            break
+        }
+        rel = parent
+    }
+    return undefined
+}
+
+// Stats a path following symlinks, or returns null for a broken link so that the caller can
+// recreate it as a symlink rather than failing the sync.
+async function statFollowingLinks(src, file) {
+    try {
+        return await fs.promises.stat(src)
+    } catch (e) {
+        if (JS_BINARY__LOG_DEBUG) {
+            console.error(`Could not follow symlink ${file}: ${e.message}`)
+        }
+        return null
+    }
 }
 
 // Utility function to retry an async operation with backoff
@@ -154,9 +227,15 @@ export function friendlyFileSize(bytes) {
     )
 }
 
-async function syncSymlink(file, src, dst, sandbox, exists) {
+async function syncSymlink(file, src, dst, sandbox, exists, sandboxSrc) {
     let symlinkMeta = ''
-    if (isNodeModulePath(file)) {
+    if (sandboxSrc) {
+        // The target is synced into the sandbox, so point at it rather than at the execroot. This
+        // keeps realpath() of the link inside the sandbox root, which bundlers that enforce a
+        // project-root boundary (e.g. Turbopack) require.
+        src = sandboxSrc
+        symlinkMeta = 'sandbox'
+    } else if (isNodeModulePath(file)) {
         let linkPath = await fs.promises.readlink(src)
         const linkAbs = path.resolve(path.dirname(src), linkPath)
         linkPath = path.relative(src, linkAbs) || '.'
@@ -195,7 +274,7 @@ async function syncSymlink(file, src, dst, sandbox, exists) {
     return 1
 }
 
-async function syncDirectory(file, src, sandbox, writePerm) {
+async function syncDirectory(file, src, sandbox, writePerm, derefDepth = 0) {
     if (JS_BINARY__LOG_DEBUG) {
         console.error(`Syncing directory ${file}...`)
     }
@@ -208,11 +287,19 @@ async function syncDirectory(file, src, sandbox, writePerm) {
                         file + path.sep + entry,
                         undefined,
                         sandbox,
-                        writePerm
+                        writePerm,
+                        derefDepth
                     )
             )
         )
     ).reduce((s, t) => s + t, 0)
+}
+
+// Materializes src at dst using a copy-on-write clone when possible. Node falls back to a regular
+// copy when the filesystem does not support cloning. Unlike a hardlink, both forms create a new
+// inode, so a devserver can chmod or modify the sandbox file without mutating the Bazel output.
+async function materializeFile(src, dst) {
+    await fs.promises.copyFile(src, dst, fs.constants.COPYFILE_FICLONE)
 }
 
 async function syncFile(file, src, dst, exists, lstat, writePerm) {
@@ -231,7 +318,7 @@ async function syncFile(file, src, dst, exists, lstat, writePerm) {
     }
 
     await withRetry(
-        () => fs.promises.copyFile(src, dst),
+        () => materializeFile(src, dst),
         `copyFile from ${src} to ${dst}`
     )
 
@@ -253,8 +340,9 @@ async function syncFile(file, src, dst, exists, lstat, writePerm) {
 // Recursively copies a file, symlink or directory to a destination. If the file has been previously
 // synced it is only re-copied if the file's last modified time has changed since the last time that
 // file was copied. Symlinks are not copied but instead a symlink is created under the destination
-// pointing to the source symlink.
-async function syncRecursive(file, _, sandbox, writePerm) {
+// pointing to the source symlink; the exception is sandbox package store mode, where a node_modules
+// symlink that would point out of the sandbox is dereferenced and its contents materialized.
+async function syncRecursive(file, _, sandbox, writePerm, derefDepth = 0) {
     const src = RUNFILES_ROOT + path.sep + file
     const dst = sandbox + path.sep + file
 
@@ -263,8 +351,48 @@ async function syncRecursive(file, _, sandbox, writePerm) {
             () => fs.promises.lstat(src),
             `lstat for ${src}`
         )
+
+        // Runfiles entries for npm packages are symlinks pointing at the package store in the
+        // execroot. Recreating them as symlinks would put the package contents outside the sandbox
+        // root, so in sandbox package store mode a node_modules symlink whose target is not itself
+        // synced into the sandbox is dereferenced and its contents materialized instead.
+        let sandboxSrc
+        let deref = false
+        let followed = null
+        if (
+            sandboxPackageStore &&
+            lstat.isSymbolicLink() &&
+            isUnderNodeModules(file)
+        ) {
+            sandboxSrc = await readSandboxSymlinkTarget(file, src, sandbox)
+            deref = !sandboxSrc
+            if (deref) {
+                followed = await statFollowingLinks(src, file)
+                // A broken link has nothing to dereference; recreate it as a symlink.
+                deref = !!followed
+            }
+        }
+
+        // A dereferenced directory is re-walked on every sync; the files within it do their own
+        // up-to-date checks. The symlink's own mtime says nothing about its contents.
+        const derefDirectory = deref && followed.isDirectory()
+
+        if (derefDirectory && derefDepth >= MAX_DEREF_DEPTH) {
+            // Symlinked directories that point at each other would otherwise recurse forever.
+            console.error(
+                `Not dereferencing ${file}: more than ${MAX_DEREF_DEPTH} levels of symlinked directories`
+            )
+            const exists = syncedTime.has(file) || fs.existsSync(dst)
+            return syncSymlink(file, src, dst, sandbox, exists)
+        }
+
         const last = syncedTime.get(file)
-        if (!lstat.isDirectory() && last && lstat.mtimeMs == last) {
+        if (
+            !lstat.isDirectory() &&
+            !derefDirectory &&
+            last &&
+            lstat.mtimeMs == last
+        ) {
             // this file is already up-to-date
             if (JS_BINARY__LOG_DEBUG) {
                 console.error(
@@ -275,11 +403,21 @@ async function syncRecursive(file, _, sandbox, writePerm) {
         }
         const exists = syncedTime.has(file) || fs.existsSync(dst)
         syncedTime.set(file, lstat.mtimeMs)
-        if (lstat.isSymbolicLink()) {
-            return syncSymlink(file, src, dst, sandbox, exists)
+        if (derefDirectory) {
+            if (JS_BINARY__LOG_DEBUG) {
+                console.error(`Dereferencing symlinked directory ${file}`)
+            }
+            return syncDirectory(file, src, sandbox, writePerm, derefDepth + 1)
+        } else if (lstat.isSymbolicLink() && !deref) {
+            return syncSymlink(file, src, dst, sandbox, exists, sandboxSrc)
         } else if (lstat.isDirectory()) {
-            return syncDirectory(file, src, sandbox, writePerm)
+            return syncDirectory(file, src, sandbox, writePerm, derefDepth)
         } else {
+            if (sandboxPackageStore && isPackageStorePath(file)) {
+                // Package store files are immutable Bazel outputs, so the mtime check above is
+                // sufficient. Skip hashing them; there can be a very large number of them.
+                return syncFile(file, src, dst, exists, lstat, writePerm)
+            }
             const lastChecksum = syncedChecksum.get(file)
             const checksum = await generateChecksum(src)
             if (lastChecksum && checksum == lastChecksum) {
@@ -369,20 +507,17 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
     const startTime = perf_hooks.performance.now()
 
     // Partition files into node_modules and non-node_modules files
-    const packageStore1pDeps = []
+    const packageStoreDeps = []
     const otherNodeModulesFiles = []
     const otherFiles = []
     for (const fileInfo of files) {
         const file = fileInfo[0]
-        if (isNodeModulePath(file)) {
-            // Node module file
-            if (is1pPackageStoreDep(file)) {
-                // 1p package store dep
-                packageStore1pDeps.push(fileInfo)
-            } else {
-                // Other node_modules file
-                otherNodeModulesFiles.push(fileInfo)
-            }
+        if (isPackageStorePath(file)) {
+            // Package store deps must land before the direct node_modules symlinks that point at
+            // them. The entries list is filtered by the rule according to package_store_mode.
+            packageStoreDeps.push(fileInfo)
+        } else if (isNodeModulePath(file)) {
+            otherNodeModulesFiles.push(fileInfo)
         } else {
             otherFiles.push(fileInfo)
         }
@@ -404,17 +539,17 @@ async function syncFiles(files, sandbox, writePerm, doSync) {
         )
     ).reduce((s, t) => s + t, 0)
 
-    // Sync first-party package store files before other node_modules files since correctly syncing
-    // direct 1p node_modules symlinks depends on checking if the package store synced files exist.
-    if (JS_BINARY__LOG_DEBUG && packageStore1pDeps.length > 0) {
+    // Sync package store files before other node_modules files since correctly syncing direct
+    // node_modules symlinks depends on the package store files they point at being in place.
+    if (JS_BINARY__LOG_DEBUG && packageStoreDeps.length > 0) {
         console.error(
-            `+ Syncing ${packageStore1pDeps.length} first party package store dep(s)`
+            `+ Syncing ${packageStoreDeps.length} package store dep(s)`
         )
     }
 
     totalSynced += (
         await Promise.all(
-            packageStore1pDeps.map(async ([file, isDirectory]) => {
+            packageStoreDeps.map(async ([file, isDirectory]) => {
                 return await doSync(file, isDirectory, sandbox, writePerm)
             })
         )
@@ -455,6 +590,8 @@ async function main(args, sandbox, config) {
     )
 
     const entriesPath = path.join(RUNFILES_ROOT, args[1])
+
+    sandboxPackageStore = config.package_store_mode === 'sandbox'
 
     const cwd = path.join(sandbox, sandboxRelativeChdir(config.chdir))
 
@@ -523,8 +660,13 @@ async function runIBazelProtocol(
     toolArgs,
     env
 ) {
+    const initialFiles = await fs.promises
+        .readFile(entriesPath)
+        .then(JSON.parse)
+    updateEntryPaths(initialFiles)
+
     await syncFiles(
-        await fs.promises.readFile(entriesPath).then(JSON.parse),
+        initialFiles,
         sandbox,
         config.grant_sandbox_write_permissions,
         syncRecursive
@@ -573,6 +715,7 @@ async function runIBazelProtocol(
                     const updatedDataFiles = await fs.promises
                         .readFile(entriesPath)
                         .then(JSON.parse)
+                    updateEntryPaths(updatedDataFiles)
 
                     // Await promises to catch any exceptions, and wait for the
                     // sync to be complete before writing to stdin of the child
@@ -677,6 +820,7 @@ async function runWatchProtocol(
 async function watchProtocolCycle(config, entriesPath, sandbox, cycle) {
     // Re-parse the config file to get the latest list of data files to copy
     const newFiles = await fs.promises.readFile(entriesPath).then(JSON.parse)
+    updateEntryPaths(newFiles)
 
     const oldFiles = config.previous_files || []
     config.previous_files = newFiles
@@ -736,6 +880,24 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
     }
 
     if (srcRunfilesInfo.is_symlink) {
+        // See the equivalent handling in syncRecursive.
+        if (sandboxPackageStore && isUnderNodeModules(file)) {
+            const sandboxSrc = await readSandboxSymlinkTarget(
+                file,
+                src,
+                sandbox
+            )
+            if (!sandboxSrc) {
+                const followed = await statFollowingLinks(src, file)
+                if (followed && followed.isDirectory()) {
+                    return syncDirectory(file, src, sandbox, writePerm, 1)
+                }
+                if (followed) {
+                    return syncFile(file, src, dst, exists, followed, writePerm)
+                }
+            }
+            return syncSymlink(file, src, dst, sandbox, exists, sandboxSrc)
+        }
         return syncSymlink(file, src, dst, sandbox, exists)
     }
 
@@ -756,8 +918,15 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
     onProcessEnd(() => sandbox && removeSandbox(sandbox) && (sandbox = null))
 
     try {
+        // The sandbox lives under the OS temp dir by default. JS_RUN_DEVSERVER_SANDBOX_DIR moves it
+        // elsewhere; placing it on the same filesystem as the execroot may allow package-store
+        // files to use copy-on-write clones rather than full copies.
+        const sandboxParent =
+            process.env.JS_RUN_DEVSERVER_SANDBOX_DIR || os.tmpdir()
+        // Intentionally synchronous; see comment on mkdirpSync
+        mkdirpSync(sandboxParent)
         sandbox = await fs.promises.mkdtemp(
-            path.join(os.tmpdir(), 'js_run_devserver-')
+            path.join(sandboxParent, 'js_run_devserver-')
         )
         const sandboxMain = path.join(sandbox, JS_BINARY__WORKSPACE)
 

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -3,6 +3,14 @@
 load(":js_binary.bzl", "js_binary_lib")
 load(":js_helpers.bzl", _gather_files_from_js_infos = "gather_files_from_js_infos")
 
+_PACKAGE_STORE_MODES = [
+    # node_modules symlinks in the custom sandbox point back at the package store in the execroot.
+    "execroot",
+    # The package store is materialized inside the custom sandbox and node_modules symlinks point
+    # at it, so that realpath() of any node_modules entry stays under the sandbox root.
+    "sandbox",
+]
+
 _attrs = js_binary_lib.attrs | {
     "tool": attr.label(
         executable = True,
@@ -14,6 +22,10 @@ _attrs = js_binary_lib.attrs | {
     "grant_sandbox_write_permissions": attr.bool(),
     "allow_execroot_entry_point_with_no_copy_data_to_bin": attr.bool(),
     "command": attr.string(),
+    "package_store_mode": attr.string(
+        default = "execroot",
+        values = _PACKAGE_STORE_MODES,
+    ),
 }
 
 def _file_to_entry_json(f):
@@ -30,6 +42,11 @@ def _file_to_entry_json(f):
         if len(path_segments) <= package_name_segment or "@0.0.0" not in path_segments[package_name_segment]:
             return None
 
+    return json.encode([f.short_path, 1 if f.is_directory else 0])
+
+def _file_to_entry_json_unfiltered(f):
+    # Used when package_store_mode is "sandbox"; third party package store deps must be synced into
+    # the custom sandbox so that node_modules symlinks can point at them there.
     return json.encode([f.short_path, 1 if f.is_directory else 0])
 
 def _js_run_devserver_impl(ctx):
@@ -61,6 +78,12 @@ def _js_run_devserver_impl(ctx):
 
     default_data_runfiles = [target[DefaultInfo].default_runfiles.files for target in ctx.attr.data]
 
+    # Third party package store deps are only synced into the custom sandbox when the package store
+    # lives there; otherwise the node_modules symlinks resolve them in the execroot.
+    file_to_entry_json = _file_to_entry_json
+    if ctx.attr.package_store_mode == "sandbox":
+        file_to_entry_json = _file_to_entry_json_unfiltered
+
     # Build the list of data files to copy to the custom sandbox using ctx.actions.args()
     entries = ctx.actions.args()
     entries.set_param_file_format("multiline")
@@ -68,7 +91,7 @@ def _js_run_devserver_impl(ctx):
     entries.add_joined(
         depset(transitive = transitive_runfiles + [dep.files for dep in ctx.attr.data] + default_data_runfiles),
         expand_directories = False,
-        map_each = _file_to_entry_json,
+        map_each = file_to_entry_json,
         join_with = ",",
     )
     entries.add("]")
@@ -92,6 +115,8 @@ def _js_run_devserver_impl(ctx):
         config["grant_sandbox_write_permissions"] = "1"
     if launcher.chdir:
         config["chdir"] = launcher.chdir
+    if ctx.attr.package_store_mode != "execroot":
+        config["package_store_mode"] = ctx.attr.package_store_mode
 
     ctx.actions.write(config_file, json.encode(config))
 
@@ -130,6 +155,7 @@ def js_run_devserver(
         grant_sandbox_write_permissions = False,
         use_execroot_entry_point = True,
         allow_execroot_entry_point_with_no_copy_data_to_bin = False,
+        package_store_mode = "execroot",
         **kwargs):
     """Runs a devserver via binary target or command.
 
@@ -204,6 +230,10 @@ def js_run_devserver(
     tree, they are recreated as symlinks in the custom sandbox and do not incur a full copy of the
     underlying npm packages.
 
+    Bundlers that resolve modules through `realpath()` and enforce a project root boundary, such as
+    Next.js with Turbopack, reject that layout since the packages physically live outside the
+    sandbox. See `package_store_mode` for syncing the package store into the sandbox instead.
+
     Supports running with [ibazel](https://github.com/bazelbuild/bazel-watcher).
     Only `data` files that change on incremental builds are synchronized when running with ibazel.
 
@@ -233,6 +263,26 @@ def js_run_devserver(
             circumstances, try to modify files when running.
 
             See https://github.com/aspect-build/rules_js/issues/935 for more context.
+
+        package_store_mode: Where the npm package store that the sandbox `node_modules` symlinks point at lives.
+
+            `"execroot"` (the default) points the symlinks back at the package store in the execroot
+            output tree. Only first-party package store deps are copied into the sandbox; third party
+            packages are resolved through the symlinks without being copied, which keeps the sandbox
+            cheap to populate.
+
+            `"sandbox"` instead materializes the whole package store inside the custom sandbox and
+            points the symlinks there. This is needed by bundlers that resolve modules through
+            `realpath()` and then refuse to compile anything outside the project root — Next.js with
+            Turbopack, for example, fails with "files outside of the project directory will not be
+            compiled" under the default mode, since every third party package physically lives in
+            the execroot.
+
+            Package store files use copy-on-write filesystem clones where possible, with a regular
+            copy fallback. Both strategies keep sandbox writes isolated from Bazel outputs. Set the
+            `JS_RUN_DEVSERVER_SANDBOX_DIR` environment variable to place the sandbox on the same
+            filesystem as the execroot and increase the chance that copy-on-write cloning is
+            available.
 
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.
@@ -279,6 +329,7 @@ def js_run_devserver(
         tool = tool,
         command = command,
         grant_sandbox_write_permissions = grant_sandbox_write_permissions,
+        package_store_mode = package_store_mode,
         use_execroot_entry_point = use_execroot_entry_point,
         allow_execroot_entry_point_with_no_copy_data_to_bin = allow_execroot_entry_point_with_no_copy_data_to_bin,
         **kwargs

--- a/js/private/test/js_run_devserver/BUILD.bazel
+++ b/js/private/test/js_run_devserver/BUILD.bazel
@@ -32,6 +32,67 @@ js_run_devserver_test(
     tool = ":jasmine",
 )
 
+# Checks that with package_store_mode = "sandbox" the package store is materialized in the custom
+# sandbox so that realpath() of every node_modules entry stays under the sandbox root, which
+# bundlers such as Turbopack require.
+js_run_devserver_test(
+    name = "node_modules_in_sandbox_test",
+    args = ["node_modules_in_sandbox.test.mjs"],
+    chdir = "js/private/test/js_run_devserver",
+    data = [
+        "node_modules_in_sandbox.test.mjs",
+        ":node_modules/@types/node",
+        ":node_modules/jasmine",
+    ],
+    package_store_mode = "sandbox",
+    tags = [
+        # devserver is meant to be `bazel run` locally.
+        # See https://github.com/aspect-build/rules_js/pull/1233
+        "no-remote-exec",
+    ],
+    tool = ":jasmine",
+)
+
+# Checks that granting write permissions in the sandbox never mutates the permissions of the
+# original files in the execroot.
+js_run_devserver_test(
+    name = "sandbox_write_permissions_test",
+    args = ["sandbox_write_permissions.test.mjs"],
+    chdir = "js/private/test/js_run_devserver",
+    data = [
+        "sandbox_write_permissions.test.mjs",
+        ":node_modules/@types/node",
+        ":node_modules/jasmine",
+    ],
+    grant_sandbox_write_permissions = True,
+    package_store_mode = "sandbox",
+    tags = [
+        # devserver is meant to be `bazel run` locally.
+        # See https://github.com/aspect-build/rules_js/pull/1233
+        "no-remote-exec",
+    ],
+    tool = ":jasmine",
+)
+
+# A devserver runs as the owner of read-only Bazel outputs and can chmod them before writing. Check
+# that package-store files are independent copies even when write permissions are not pre-granted.
+js_run_devserver_test(
+    name = "sandbox_write_isolation_test",
+    args = ["sandbox_write_isolation.test.mjs"],
+    chdir = "js/private/test/js_run_devserver",
+    data = [
+        "sandbox_write_isolation.test.mjs",
+        ":node_modules/jasmine",
+    ],
+    package_store_mode = "sandbox",
+    tags = [
+        # devserver is meant to be `bazel run` locally.
+        # See https://github.com/aspect-build/rules_js/pull/1233
+        "no-remote-exec",
+    ],
+    tool = ":jasmine",
+)
+
 jasmine_bin.jasmine_binary(
     name = "jasmine",
 )

--- a/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
+++ b/js/private/test/js_run_devserver/js_run_devserver.spec.mjs
@@ -1,6 +1,9 @@
+import * as path from 'node:path'
 import {
     isNodeModulePath,
-    is1pPackageStoreDep,
+    isPackageStorePath,
+    isUnderNodeModules,
+    resolveSandboxSymlinkTarget,
     friendlyFileSize,
     sandboxRelativeChdir,
 } from '../../devserver/js_run_devserver.mjs'
@@ -24,32 +27,141 @@ for (const p of isNodeModulePath_false) {
     }
 }
 
-// is1pPackageStoreDep
-const is1pPackageStoreDep_true = [
-    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/@mycorp/pkg',
+// isPackageStorePath
+const isPackageStorePath_true = [
     'some/path/node_modules/.aspect_rules_js/mycorp-pkg@0.0.0/node_modules/mycorp-pkg',
+    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/@mycorp/pkg',
+    'node_modules/.aspect_rules_js/next@16.2.1/node_modules/next/dist/bin/next',
 ]
-for (const p of is1pPackageStoreDep_true) {
-    if (!is1pPackageStoreDep(p)) {
-        console.error(`ERROR: expected ${p} to be a 1p package store dep`)
+for (const p of isPackageStorePath_true) {
+    if (!isPackageStorePath(p)) {
+        console.error(`ERROR: expected ${p} to be a package store path`)
         process.exit(1)
     }
 }
-const is1pPackageStoreDep_false = [
-    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/mycorp/pkg',
-    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg0.0.0/node_modules/@mycorp/pkg',
-    'some/path/node_modules/.aspect_rules_js/mycorp+pkg@0.0.0/node_modules/@mycorp/pkg',
-    'some/path/node_modules/.aspect_rules_js/mycorp-pkg0.0.0/node_modules/mycorp-pkg',
-    'some/path/node_modules/.aspect_rules_js/@mycorp+pkg@0.0.0/node_modules/acorn',
-    'some/path/node_modules/.aspect_rules_js/mycorp-pkg@0.0.0/node_modules/acorn',
-    'some/path/node_modules/.aspect_rules_js/@babel+runtime@7.21.0/node_modules/@babel/runtime',
-    'some/path/node_modules/.aspect_rules_js/@babel+runtime@7.21.0/node_modules/acorn',
-    'some/path/node_modules/.aspect_rules_js/eval@0.1.6/node_modules/eval',
-    'some/path/node_modules/.aspect_rules_js/eval@0.1.6/node_modules/acorn',
+const isPackageStorePath_false = [
+    'some/path/node_modules/next',
+    'some/path/node_modules/@types/node',
+    'some/path/some-file.js',
 ]
-for (const p of is1pPackageStoreDep_false) {
-    if (is1pPackageStoreDep(p)) {
-        console.error(`ERROR: expected ${p} to not be a 1p package store dep`)
+for (const p of isPackageStorePath_false) {
+    if (isPackageStorePath(p)) {
+        console.error(`ERROR: expected ${p} to not be a package store path`)
+        process.exit(1)
+    }
+}
+
+// isUnderNodeModules
+const isUnderNodeModules_true = [
+    'some/path/node_modules/next',
+    'some/path/node_modules/@types/node',
+    // .bin entries and files within a package's contents are not package directories, but they are
+    // still resolved through node_modules and so must not point outside the sandbox.
+    'some/path/node_modules/.bin/next',
+    'node_modules/.bin/next',
+    'some/path/node_modules/next/dist/bin/next',
+    'node_modules/.aspect_rules_js/next@16.2.1/node_modules/next/package.json',
+]
+for (const p of isUnderNodeModules_true) {
+    if (!isUnderNodeModules(p)) {
+        console.error(`ERROR: expected ${p} to be under node_modules`)
+        process.exit(1)
+    }
+}
+const isUnderNodeModules_false = [
+    'some/path/some-file.js',
+    'src/app/page.tsx',
+    // A directory that merely ends in node_modules is not a node_modules tree.
+    'some/path/not_node_modules',
+    'node_modules',
+]
+for (const p of isUnderNodeModules_false) {
+    if (isUnderNodeModules(p)) {
+        console.error(`ERROR: expected ${p} to not be under node_modules`)
+        process.exit(1)
+    }
+}
+
+// resolveSandboxSymlinkTarget
+const SANDBOX = path.join('/tmp', 'js_run_devserver-abc123', '_main')
+// `linkPath` is relative to the symlink itself, matching what syncSymlink computes.
+const LINK = 'app/node_modules/next'
+const LINK_PATH = path.join(
+    '..',
+    '..',
+    '..',
+    'node_modules',
+    '.aspect_rules_js',
+    'next@16.2.1',
+    'node_modules',
+    'next'
+)
+const STORE_ENTRY =
+    'node_modules/.aspect_rules_js/next@16.2.1/node_modules/next'
+
+// The package store entry is synced, so the link resolves into the sandbox.
+{
+    const actual = resolveSandboxSymlinkTarget(
+        SANDBOX,
+        LINK,
+        LINK_PATH,
+        new Set([STORE_ENTRY])
+    )
+    const expected = path.join(SANDBOX, STORE_ENTRY)
+    if (actual !== expected) {
+        console.error(
+            `ERROR: expected resolveSandboxSymlinkTarget to return '${expected}' but got '${actual}'`
+        )
+        process.exit(1)
+    }
+}
+
+// A file under a synced directory entry also resolves; the directory entry covers it.
+{
+    const deepLinkPath = path.join(LINK_PATH, 'dist', 'bin')
+    const actual = resolveSandboxSymlinkTarget(
+        SANDBOX,
+        LINK,
+        deepLinkPath,
+        new Set([STORE_ENTRY])
+    )
+    const expected = path.join(SANDBOX, STORE_ENTRY, 'dist', 'bin')
+    if (actual !== expected) {
+        console.error(
+            `ERROR: expected resolveSandboxSymlinkTarget to return '${expected}' but got '${actual}'`
+        )
+        process.exit(1)
+    }
+}
+
+// Nothing synced for the target, so there is no in-sandbox path to point at.
+{
+    const actual = resolveSandboxSymlinkTarget(
+        SANDBOX,
+        LINK,
+        LINK_PATH,
+        new Set(['app/index.js'])
+    )
+    if (actual !== undefined) {
+        console.error(
+            `ERROR: expected resolveSandboxSymlinkTarget to return undefined but got '${actual}'`
+        )
+        process.exit(1)
+    }
+}
+
+// A target that escapes the sandbox root is never used.
+{
+    const actual = resolveSandboxSymlinkTarget(
+        SANDBOX,
+        LINK,
+        path.join('..', '..', '..', '..', '..', 'elsewhere'),
+        new Set(['elsewhere'])
+    )
+    if (actual !== undefined) {
+        console.error(
+            `ERROR: expected resolveSandboxSymlinkTarget to return undefined for a target outside the sandbox but got '${actual}'`
+        )
         process.exit(1)
     }
 }

--- a/js/private/test/js_run_devserver/node_modules_in_sandbox.test.mjs
+++ b/js/private/test/js_run_devserver/node_modules_in_sandbox.test.mjs
@@ -1,0 +1,160 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// js_binary patches node's fs module so that resolving a symlink never appears to leave the
+// runfiles/execroot roots. That patch would hide exactly the escape these tests are looking for, so
+// every path resolution here happens in a plain node process without the patches applied — which is
+// also what a non-node bundler such as Turbopack does when it calls realpath(3).
+function unpatchedNode(script, arg) {
+    return execFileSync(process.execPath, ['-e', script, arg], {
+        encoding: 'utf-8',
+    })
+}
+
+function realpath(p) {
+    return unpatchedNode(
+        'process.stdout.write(require("fs").realpathSync(process.argv[1]))',
+        path.resolve(p)
+    )
+}
+
+// Walks the sandbox and returns every symlink whose target resolves outside of it.
+function findEscapingSymlinks(sandboxRoot, startDir) {
+    const script = `
+        const fs = require('fs')
+        const path = require('path')
+        const root = process.argv[1].split(path.delimiter)[0]
+        const start = process.argv[1].split(path.delimiter)[1]
+        const escaping = []
+        const inside = (p) => {
+            const rel = path.relative(root, p)
+            return !!rel && rel !== '..' && !rel.startsWith('..' + path.sep)
+        }
+        const walk = (dir) => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const p = path.join(dir, entry.name)
+                if (entry.isSymbolicLink()) {
+                    let real
+                    try {
+                        real = fs.realpathSync(p)
+                    } catch {
+                        continue // broken link, not an escape
+                    }
+                    if (!inside(real)) {
+                        escaping.push(path.relative(root, p) + ' -> ' + real)
+                    }
+                } else if (entry.isDirectory()) {
+                    walk(p)
+                }
+            }
+        }
+        walk(start)
+        process.stdout.write(JSON.stringify(escaping))
+    `
+    return JSON.parse(
+        unpatchedNode(
+            script,
+            [sandboxRoot, path.resolve(startDir)].join(path.delimiter)
+        )
+    )
+}
+
+// Walks up from the working directory to the sandbox root that js_run_devserver created.
+function findSandboxRoot() {
+    let dir = process.cwd()
+    while (true) {
+        if (path.basename(dir).startsWith('js_run_devserver-')) {
+            return dir
+        }
+        const parent = path.dirname(dir)
+        if (parent === dir) {
+            throw new Error(
+                `Could not find the js_run_devserver sandbox root above ${process.cwd()}`
+            )
+        }
+        dir = parent
+    }
+}
+
+function isInside(root, p) {
+    const rel = path.relative(root, p)
+    return !!rel && rel !== '..' && !rel.startsWith('..' + path.sep)
+}
+
+describe('package_store_mode = "sandbox" >', () => {
+    const sandboxRoot = findSandboxRoot()
+    const workspaceRoot = path.join(
+        sandboxRoot,
+        process.env.JS_BINARY__WORKSPACE
+    )
+    const execRootDir = process.env.JS_BINARY__EXECROOT
+
+    // The packages linked into data; both an unscoped and a scoped one.
+    const packages = ['jasmine', '@types/node']
+
+    beforeAll(() => {
+        if (typeof execRootDir !== 'string' || execRootDir.length === 0) {
+            throw new Error(
+                `process.env.JS_BINARY__EXECROOT is empty - can't run tests which rely on it`
+            )
+        }
+    })
+
+    for (const pkg of packages) {
+        const link = `./node_modules/${pkg}`
+
+        it(`resolves '${pkg}' to a real path inside the sandbox so that bundlers enforcing a project root boundary can compile it`, () => {
+            const real = realpath(link)
+
+            expect(isInside(sandboxRoot, real)).toBe(true)
+            expect(real).not.toContain(execRootDir)
+        })
+
+        it(`materializes the contents of '${pkg}' in the sandbox rather than linking out to the execroot`, () => {
+            // Read through the package store copy, not the link, so that a link pointing at the
+            // execroot cannot satisfy this.
+            const real = realpath(link)
+            const packageJson = JSON.parse(
+                fs.readFileSync(path.join(real, 'package.json'), 'utf-8')
+            )
+
+            expect(packageJson.name).toBe(pkg)
+            expect(fs.lstatSync(real).isDirectory()).toBe(true)
+        })
+    }
+
+    it('materializes the package store as real directories, not as symlinks back to the execroot', () => {
+        const store = path.join(workspaceRoot, 'node_modules/.aspect_rules_js')
+        const packageDirs = fs
+            .readdirSync(store)
+            .map((v) => path.join(store, v, 'node_modules'))
+            .flatMap((nm) =>
+                fs.readdirSync(nm).map((name) => path.join(nm, name))
+            )
+
+        expect(packageDirs.length).toBeGreaterThan(0)
+
+        // Every package store entry either is a real directory holding the package contents, or is
+        // a symlink to another entry within the sandbox (the peer dependency links).
+        const escaping = packageDirs.filter(
+            (p) => !isInside(sandboxRoot, realpath(p))
+        )
+
+        expect(escaping).toEqual([])
+    })
+
+    it('leaves no symlink under any node_modules tree pointing outside the sandbox', () => {
+        // Covers node_modules/.bin entries and symlinks shipped within package contents, neither of
+        // which is a package directory that isNodeModulePath would match.
+        const escaping = [
+            ...findEscapingSymlinks(
+                sandboxRoot,
+                path.join(workspaceRoot, 'node_modules')
+            ),
+            ...findEscapingSymlinks(sandboxRoot, './node_modules'),
+        ]
+
+        expect(escaping).toEqual([])
+    })
+})

--- a/js/private/test/js_run_devserver/sandbox_write_isolation.test.mjs
+++ b/js/private/test/js_run_devserver/sandbox_write_isolation.test.mjs
@@ -1,0 +1,27 @@
+import fs from 'fs'
+import path from 'path'
+
+const USER_WRITE = 0o200
+const PACKAGE_JSON = './node_modules/jasmine/package.json'
+
+describe('package_store_mode = "sandbox" write isolation >', () => {
+    it('keeps content and mode changes isolated from the execroot', () => {
+        const runfilesLink = path.join(
+            process.env.JS_BINARY__RUNFILES,
+            process.env.JS_BINARY__WORKSPACE,
+            'js/private/test/js_run_devserver/node_modules/jasmine/package.json'
+        )
+        const execrootFile = fs.realpathSync(runfilesLink)
+        const originalContent = fs.readFileSync(execrootFile, 'utf-8')
+        const originalMode = fs.statSync(execrootFile).mode
+
+        // Read-only mode is not a write-isolation boundary: the devserver owns the file and can
+        // chmod it before writing. This sequence would mutate the execroot through a hardlink.
+        fs.chmodSync(PACKAGE_JSON, fs.statSync(PACKAGE_JSON).mode | USER_WRITE)
+        fs.appendFileSync(PACKAGE_JSON, '\n')
+
+        expect(fs.readFileSync(PACKAGE_JSON, 'utf-8')).not.toBe(originalContent)
+        expect(fs.readFileSync(execrootFile, 'utf-8')).toBe(originalContent)
+        expect(fs.statSync(execrootFile).mode).toBe(originalMode)
+    })
+})

--- a/js/private/test/js_run_devserver/sandbox_write_permissions.test.mjs
+++ b/js/private/test/js_run_devserver/sandbox_write_permissions.test.mjs
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+
+const USER_WRITE = 0o200
+
+// The package store file that both the sandbox and the execroot hold a copy of.
+const PACKAGE_JSON = './node_modules/jasmine/package.json'
+
+describe('package_store_mode = "sandbox" with grant_sandbox_write_permissions >', () => {
+    it('grants write permissions on the sandbox copy', () => {
+        const mode = fs.statSync(PACKAGE_JSON).mode
+
+        expect(mode & USER_WRITE).toBe(USER_WRITE)
+    })
+
+    it('does not mutate the permissions of the file in the execroot', () => {
+        // The runfiles tree still points at the read-only Bazel outputs; sandbox chmod must not
+        // affect them.
+        const runfilesLink = path.join(
+            process.env.JS_BINARY__RUNFILES,
+            process.env.JS_BINARY__WORKSPACE,
+            'js/private/test/js_run_devserver/node_modules/jasmine/package.json'
+        )
+        const execrootFile = fs.realpathSync(runfilesLink)
+
+        expect(execrootFile).toContain(process.env.JS_BINARY__EXECROOT)
+        expect(fs.statSync(execrootFile).mode & USER_WRITE).toBe(0)
+    })
+})


### PR DESCRIPTION
Add an opt-in `package_store_mode = "sandbox"` mode to `js_run_devserver`.

By default, npm package symlinks in the custom devserver sandbox point back to the Bazel execroot. Bundlers that canonicalize paths using native `realpath()` and enforce a project-root boundary, such as Next.js with Turbopack, reject packages resolved outside the sandbox.

The new mode materializes the npm package store inside the sandbox and rewrites or dereferences `node_modules` symlinks so their real paths remain within the sandbox root.

Files are copied with `COPYFILE_FICLONE`, which uses a copy-on-write filesystem clone when supported and falls back to a regular copy. Both strategies keep devserver writes isolated from Bazel outputs. The sandbox parent directory can be configured with `JS_RUN_DEVSERVER_SANDBOX_DIR`; placing it on the same filesystem as the execroot increases the chance that copy-on-write cloning is available.

The existing behavior remains the default, so current users are unaffected unless they opt in.

Related: #2888

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

`js_run_devserver` now supports `package_store_mode = "sandbox"` for bundlers such as Turbopack that require resolved npm package paths to remain within the project root.

### Test plan

- Added unit coverage for package-store path and sandbox symlink resolution.
- Added integration tests verifying that:
  - scoped and unscoped npm packages resolve inside the sandbox;
  - package-store directories are materialized rather than linked to the execroot;
  - no `node_modules` symlink, including `.bin` and package-internal links, escapes the sandbox;
  - granting sandbox write permissions does not modify execroot files;
  - a devserver that chmods and writes a package file without pre-granted write permissions cannot mutate the execroot file.
- Extended the `js_run_devserver` end-to-end test to exercise incremental syncing with `package_store_mode = "sandbox"`.
- Verified JavaScript syntax, focused unit tests, and diff checks locally.