### PR TITLE
refactor: move node compile cache logic into bootstrap.cjs

### DIFF
--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -402,9 +402,8 @@ if [ "${COVERAGE_DIR:-}" ]; then
 fi
 
 # Disable Node's module compile cache by default (aspect-build/rules_js#2937).
-if [ -z "${NODE_COMPILE_CACHE:-}" ] && [ -z "${NODE_DISABLE_COMPILE_CACHE:-}" ]; then
-    export NODE_DISABLE_COMPILE_CACHE=1
-fi
+# We will re-enable it at runtime if NODE_COMPILE_CACHE is set.
+export NODE_DISABLE_COMPILE_CACHE=1
 
 # Put the node wrapper directory and optionally the npm wrapper directory on the path so that
 # child processes can find them.

--- a/js/private/node-bootstrap/bootstrap.cjs
+++ b/js/private/node-bootstrap/bootstrap.cjs
@@ -1,3 +1,10 @@
+// The launcher exports NODE_DISABLE_COMPILE_CACHE unconditionally, and then we re-enable
+// the cache here if necessary.
+if (process.env.NODE_COMPILE_CACHE) {
+    delete process.env.NODE_DISABLE_COMPILE_CACHE
+    require('node:module').enableCompileCache?.(process.env.NODE_COMPILE_CACHE)
+}
+
 const patchfs = require('./fs.cjs').patcher
 const {
     JS_BINARY__FS_PATCH_ROOTS,

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-20b7bfd6f5bfb5f519783d90fe689528fbf38ee4c98286bd43ffc52189702bac  js/private/test/image/cksum_node.tar
+c9b05fddea6816e517b5d166300f5350975d43a2ede54b30ca25db59b7ad3dde  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 2cb6f678d6eb0b2e9d5e2637f41ae3f192233752f1ea2a55cede2531deec2a64  js/private/test/image/cksum_package_store_1p.tar
 79afa99006aff19460354e72cf2634db693670d09ccc7531fbf27f1f20fe0a5f  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1539 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 100    0        1539 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 100    0        1832 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 100    0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1539 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1539 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/nodejs/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1539 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1539 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/js_binary_sh/BUILD.bazel
+++ b/js/private/test/js_binary_sh/BUILD.bazel
@@ -239,15 +239,15 @@ assert_contains(
 )
 
 ####################################################################################################
-# Node module compile cache: disabled under ephemeral sandbox paths, left enabled otherwise.
+# Node module compile cache: off by default, re-enabled by node-bootstrap/bootstrap.cjs when
+# NODE_COMPILE_CACHE is set.
 # https://github.com/aspect-build/rules_js/issues/2937
 
 write_file(
     name = "write_compile_cache",
     out = "compile_cache.js",
-    # Ask Node to enable the cache (into a sandbox-relative dir so nothing leaks out)
-    # and report the resulting status. It comes back DISABLED only when the launcher
-    # exported NODE_DISABLE_COMPILE_CACHE.
+    # Ask Node to enable the cache (into a sandbox-relative dir so nothing leaks out) and
+    # report the resulting status. It comes back DISABLED unless NODE_COMPILE_CACHE was set.
     content = ["""
         const { enableCompileCache, constants } = require("node:module");
         const { status } = enableCompileCache("node-compile-cache");
@@ -318,10 +318,10 @@ assert_contains(
     expected = "COMPILE_CACHE_DISABLED=yes",
 )
 
-# An explicit NODE_DISABLE_COMPILE_CACHE is respected even when a cache dir is
-# also set, matching Node's own precedence (disable wins).
+# Node gives NODE_DISABLE_COMPILE_CACHE precedence over NODE_COMPILE_CACHE, but we do the
+# opposite.
 js_binary(
-    name = "compile_cache_explicit_disable",
+    name = "compile_cache_dir_wins_over_disable",
     entry_point = "compile_cache.js",
     env = {
         "NODE_COMPILE_CACHE": "node-compile-cache",
@@ -330,14 +330,14 @@ js_binary(
 )
 
 js_run_binary(
-    name = "_compile_cache_explicit_disable",
+    name = "_compile_cache_dir_wins_over_disable",
     silent_on_success = False,
-    stdout = "compile-cache-explicit-disable-stdout",
-    tool = ":compile_cache_explicit_disable",
+    stdout = "compile-cache-dir-wins-over-disable-stdout",
+    tool = ":compile_cache_dir_wins_over_disable",
 )
 
 assert_contains(
-    name = "compile_cache_explicit_disable_test",
-    actual = ":compile-cache-explicit-disable-stdout",
-    expected = "COMPILE_CACHE_DISABLED=yes",
+    name = "compile_cache_dir_wins_over_disable_test",
+    actual = ":compile-cache-dir-wins-over-disable-stdout",
+    expected = "COMPILE_CACHE_DISABLED=no",
 )

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -522,9 +522,8 @@ if [ "${COVERAGE_DIR:-}" ]; then
 fi
 
 # Disable Node's module compile cache by default (aspect-build/rules_js#2937).
-if [ -z "${NODE_COMPILE_CACHE:-}" ] && [ -z "${NODE_DISABLE_COMPILE_CACHE:-}" ]; then
-    export NODE_DISABLE_COMPILE_CACHE=1
-fi
+# We will re-enable it at runtime if NODE_COMPILE_CACHE is set.
+export NODE_DISABLE_COMPILE_CACHE=1
 
 # Put the node wrapper directory and optionally the npm wrapper directory on the path so that
 # child processes can find them.


### PR DESCRIPTION
The bash launcher currently disables node's compile cache only when `NODE_COMPILE_CACHE` is unset (see #2937). When we replace the bash launcher with hermetic_launcher, we are no longer going to have a place to put this logic so that it executes before the Node process starts. This change therefore disables the cache unconditionally with an environment variable but re-enables it at runtime if `NODE_COMPILE_CACHE` is set. This is compatible with hermetic_launcher because we can embed a command line of something like `env NODE_DISABLE_COMPILE_CACHE=1 node ...`

One drawback of this approach is that it inverts the priority of the `NODE_COMPILE_CACHE` and `NODE_DISABLE_COMPILE_CACHE` variables. Node treats the latter as overriding the former, but this change reverses that. I think this is acceptable because it will not be an issue unless the user sets both variables. We cannot easily detect this situation because we do not have a good way to tell whether `NODE_DISABLE_COMPILE_CACHE` was set by the user or just set by us.

---

### Changes are visible to end-users: no (unless they're setting both of these variables but hopefully no one's doing that)

### Test plan

- Covered by existing test cases
- New test cases added
