### PR TITLE
feat(js_run_binary): add flag controlling default of silent_on_success

### DIFF
--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -37,6 +37,23 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# This flag controls the default behavior of the silent_on_success flag
+# on js_run_binary.
+bool_flag(
+    name = "silent_on_success",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_silent_on_success_true",
+    flag_values = {"silent_on_success": "True"},
+    # Must be public: this is referenced by select() expressions that the js_run_binary
+    # macro expands into user packages, where visibility is checked from the use site.
+    # Without this, builds fail under --incompatible_config_setting_private_default_visibility.
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -48,9 +48,6 @@ bool_flag(
 config_setting(
     name = "_silent_on_success_true",
     flag_values = {"silent_on_success": "True"},
-    # Must be public: this is referenced by select() expressions that the js_run_binary
-    # macro expands into user packages, where visibility is checked from the use site.
-    # Without this, builds fail under --incompatible_config_setting_private_default_visibility.
     visibility = ["//visibility:public"],
 )
 

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -154,10 +154,6 @@ def js_run_binary(
             If `None` (the default), the behavior is controlled by the `//js:silent_on_success`
             build flag, which defaults to `True`.
 
-            Enabling this has a cost: the action must run the program under a wrapper process that
-            buffers both streams so they can be replayed if the program fails, rather than simply
-            `exec`ing Node.
-
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.
 

--- a/js/private/js_run_binary.bzl
+++ b/js/private/js_run_binary.bzl
@@ -28,7 +28,7 @@ def js_run_binary(
         stdout = None,
         stderr = None,
         exit_code_out = None,
-        silent_on_success = True,
+        silent_on_success = None,
         use_execroot_entry_point = None,
         copy_srcs_to_bin = True,
         include_sources = True,
@@ -150,6 +150,13 @@ def js_run_binary(
 
             This only applies to streams that are not captured to an output file by `stdout` or
             `stderr`; a captured stream never reaches the terminal to begin with.
+
+            If `None` (the default), the behavior is controlled by the `//js:silent_on_success`
+            build flag, which defaults to `True`.
+
+            Enabling this has a cost: the action must run the program under a wrapper process that
+            buffers both streams so they can be replayed if the program fails, rather than simply
+            `exec`ing Node.
 
         use_execroot_entry_point: Use the `entry_point` script of the `js_binary` `tool` that is in the execroot output tree
             instead of the copy that is in runfiles.
@@ -413,6 +420,13 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
         Label("//js:_use_execroot_entry_point_true"): {"JS_BINARY__USE_EXECROOT_ENTRY_POINT": "1"},
         "//conditions:default": {},
     }) if use_execroot_entry_point == None else {}
+
+    # When silent_on_success is None, behavior is controlled by the //js:silent_on_success flag.
+    if silent_on_success == None:
+        silent_on_success = select({
+            Label("//js:_silent_on_success_true"): True,
+            "//conditions:default": False,
+        })
 
     _run_binary(
         name = name,

--- a/js/private/test/js_run_binary/BUILD.bazel
+++ b/js/private/test/js_run_binary/BUILD.bazel
@@ -4,6 +4,7 @@ load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//js:defs.bzl", "js_binary", "js_run_binary")
 load(":label_capture.bzl", "label_capture")
+load(":silent_on_success_test.bzl", "silent_on_success_test_suite")
 
 package(default_testonly = True)
 
@@ -157,4 +158,9 @@ assert_contains(
     name = "windows_target_platform_test",
     actual = ":target_os_windows",
     expected = "windows",
+)
+
+silent_on_success_test_suite(
+    name = "silent_on_success_tests",
+    tool = ":find_cfg_probe",
 )

--- a/js/private/test/js_run_binary/silent_on_success_test.bzl
+++ b/js/private/test/js_run_binary/silent_on_success_test.bzl
@@ -1,0 +1,117 @@
+"""Tests that the //js:silent_on_success build flag controls the js_run_binary default.
+
+bazel-lib's `run_binary` passes `--silent-on-success` to the wrapper it spawns only when its
+`silent_on_success` attribute is true, so the presence of that argument in the action's command
+line tells us which value the attribute resolved to.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//js:defs.bzl", "js_run_binary")
+
+_SILENT_ON_SUCCESS_FLAG = str(Label("//js:silent_on_success"))
+
+def _silent_on_success_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    actions = [
+        a
+        for a in analysistest.target_actions(env)
+        if a.mnemonic == "JsRunBinary"
+    ]
+    asserts.equals(env, 1, len(actions), "expected exactly one JsRunBinary action")
+
+    if len(actions) == 1:
+        asserts.equals(
+            env,
+            ctx.attr.expect_silent,
+            "--silent-on-success" in actions[0].argv,
+            "--silent-on-success should{} be passed to the action".format(
+                "" if ctx.attr.expect_silent else " not",
+            ),
+        )
+
+    return analysistest.end(env)
+
+_silent_on_success_test = analysistest.make(
+    _silent_on_success_test_impl,
+    attrs = {
+        "expect_silent": attr.bool(
+            mandatory = True,
+            doc = "Whether the action is expected to be run with --silent-on-success",
+        ),
+    },
+)
+
+_silent_on_success_flag_off_test = analysistest.make(
+    _silent_on_success_test_impl,
+    attrs = {
+        "expect_silent": attr.bool(
+            mandatory = True,
+            doc = "Whether the action is expected to be run with --silent-on-success",
+        ),
+    },
+    config_settings = {
+        _SILENT_ON_SUCCESS_FLAG: False,
+    },
+)
+
+def silent_on_success_test_suite(name, tool):
+    """Test suite for the //js:silent_on_success build flag.
+
+    Args:
+        name: Name of the test suite
+        tool: js_binary label to use as the js_run_binary tool
+    """
+
+    # Each subject leaves stdout/stderr/exit_code_out/chdir unset, since any of those would make
+    # run_binary use its wrapper regardless of silent_on_success. The actions are never executed:
+    # the tests only need the target analyzed.
+    for suffix, silent_on_success in [
+        ("flag", None),
+        ("true", True),
+        ("false", False),
+    ]:
+        js_run_binary(
+            name = "{}_{}_subject".format(name, suffix),
+            outs = ["{}_{}_subject.out".format(name, suffix)],
+            silent_on_success = silent_on_success,
+            tags = ["manual"],
+            tool = tool,
+        )
+
+    # With the flag at its default of True, a target that does not set the attribute is silent.
+    _silent_on_success_test(
+        name = name + "_flag_default_test",
+        expect_silent = True,
+        target_under_test = ":{}_flag_subject".format(name),
+    )
+
+    # With the flag turned off, the same target is not silent.
+    _silent_on_success_flag_off_test(
+        name = name + "_flag_off_test",
+        expect_silent = False,
+        target_under_test = ":{}_flag_subject".format(name),
+    )
+
+    # An explicit attribute wins over the flag in both directions.
+    _silent_on_success_flag_off_test(
+        name = name + "_attr_true_beats_flag_test",
+        expect_silent = True,
+        target_under_test = ":{}_true_subject".format(name),
+    )
+
+    _silent_on_success_test(
+        name = name + "_attr_false_beats_flag_test",
+        expect_silent = False,
+        target_under_test = ":{}_false_subject".format(name),
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":" + name + "_flag_default_test",
+            ":" + name + "_flag_off_test",
+            ":" + name + "_attr_true_beats_flag_test",
+            ":" + name + "_attr_false_beats_flag_test",
+        ],
+    )


### PR DESCRIPTION
`silent_on_success = True` has a cost: the action must run the program under the `spawn_binary` wrapper so that stdout and stderr can be buffered and replayed on failure.

This change adds the `//js:silent_on_success` build flag, which sets the default behavior for `silent_on_success`. Individual targets can still override it by setting the attribute explicitly.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

The flag `--@aspect_rules_js//js:silent_on_success` now controls the default behavior of `silent_on_success` for `js_run_binary`.

### Test plan

- Covered by existing test cases
- New test cases added
