### PR TITLE
refactor: collect v8 coverage from node, not the launcher

### DIFF
--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -277,7 +277,7 @@ _ATTRS = {
         allow_single_file = True,
         default = Label("@aspect_rules_js//js/private/node-bootstrap:bootstrap.cjs"),
     ),
-    # Required by bootstrap.cjs only when generating a coverage report
+    # Required by bootstrap.cjs only under `bazel coverage`
     "_coverage_bootstrap": attr.label(
         allow_single_file = True,
         default = Label("@aspect_rules_js//js/private/node-bootstrap:coverage.cjs"),
@@ -525,6 +525,13 @@ def _js_binary_impl(ctx):
     if run_env_info_kwargs:
         providers.append(RunEnvironmentInfo(**run_env_info_kwargs))
 
+    # bootstrap.cjs requires coverage.cjs when it finds COVERAGE_DIR or
+    # JS_BINARY__COVERAGE_REPORT in the environment, so the module has to be in the runfiles
+    # of every js_binary whose configuration collects coverage -- not only the tests that
+    # report it, since a test's coverage-enabled child needs it too. See #2901.
+    if ctx.configuration.coverage_enabled:
+        runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file._coverage_bootstrap]))
+
     if ctx.attr.testonly and ctx.configuration.coverage_enabled:
         # We have to propagate _lcov_merger runfiles since bazel does not treat _lcov_merger as a proper tool.
         # See: https://github.com/bazelbuild/bazel/issues/4033
@@ -538,12 +545,9 @@ def _js_binary_impl(ctx):
             runfiles = runfiles.merge(ctx.attr._lcov_merger[DefaultInfo].default_runfiles)
 
         # coverage.cjs runs coverage.js when the test program exits to generate the
-        # report, so both must be in the test's runfiles. See #2901.
+        # report, so the generator has to be in the test's runfiles as well. See #2901.
         if _generates_coverage_report(ctx):
-            runfiles = runfiles.merge(ctx.runfiles(files = [
-                ctx.file._coverage_bootstrap,
-                ctx.file._coverage_report,
-            ]))
+            runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file._coverage_report]))
 
         providers.append(
             coverage_common.instrumented_files_info(

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -525,10 +525,8 @@ def _js_binary_impl(ctx):
     if run_env_info_kwargs:
         providers.append(RunEnvironmentInfo(**run_env_info_kwargs))
 
-    # bootstrap.cjs requires coverage.cjs when it finds COVERAGE_DIR or
-    # JS_BINARY__COVERAGE_REPORT in the environment, so the module has to be in the runfiles
-    # of every js_binary whose configuration collects coverage -- not only the tests that
-    # report it, since a test's coverage-enabled child needs it too. See #2901.
+    # If coverage is enabled, we need to include the coverage bootstrap code. Even if this target is
+    # not a test, it could get invoked as a child process.
     if ctx.configuration.coverage_enabled:
         runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file._coverage_bootstrap]))
 
@@ -545,7 +543,7 @@ def _js_binary_impl(ctx):
             runfiles = runfiles.merge(ctx.attr._lcov_merger[DefaultInfo].default_runfiles)
 
         # coverage.cjs runs coverage.js when the test program exits to generate the
-        # report, so the generator has to be in the test's runfiles as well. See #2901.
+        # report, so the generator must be included in the test's runfiles. See #2901.
         if _generates_coverage_report(ctx):
             runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file._coverage_report]))
 

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -468,7 +468,7 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
     # principle be the root node process (for example if it is invoked by an sh_test), so we
     # need to include the coverage bootstrap for every js_binary target. It ships with the
     # launcher so that rules such as js_run_devserver get it as well.
-    if ctx.configuration.coverage_enabled and hasattr(ctx.file, "_coverage_bootstrap"):
+    if ctx.configuration.coverage_enabled:
         launcher_files.append(ctx.file._coverage_bootstrap)
 
     transitive_launcher_files = None

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -462,6 +462,16 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
         launcher_files.append(nodeinfo.node)
 
     launcher_files.extend(ctx.files._node_patches_files + [ctx.file._node_patches])
+
+    # The coverage bootstrap code is required in the root node process, which will enable
+    # coverage for child processes by setting NODE_V8_COVERAGE. Any js_binary could in
+    # principle be the root node process (for example if it is invoked by an sh_test), so we
+    # need to include the coverage bootstrap for every js_binary target. It ships with the
+    # launcher rather than from _js_binary_impl so that rules assembling their own runfiles
+    # around create_launcher, such as js_run_devserver, get it as well.
+    if ctx.configuration.coverage_enabled and hasattr(ctx.file, "_coverage_bootstrap"):
+        launcher_files.append(ctx.file._coverage_bootstrap)
+
     transitive_launcher_files = None
     if ctx.attr.include_npm:
         transitive_launcher_files = nodeinfo.npm_sources
@@ -524,13 +534,6 @@ def _js_binary_impl(ctx):
     # Only create provider if we have something to provide
     if run_env_info_kwargs:
         providers.append(RunEnvironmentInfo(**run_env_info_kwargs))
-
-    # The coverage bootstrap code is required in the root node process, which will enable
-    # coverage for child processes by setting NODE_V8_COVERAGE. Any js_binary could in
-    # principle be the root node process (for example if it is invoked by an sh_test), so we
-    # need to include the coverage bootstrap for every js_binary target.
-    if ctx.configuration.coverage_enabled:
-        runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file._coverage_bootstrap]))
 
     if ctx.attr.testonly and ctx.configuration.coverage_enabled:
         # We have to propagate _lcov_merger runfiles since bazel does not treat _lcov_merger as a proper tool.

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -467,8 +467,7 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
     # coverage for child processes by setting NODE_V8_COVERAGE. Any js_binary could in
     # principle be the root node process (for example if it is invoked by an sh_test), so we
     # need to include the coverage bootstrap for every js_binary target. It ships with the
-    # launcher rather than from _js_binary_impl so that rules assembling their own runfiles
-    # around create_launcher, such as js_run_devserver, get it as well.
+    # launcher so that rules such as js_run_devserver get it as well.
     if ctx.configuration.coverage_enabled and hasattr(ctx.file, "_coverage_bootstrap"):
         launcher_files.append(ctx.file._coverage_bootstrap)
 

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -525,8 +525,10 @@ def _js_binary_impl(ctx):
     if run_env_info_kwargs:
         providers.append(RunEnvironmentInfo(**run_env_info_kwargs))
 
-    # If coverage is enabled, we need to include the coverage bootstrap code. Even if this target is
-    # not a test, it could get invoked as a child process.
+    # The coverage bootstrap code is required in the root node process, which will enable
+    # coverage for child processes by setting NODE_V8_COVERAGE. Any js_binary could in
+    # principle be the root node process (for example if it is invoked by an sh_test), so we
+    # need to include the coverage bootstrap for every js_binary target.
     if ctx.configuration.coverage_enabled:
         runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file._coverage_bootstrap]))
 

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -386,12 +386,6 @@ if [ -z "${JS_BINARY__FS_PATCH_ROOTS:-}" ]; then
 fi
 export JS_BINARY__FS_PATCH_ROOTS
 
-# Enable coverage if requested
-if [ "${COVERAGE_DIR:-}" ]; then
-    logf_debug "enabling v8 coverage support ${COVERAGE_DIR}"
-    export NODE_V8_COVERAGE=${COVERAGE_DIR}
-fi
-
 # Disable Node's module compile cache by default (aspect-build/rules_js#2937).
 # We will re-enable it at runtime if NODE_COMPILE_CACHE is set.
 export NODE_DISABLE_COMPILE_CACHE=1

--- a/js/private/node-bootstrap/bootstrap.cjs
+++ b/js/private/node-bootstrap/bootstrap.cjs
@@ -1,10 +1,8 @@
 // Code coverage. We load this before anything else here, so that the coverage session
-// sees as much of this process compiled under it as possible. We require coverage.cjs
-// conditionally to cut down on code size for non-test targets.
-if (
-    process.env.JS_BINARY__COVERAGE_REPORT ||
-    (process.env.COVERAGE_DIR && !process.env.NODE_V8_COVERAGE)
-) {
+// sees as much of this process compiled under it as possible, and only when there is
+// something to collect or report, to keep the module out of every other process.
+// coverage.cjs decides which of the two applies.
+if (process.env.JS_BINARY__COVERAGE_REPORT || process.env.COVERAGE_DIR) {
     require('./coverage.cjs')
 }
 

--- a/js/private/node-bootstrap/bootstrap.cjs
+++ b/js/private/node-bootstrap/bootstrap.cjs
@@ -1,7 +1,6 @@
 // Code coverage. We load this before anything else here, so that the coverage session
-// sees as much of this process compiled under it as possible, and only when there is
-// something to collect or report, to keep the module out of every other process.
-// coverage.cjs decides which of the two applies.
+// sees as much of this process compiled under it as possible. We require coverage.cjs
+// conditionally to cut down on code size for non-test targets.
 if (process.env.JS_BINARY__COVERAGE_REPORT || process.env.COVERAGE_DIR) {
     require('./coverage.cjs')
 }

--- a/js/private/node-bootstrap/bootstrap.cjs
+++ b/js/private/node-bootstrap/bootstrap.cjs
@@ -1,3 +1,13 @@
+// Code coverage. We load this before anything else here, so that the coverage session
+// sees as much of this process compiled under it as possible. We require coverage.cjs
+// conditionally to cut down on code size for non-test targets.
+if (
+    process.env.JS_BINARY__COVERAGE_REPORT ||
+    (process.env.COVERAGE_DIR && !process.env.NODE_V8_COVERAGE)
+) {
+    require('./coverage.cjs')
+}
+
 // The launcher exports NODE_DISABLE_COMPILE_CACHE unconditionally, and then we re-enable
 // the cache here if necessary.
 if (process.env.NODE_COMPILE_CACHE) {
@@ -77,8 +87,4 @@ if (
         )
     }
     patchfs(roots)
-}
-
-if (process.env.JS_BINARY__COVERAGE_REPORT) {
-    require('./coverage.cjs')
 }

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -106,13 +106,23 @@ function startCollection() {
     const path = require('node:path')
     const { mkdirSync, writeFileSync } = require('node:fs')
 
-    const session = new (require('node:inspector').Session)()
-    session.connect()
-    session.post('Profiler.enable')
-    session.post('Profiler.startPreciseCoverage', {
-        callCount: true,
-        detailed: true,
-    })
+    // A node without inspector support, or a program that already holds the session,
+    // makes this throw. Report empty coverage rather than take down a program that would
+    // otherwise have run: this preload is in every js_binary under `bazel coverage`, so a
+    // throw here fails the target before its own code starts.
+    let session
+    try {
+        session = new (require('node:inspector').Session)()
+        session.connect()
+        session.post('Profiler.enable')
+        session.post('Profiler.startPreciseCoverage', {
+            callCount: true,
+            detailed: true,
+        })
+    } catch (e) {
+        logError(`v8 coverage collection unavailable: ${e.message}`)
+        return false
+    }
 
     // Resolve now: bootstrap.cjs may chdir this process later, and node itself resolves
     // NODE_V8_COVERAGE against the directory it started in.

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -116,8 +116,12 @@ function startCollection() {
         detailed: true,
     })
 
+    // Resolve now: bootstrap.cjs may chdir this process later, and node itself resolves
+    // NODE_V8_COVERAGE against the directory it started in.
+    const dir = path.resolve(process.env.COVERAGE_DIR)
+
     // Enable coverage for all child processes.
-    process.env.NODE_V8_COVERAGE = path.resolve(process.env.COVERAGE_DIR)
+    process.env.NODE_V8_COVERAGE = dir
 
     let written = false
     function flush() {

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -11,7 +11,7 @@
 // coverage.js's runfiles-relative path.
 const { JS_BINARY__LOG_ERROR, JS_BINARY__LOG_PREFIX } = process.env
 
-const flushCoverage = startCollection()
+const collecting = startCollection()
 
 // Child node processes re-enter bootstrap.cjs with an inherited environment. Only the root
 // process reports, once every child has exited and written its profile.
@@ -72,14 +72,12 @@ function reportOnExit(reportPath) {
                 )
                 return
             }
-            // This process's own profile is not on disk yet: whoever is collecting writes it
-            // during teardown, which happens after this handler runs. Flush it here so that
-            // the report includes it.
-            if (flushCoverage) {
-                flushCoverage()
-            } else {
-                // node is collecting. Deliberately no v8.stopCoverage(): node's teardown
-                // asks V8 for coverage regardless, and errors out once it has stopped.
+            // When we collect, our own profile is already on disk: startCollection
+            // registered its exit listener before this one. node instead writes it during
+            // teardown, after this handler, so ask for it here. Deliberately no
+            // v8.stopCoverage(): node's teardown asks V8 for coverage regardless, and
+            // errors out once it has stopped.
+            if (!collecting) {
                 require('node:v8').takeCoverage()
             }
             const { status, error } = spawnSync(nodeBinary, [report], {
@@ -99,10 +97,10 @@ function reportOnExit(reportPath) {
 }
 
 // Starts a V8 precise coverage session for this process, unless node is already collecting.
-// Returns a function that writes the profile early, or undefined when node is collecting.
+// Returns whether we are the collector.
 function startCollection() {
     if (!process.env.COVERAGE_DIR || process.env.NODE_V8_COVERAGE) {
-        return undefined
+        return false
     }
 
     const path = require('node:path')
@@ -160,7 +158,7 @@ function startCollection() {
     globalThis[Symbol.for('aspect_rules_js.v8_coverage')] = flush
 
     process.on('exit', flush)
-    return flush
+    return true
 }
 
 function logError(message) {

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -1,14 +1,18 @@
 // Code coverage
 //
-// Generate the lcov report when this process exits. The test action is the only place the
-// V8 coverage data and the instrumented sources are both present, and this hook is the
-// only thing that runs there once the launcher script `exec`s node. coverage.js is run in
-// its own process: it is async, it chdir()s, and running it here would land its own
-// execution in this process's V8 profile. See #2901.
+// Collects this process's V8 coverage, and, for a test that reports, runs coverage.js on
+// exit to turn the collected profiles into an lcov report. bootstrap.cjs requires this
+// module when JS_BINARY__COVERAGE_REPORT is set, or when COVERAGE_DIR is set and node is
+// not already collecting. js_binary.bzl sets the former for a reporting test under
+// `bazel coverage` only; it holds coverage.js's runfiles-relative path.
 //
-// bootstrap.cjs requires this module only when JS_BINARY__COVERAGE_REPORT is set, which
-// js_binary.bzl does for a test target under `bazel coverage` only; the variable holds
-// coverage.js's runfiles-relative path.
+// Collection drives the inspector rather than setting NODE_V8_COVERAGE, which node reads
+// as it starts up: only a process running before node could set it, and the launcher must
+// not have to be one.
+//
+// The report is generated here because the test action is the only place the profiles and
+// the instrumented sources are both present, and in its own process because coverage.js is
+// async, chdir()s, and would otherwise land in this process's own profile. See #2901.
 const { JS_BINARY__LOG_ERROR, JS_BINARY__LOG_PREFIX } = process.env
 
 const collecting = startCollection()

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -117,8 +117,19 @@ function startCollection() {
     try {
         session = new (require('node:inspector').Session)()
         session.connect()
-        session.post('Profiler.enable')
-        session.post('Profiler.startPreciseCoverage', {
+        // post() reports a command failure through its callback and drops it entirely
+        // without one. The callback is synchronous, so this rethrows into the catch below.
+        const post = (method, params) => {
+            let failure
+            session.post(method, params, (err) => {
+                failure = err
+            })
+            if (failure) {
+                throw failure
+            }
+        }
+        post('Profiler.enable')
+        post('Profiler.startPreciseCoverage', {
             callCount: true,
             detailed: true,
         })

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -177,13 +177,10 @@ function startCollection() {
 // alongside its own: {<script url>: {data, lineLengths}}. The reporter needs them to map V8
 // offsets in generated code back to the original source. It re-reads a //# sourceMappingURL
 // from disk on its own, so this only matters for a runtime transpiler such as ts-node, which
-// compiles from memory and leaves nothing on disk to read; there the map is unrecoverable
-// without this, and the reporter silently attributes execution to the wrong lines rather
-// than reporting none.
+// compiles from memory and leaves nothing on disk to read.
 //
 // node populates this cache as it compiles each module, gated on NODE_V8_COVERAGE, which
-// startCollection sets above before any of the program is compiled. That is the same gate
-// node's own writer relies on, and it does not turn on source-mapped stack traces.
+// startCollection sets above before any of the program is compiled.
 function sourceMapCache(result) {
     const { findSourceMap } = require('node:module')
     const cache = {}

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -106,25 +106,30 @@ function startCollection() {
     const path = require('node:path')
     const { mkdirSync, writeFileSync } = require('node:fs')
 
+    let session
+
+    // session.post() reports a command failure through its callback and drops it entirely
+    // without one. The callback is synchronous, which is both why this can rethrow and why
+    // flush() below can run from an exit listener.
+    const post = (method, params) => {
+        let failure, result
+        session.post(method, params, (err, res) => {
+            failure = err
+            result = res
+        })
+        if (failure) {
+            throw failure
+        }
+        return result
+    }
+
     // A node without inspector support, or a program that already holds the session,
     // makes this throw. Report empty coverage rather than take down a program that would
     // otherwise have run: this preload is in every js_binary under `bazel coverage`, so a
     // throw here fails the target before its own code starts.
-    let session
     try {
         session = new (require('node:inspector').Session)()
         session.connect()
-        // post() reports a command failure through its callback and drops it entirely
-        // without one. The callback is synchronous, so this rethrows into the catch below.
-        const post = (method, params) => {
-            let failure
-            session.post(method, params, (err) => {
-                failure = err
-            })
-            if (failure) {
-                throw failure
-            }
-        }
         post('Profiler.enable')
         post('Profiler.startPreciseCoverage', {
             callCount: true,
@@ -143,29 +148,24 @@ function startCollection() {
     process.env.NODE_V8_COVERAGE = dir
 
     function flush() {
-        // The callback is synchronous, which is what makes this usable from an exit listener.
-        session.post('Profiler.takePreciseCoverage', (err, coverage) => {
-            try {
-                if (err) {
-                    throw err
-                }
-                mkdirSync(dir, { recursive: true })
-                // The name node itself uses: pid, timestamp, thread id. Only one collector
-                // ever runs in a thread, so no two can pick the same name.
-                const { threadId } = require('node:worker_threads')
-                const name = `coverage-${process.pid}-${Date.now()}-${threadId}.json`
-                writeFileSync(
-                    path.join(dir, name),
-                    JSON.stringify({
-                        result: coverage.result,
-                        timestamp: Date.now(),
-                        'source-map-cache': sourceMapCache(coverage.result),
-                    })
-                )
-            } catch (e) {
-                logErrorAndFail(`v8 coverage collection failed: ${e.message}`)
-            }
-        })
+        try {
+            const { result } = post('Profiler.takePreciseCoverage')
+            // The name node itself uses: pid, timestamp, thread id. Only one collector
+            // ever runs in a thread, so no two can pick the same name.
+            const { threadId } = require('node:worker_threads')
+            const now = Date.now()
+            mkdirSync(dir, { recursive: true })
+            writeFileSync(
+                path.join(dir, `coverage-${process.pid}-${now}-${threadId}.json`),
+                JSON.stringify({
+                    result,
+                    timestamp: now,
+                    'source-map-cache': sourceMapCache(result),
+                })
+            )
+        } catch (e) {
+            logErrorAndFail(`v8 coverage collection failed: ${e.message}`)
+        }
         session.disconnect()
     }
 
@@ -186,7 +186,7 @@ function sourceMapCache(result) {
     const cache = {}
     for (const { url } of result) {
         // Skip node's own builtins, and anything not compiled from a file.
-        if (!url || !url.startsWith('file://')) {
+        if (!url?.startsWith('file://')) {
             continue
         }
         try {

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -134,12 +134,7 @@ function startCollection() {
     // Enable coverage for all child processes.
     process.env.NODE_V8_COVERAGE = dir
 
-    let written = false
     function flush() {
-        if (written) {
-            return
-        }
-        written = true
         // The callback is synchronous, which is what makes this usable from an exit listener.
         session.post('Profiler.takePreciseCoverage', (err, coverage) => {
             try {
@@ -164,10 +159,6 @@ function startCollection() {
         })
         session.disconnect()
     }
-
-    // The handle a program can use to write the profile before an exit that runs no 'exit'
-    // listener.
-    globalThis[Symbol.for('aspect_rules_js.v8_coverage')] = flush
 
     process.on('exit', flush)
     return true

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -90,8 +90,7 @@ function reportOnExit(reportPath) {
             }
         } catch (e) {
             // Throwing here would skip every later 'exit' listener, including the program's own.
-            logError(`coverage report generation failed: ${e.message}`)
-            process.exitCode = 1
+            logErrorAndFail(`coverage report generation failed: ${e.message}`)
         }
     })
 }
@@ -156,8 +155,7 @@ function startCollection() {
                     })
                 )
             } catch (e) {
-                logError(`v8 coverage collection failed: ${e.message}`)
-                process.exitCode = 1
+                logErrorAndFail(`v8 coverage collection failed: ${e.message}`)
             }
         })
         session.disconnect()
@@ -174,5 +172,14 @@ function startCollection() {
 function logError(message) {
     if (JS_BINARY__LOG_ERROR) {
         console.error(`ERROR: ${JS_BINARY__LOG_PREFIX}: ${message}`)
+    }
+}
+
+// Fail the target, without masking an exit code the program has already chosen. node keeps
+// process.exitCode up to date as it exits, and leaves it unset only on a clean exit.
+function logErrorAndFail(message) {
+    logError(message)
+    if (!process.exitCode) {
+        process.exitCode = 1
     }
 }

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -9,79 +9,158 @@
 // bootstrap.cjs requires this module only when JS_BINARY__COVERAGE_REPORT is set, which
 // js_binary.bzl does for a test target under `bazel coverage` only; the variable holds
 // coverage.js's runfiles-relative path.
+const { JS_BINARY__LOG_ERROR, JS_BINARY__LOG_PREFIX } = process.env
+
+const flushCoverage = startCollection()
 
 // Child node processes re-enter bootstrap.cjs with an inherited environment. Only the root
 // process reports, once every child has exited and written its profile.
 const { JS_BINARY__COVERAGE_REPORT } = process.env
 delete process.env.JS_BINARY__COVERAGE_REPORT
-
-// Snapshot the environment and cwd now: the program under test may mutate either before it
-// exits, and the reporter must see what the launcher set up.
-//
-// NODE_V8_COVERAGE is blanked so the reporter writes no profile of its own alongside the
-// ones it reads. It has to be emptied rather than deleted: child_process always propagates
-// NODE_V8_COVERAGE from the parent, and only skips doing so when the env passed to it has
-// the key as a property.
-const env = {
-    ...process.env,
-    JS_COVERAGE__RUNFILES: process.env.JS_BINARY__RUNFILES,
-    NODE_V8_COVERAGE: '',
+if (JS_BINARY__COVERAGE_REPORT) {
+    reportOnExit(JS_BINARY__COVERAGE_REPORT)
 }
-const cwd = process.cwd()
-// Not process.execPath, which bootstrap.cjs patched to the node wrapper; that would
-// re-apply the bootstrap in the reporter process.
-const nodeBinary = process.env.JS_BINARY__NODE_BINARY
-const report = require('node:path').resolve(
-    process.env.JS_BINARY__RUNFILES,
-    JS_BINARY__COVERAGE_REPORT
-)
 
-// This listener is registered by a --require preload, so it runs before any
-// 'exit' listener the program itself registers.  takeCoverage() below
-// therefore snapshots the profile before those listeners run, and code the
-// program executes from one of them is reported as uncovered.
-process.on('exit', function onExitCoverageReport() {
-    try {
-        const fs = require('node:fs')
-        const v8 = require('node:v8')
-        const { spawnSync } = require('node:child_process')
+// Registers the exit hook that runs coverage.js, the executable that turns the V8 profiles in
+// COVERAGE_DIR into the lcov report the _lcov_merger publishes.
+function reportOnExit(reportPath) {
+    // Snapshot the environment and cwd now: the program under test may mutate either before it
+    // exits, and the reporter must see what the launcher set up.
+    //
+    // NODE_V8_COVERAGE is blanked so the reporter writes no profile of its own alongside the
+    // ones it reads. It has to be emptied rather than deleted: child_process always propagates
+    // NODE_V8_COVERAGE from the parent, and only skips doing so when the env passed to it has
+    // the key as a property.
+    const env = {
+        ...process.env,
+        JS_COVERAGE__RUNFILES: process.env.JS_BINARY__RUNFILES,
+        NODE_V8_COVERAGE: '',
+    }
+    const cwd = process.cwd()
+    // Not process.execPath, which bootstrap.cjs patched to the node wrapper; that would
+    // re-apply the bootstrap in the reporter process.
+    const nodeBinary = process.env.JS_BINARY__NODE_BINARY
+    const report = require('node:path').resolve(
+        process.env.JS_BINARY__RUNFILES,
+        reportPath
+    )
 
-        // A test reporting its own coverage owns it, except under split
-        // post-processing, where bazel drops what the test wrote.
-        if (env.SPLIT_COVERAGE_POST_PROCESSING !== '1' && env.COVERAGE_OUTPUT_FILE) {
-            const stat = fs.statSync(env.COVERAGE_OUTPUT_FILE, {
-                throwIfNoEntry: false,
+    // This listener is registered by a --require preload, so it runs before any
+    // 'exit' listener the program itself registers.  takeCoverage() below
+    // therefore snapshots the profile before those listeners run, and code the
+    // program executes from one of them is reported as uncovered.
+    process.on('exit', function onExitCoverageReport() {
+        try {
+            const fs = require('node:fs')
+            const { spawnSync } = require('node:child_process')
+
+            // A test reporting its own coverage owns it, except under split
+            // post-processing, where bazel drops what the test wrote.
+            if (
+                env.SPLIT_COVERAGE_POST_PROCESSING !== '1' &&
+                env.COVERAGE_OUTPUT_FILE
+            ) {
+                const stat = fs.statSync(env.COVERAGE_OUTPUT_FILE, {
+                    throwIfNoEntry: false,
+                })
+                if (stat && stat.size > 0) return
+            }
+            if (!fs.existsSync(report)) {
+                // Report empty coverage rather than fail an otherwise passing test.
+                logError(
+                    `coverage report generator '${report}' not found; code coverage requires a runfiles tree`
+                )
+                return
+            }
+            // This process's own profile is not on disk yet: whoever is collecting writes it
+            // during teardown, which happens after this handler runs. Flush it here so that
+            // the report includes it.
+            if (flushCoverage) {
+                flushCoverage()
+            } else {
+                // node is collecting. Deliberately no v8.stopCoverage(): node's teardown
+                // asks V8 for coverage regardless, and errors out once it has stopped.
+                require('node:v8').takeCoverage()
+            }
+            const { status, error } = spawnSync(nodeBinary, [report], {
+                cwd,
+                env,
+                stdio: 'inherit',
             })
-            if (stat && stat.size > 0) return
+            if (error || status !== 0) {
+                throw error || new Error(`exit code ${status}`)
+            }
+        } catch (e) {
+            // Throwing here would skip every later 'exit' listener, including the program's own.
+            logError(`coverage report generation failed: ${e.message}`)
+            process.exitCode = 1
         }
-        if (!fs.existsSync(report)) {
-            // Report empty coverage rather than fail an otherwise passing test.
-            logError(
-                `coverage report generator '${report}' not found; code coverage requires a runfiles tree`
-            )
+    })
+}
+
+// Starts a V8 precise coverage session for this process, unless node is already collecting.
+// Returns a function that writes the profile early, or undefined when node is collecting.
+function startCollection() {
+    if (!process.env.COVERAGE_DIR || process.env.NODE_V8_COVERAGE) {
+        return undefined
+    }
+
+    const path = require('node:path')
+    const { mkdirSync, writeFileSync } = require('node:fs')
+
+    const session = new (require('node:inspector').Session)()
+    session.connect()
+    session.post('Profiler.enable')
+    session.post('Profiler.startPreciseCoverage', {
+        callCount: true,
+        detailed: true,
+    })
+
+    // Enable coverage for all child processes.
+    process.env.NODE_V8_COVERAGE = path.resolve(process.env.COVERAGE_DIR)
+
+    let written = false
+    function flush() {
+        if (written) {
             return
         }
-        // node writes this process's own profile during teardown, which happens after
-        // this handler runs, so flush it here. Deliberately no v8.stopCoverage(): node's
-        // teardown asks V8 for coverage regardless, and errors out once it has stopped.
-        v8.takeCoverage()
-        const { status, error } = spawnSync(nodeBinary, [report], {
-            cwd,
-            env,
-            stdio: 'inherit',
+        written = true
+        // The callback is synchronous, which is what makes this usable from an exit listener.
+        session.post('Profiler.takePreciseCoverage', (err, coverage) => {
+            try {
+                if (err) {
+                    throw err
+                }
+                mkdirSync(dir, { recursive: true })
+                // The name node itself uses: pid, timestamp, thread id. Only one collector
+                // ever runs in a thread, so no two can pick the same name.
+                const { threadId } = require('node:worker_threads')
+                const name = `coverage-${process.pid}-${Date.now()}-${threadId}.json`
+                writeFileSync(
+                    path.join(dir, name),
+                    JSON.stringify({
+                        result: coverage.result,
+                        timestamp: Date.now(),
+                    })
+                )
+            } catch (e) {
+                logError(`v8 coverage collection failed: ${e.message}`)
+                process.exitCode = 1
+            }
         })
-        if (error || status !== 0) {
-            throw error || new Error(`exit code ${status}`)
-        }
-    } catch (e) {
-        // Throwing here would skip every later 'exit' listener, including the program's own.
-        logError(`coverage report generation failed: ${e.message}`)
-        process.exitCode = 1
+        session.disconnect()
     }
-})
+
+    // The handle a program can use to write the profile before an exit that runs no 'exit'
+    // listener.
+    globalThis[Symbol.for('aspect_rules_js.v8_coverage')] = flush
+
+    process.on('exit', flush)
+    return flush
+}
 
 function logError(message) {
-    if (env.JS_BINARY__LOG_ERROR) {
-        console.error(`ERROR: ${env.JS_BINARY__LOG_PREFIX}: ${message}`)
+    if (JS_BINARY__LOG_ERROR) {
+        console.error(`ERROR: ${JS_BINARY__LOG_PREFIX}: ${message}`)
     }
 }

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -159,6 +159,7 @@ function startCollection() {
                     JSON.stringify({
                         result: coverage.result,
                         timestamp: Date.now(),
+                        'source-map-cache': sourceMapCache(coverage.result),
                     })
                 )
             } catch (e) {
@@ -170,6 +171,38 @@ function startCollection() {
 
     process.on('exit', flush)
     return true
+}
+
+// The source maps node recorded for the scripts in this profile, in the shape node writes
+// alongside its own: {<script url>: {data, lineLengths}}. The reporter needs them to map V8
+// offsets in generated code back to the original source. It re-reads a //# sourceMappingURL
+// from disk on its own, so this only matters for a runtime transpiler such as ts-node, which
+// compiles from memory and leaves nothing on disk to read; there the map is unrecoverable
+// without this, and the reporter silently attributes execution to the wrong lines rather
+// than reporting none.
+//
+// node populates this cache as it compiles each module, gated on NODE_V8_COVERAGE, which
+// startCollection sets above before any of the program is compiled. That is the same gate
+// node's own writer relies on, and it does not turn on source-mapped stack traces.
+function sourceMapCache(result) {
+    const { findSourceMap } = require('node:module')
+    const cache = {}
+    for (const { url } of result) {
+        // Skip node's own builtins, and anything not compiled from a file.
+        if (!url || !url.startsWith('file://')) {
+            continue
+        }
+        try {
+            const map = findSourceMap(url)
+            if (map) {
+                cache[url] = { data: map.payload, lineLengths: map.lineLengths }
+            }
+        } catch {
+            // A script whose map cannot be recovered is reported unmapped, as it would
+            // have been without this.
+        }
+    }
+    return cache
 }
 
 function logError(message) {

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -1,14 +1,11 @@
 // Code coverage
 //
 // Collects this process's V8 coverage, and, for a test that reports, runs coverage.js on
-// exit to turn the collected profiles into an lcov report. bootstrap.cjs requires this
-// module when JS_BINARY__COVERAGE_REPORT is set, or when COVERAGE_DIR is set and node is
-// not already collecting. js_binary.bzl sets the former for a reporting test under
-// `bazel coverage` only; it holds coverage.js's runfiles-relative path.
+// exit to turn the collected profiles into an lcov report.
 //
-// Collection drives the inspector rather than setting NODE_V8_COVERAGE, which node reads
-// as it starts up: only a process running before node could set it, and the launcher must
-// not have to be one.
+// We enable collection via the inspector rather than by setting the NODE_V8_COVERAGE
+// environment variable. This allows us to start collection in-process without relying on any
+// shell script logic to run beforehand.
 //
 // The report is generated here because the test action is the only place the profiles and
 // the instrumented sources are both present, and in its own process because coverage.js is
@@ -181,8 +178,7 @@ function logError(message) {
     }
 }
 
-// Fail the target, without masking an exit code the program has already chosen. node keeps
-// process.exitCode up to date as it exits, and leaves it unset only on a clean exit.
+// Fail the target, without masking an exit code the program has already chosen.
 function logErrorAndFail(message) {
     logError(message)
     if (!process.exitCode) {

--- a/js/private/node-bootstrap/coverage.cjs
+++ b/js/private/node-bootstrap/coverage.cjs
@@ -18,13 +18,10 @@ const collecting = startCollection()
 // process reports, once every child has exited and written its profile.
 const { JS_BINARY__COVERAGE_REPORT } = process.env
 delete process.env.JS_BINARY__COVERAGE_REPORT
-if (JS_BINARY__COVERAGE_REPORT) {
-    reportOnExit(JS_BINARY__COVERAGE_REPORT)
-}
 
-// Registers the exit hook that runs coverage.js, the executable that turns the V8 profiles in
-// COVERAGE_DIR into the lcov report the _lcov_merger publishes.
-function reportOnExit(reportPath) {
+// The exit hook runs coverage.js, the executable that turns the V8 profiles in COVERAGE_DIR
+// into the lcov report the _lcov_merger publishes.
+if (JS_BINARY__COVERAGE_REPORT) {
     // Snapshot the environment and cwd now: the program under test may mutate either before it
     // exits, and the reporter must see what the launcher set up.
     //
@@ -43,7 +40,7 @@ function reportOnExit(reportPath) {
     const nodeBinary = process.env.JS_BINARY__NODE_BINARY
     const report = require('node:path').resolve(
         process.env.JS_BINARY__RUNFILES,
-        reportPath
+        JS_BINARY__COVERAGE_REPORT
     )
 
     // This listener is registered by a --require preload, so it runs before any

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -4,8 +4,6 @@ load(":test.bzl", "coverage_child_test", "coverage_no_report_test", "coverage_pa
 
 package(default_testonly = True)
 
-# Every fixture here needs the same answer; a coverage report is only generated from a
-# runfiles tree.
 _ENABLE_RUNFILES = select({
     "@bazel_lib//lib:enable_runfiles": True,
     "//conditions:default": False,
@@ -96,7 +94,7 @@ coverage_pass_test(
 
 # transpiled.js explains what it emulates. Dropping the source map from the profile does
 # not empty the report, it shifts it: transpiled.js puts the generated code one line lower,
-# turning these into FN:2, DA:5,1 and DA:8,0. Hence asserting lines, not just non-emptiness.
+# turning these into FN:2, DA:5,1 and DA:8,0.
 coverage_merger(
     name = "transpiled_merger",
     merge_assertions = """\

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -4,6 +4,13 @@ load(":test.bzl", "coverage_child_test", "coverage_no_report_test", "coverage_pa
 
 package(default_testonly = True)
 
+# Every fixture here needs the same answer; a coverage report is only generated from a
+# runfiles tree.
+_ENABLE_RUNFILES = select({
+    "@bazel_lib//lib:enable_runfiles": True,
+    "//conditions:default": False,
+})
+
 merger_test_suite(name = "merger_test")
 
 # The test program reported its own coverage to COVERAGE_OUTPUT_FILE, so the merger
@@ -43,10 +50,7 @@ fi
 coverage_preexisting_test(
     name = "preexisting",
     data = ["preexisting.js"],
-    enable_runfiles = select({
-        "@bazel_lib//lib:enable_runfiles": True,
-        "//conditions:default": False,
-    }),
+    enable_runfiles = _ENABLE_RUNFILES,
     entry_point = "preexisting.js",
 )
 
@@ -75,10 +79,7 @@ fi
 coverage_pass_test(
     name = "pass",
     data = ["lib.js"],
-    enable_runfiles = select({
-        "@bazel_lib//lib:enable_runfiles": True,
-        "//conditions:default": False,
-    }),
+    enable_runfiles = _ENABLE_RUNFILES,
     entry_point = "lib.js",
 )
 
@@ -88,19 +89,14 @@ coverage_pass_test(
 coverage_pass_test(
     name = "expected_exit",
     data = ["expected_exit.js"],
-    enable_runfiles = select({
-        "@bazel_lib//lib:enable_runfiles": True,
-        "//conditions:default": False,
-    }),
+    enable_runfiles = _ENABLE_RUNFILES,
     entry_point = "expected_exit.js",
     expected_exit_code = 42,
 )
 
-# A runtime transpiler compiles from memory, so nothing on disk carries the generated code
-# or a //# sourceMappingURL for the reporter to find. The source map node recorded, which
-# coverage.cjs writes into the profile, is the only way back to the real lines. Without it
-# the reporter reports the wrong lines: transpiled.js shifts the generated code down by
-# one, which turns these into FN:2, DA:5,1 and DA:8,0.
+# transpiled.js explains what it emulates. Dropping the source map from the profile does
+# not empty the report, it shifts it: transpiled.js puts the generated code one line lower,
+# turning these into FN:2, DA:5,1 and DA:8,0. Hence asserting lines, not just non-emptiness.
 coverage_merger(
     name = "transpiled_merger",
     merge_assertions = """\
@@ -127,10 +123,7 @@ coverage_transpiled_test(
         "transpiled.js",
         "transpiled_lib.js",
     ],
-    enable_runfiles = select({
-        "@bazel_lib//lib:enable_runfiles": True,
-        "//conditions:default": False,
-    }),
+    enable_runfiles = _ENABLE_RUNFILES,
     entry_point = "transpiled.js",
 )
 
@@ -162,10 +155,7 @@ coverage_child_test(
         "child.js",
         "child_lib.js",
     ],
-    enable_runfiles = select({
-        "@bazel_lib//lib:enable_runfiles": True,
-        "//conditions:default": False,
-    }),
+    enable_runfiles = _ENABLE_RUNFILES,
     entry_point = "child.js",
 )
 
@@ -186,9 +176,6 @@ fi
 coverage_no_report_test(
     name = "no_report",
     data = ["lib.js"],
-    enable_runfiles = select({
-        "@bazel_lib//lib:enable_runfiles": True,
-        "//conditions:default": False,
-    }),
+    enable_runfiles = _ENABLE_RUNFILES,
     entry_point = "lib.js",
 )

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//js/private/coverage:merger.bzl", "coverage_merger")
 load(":merger_test.bzl", "merger_test_suite")
-load(":test.bzl", "coverage_child_test", "coverage_no_report_test", "coverage_pass_test", "coverage_preexisting_test")
+load(":test.bzl", "coverage_child_test", "coverage_no_report_test", "coverage_pass_test", "coverage_preexisting_test", "coverage_transpiled_test")
 
 package(default_testonly = True)
 
@@ -94,6 +94,44 @@ coverage_pass_test(
     }),
     entry_point = "expected_exit.js",
     expected_exit_code = 42,
+)
+
+# A runtime transpiler compiles from memory, so nothing on disk carries the generated code
+# or a //# sourceMappingURL for the reporter to find; the source map node recorded, which
+# coverage.cjs writes into the profile, is the only way back to the real lines. Without it
+# the reporter does not report nothing, it reports the wrong lines: transpiled.js shifts the
+# generated code down by one, which turns these into FN:2, DA:5,1 and DA:8,0.
+coverage_merger(
+    name = "transpiled_merger",
+    merge_assertions = """\
+record="$(awk -v sf='SF:js/private/test/coverage/transpiled_lib.js' '$0 == sf { p = 1 } p { print } p && $0 == "end_of_record" { exit }' "$COVERAGE_OUTPUT_FILE")"
+if [ -z "$record" ]; then
+    echo "no coverage record for transpiled_lib.js, got:" >&2
+    cat "$COVERAGE_OUTPUT_FILE" >&2
+    exit 1
+fi
+for expected in "FN:1,transpiledCovered" "FNDA:1,transpiledCovered" "FNDA:0,transpiledUncovered" "DA:5,0" "DA:8,1"; do
+    echo "$record" | grep -qxF "$expected" || {
+        echo "expected '$expected' in the report for transpiled_lib.js:" >&2
+        echo "$record" >&2
+        exit 1
+    }
+done
+""",
+    visibility = ["//visibility:public"],
+)
+
+coverage_transpiled_test(
+    name = "transpiled",
+    data = [
+        "transpiled.js",
+        "transpiled_lib.js",
+    ],
+    enable_runfiles = select({
+        "@bazel_lib//lib:enable_runfiles": True,
+        "//conditions:default": False,
+    }),
+    entry_point = "transpiled.js",
 )
 
 # Only the root node process generates the report; a child that re-enters bootstrap.cjs

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -97,10 +97,10 @@ coverage_pass_test(
 )
 
 # A runtime transpiler compiles from memory, so nothing on disk carries the generated code
-# or a //# sourceMappingURL for the reporter to find; the source map node recorded, which
+# or a //# sourceMappingURL for the reporter to find. The source map node recorded, which
 # coverage.cjs writes into the profile, is the only way back to the real lines. Without it
-# the reporter does not report nothing, it reports the wrong lines: transpiled.js shifts the
-# generated code down by one, which turns these into FN:2, DA:5,1 and DA:8,0.
+# the reporter reports the wrong lines: transpiled.js shifts the generated code down by
+# one, which turns these into FN:2, DA:5,1 and DA:8,0.
 coverage_merger(
     name = "transpiled_merger",
     merge_assertions = """\

--- a/js/private/test/coverage/child.js
+++ b/js/private/test/coverage/child.js
@@ -6,6 +6,18 @@
 const assert = require('node:assert')
 const path = require('node:path')
 
+// The report below is only evidence of anything if coverage.cjs is what collected the
+// coverage that went into it. Nothing sets NODE_V8_COVERAGE before node starts any more, so
+// a missing session here means an empty report rather than one collected some other way.
+// This target also runs under plain `bazel test`, where there is no coverage to collect.
+if (process.env.COVERAGE_DIR) {
+    assert.strictEqual(
+        typeof globalThis[Symbol.for('aspect_rules_js.v8_coverage')],
+        'function',
+        'expected coverage.cjs to have started a v8 coverage session'
+    )
+}
+
 // bootstrap.cjs patched process.execPath to the node wrapper, so this is the same
 // `node` a program would pick up off the PATH.
 const { status, error } = require('node:child_process').spawnSync(

--- a/js/private/test/coverage/child.js
+++ b/js/private/test/coverage/child.js
@@ -6,11 +6,16 @@
 const assert = require('node:assert')
 const path = require('node:path')
 
+// The report below is only evidence of anything if coverage.cjs collected what went into
+// it. Nothing sets NODE_V8_COVERAGE before node starts any more, so seeing it here means
+// coverage.cjs started a session; without one the report would be empty rather than
+// collected some other way. This target also runs under plain `bazel test`, where there is
+// no coverage to collect.
 if (process.env.COVERAGE_DIR) {
-    assert.strictEqual(
-        typeof globalThis[Symbol.for('aspect_rules_js.v8_coverage')],
-        'function',
-        'expected coverage.cjs to have started a v8 coverage session'
+    assert.match(
+        process.env.NODE_V8_COVERAGE || '',
+        /^\//,
+        `expected coverage.cjs to have started a v8 coverage session, got NODE_V8_COVERAGE '${process.env.NODE_V8_COVERAGE}'`
     )
 }
 

--- a/js/private/test/coverage/child.js
+++ b/js/private/test/coverage/child.js
@@ -6,11 +6,7 @@
 const assert = require('node:assert')
 const path = require('node:path')
 
-// The report below is only evidence of anything if coverage.cjs collected what went into
-// it. Nothing sets NODE_V8_COVERAGE before node starts any more, so seeing it here means
-// coverage.cjs started a session; without one the report would be empty rather than
-// collected some other way. This target also runs under plain `bazel test`, where there is
-// no coverage to collect.
+// If this is a coverage-enabled run, then this process should have set NODE_V8_COVERAGE.
 if (process.env.COVERAGE_DIR) {
     assert.match(
         process.env.NODE_V8_COVERAGE || '',

--- a/js/private/test/coverage/child.js
+++ b/js/private/test/coverage/child.js
@@ -6,10 +6,6 @@
 const assert = require('node:assert')
 const path = require('node:path')
 
-// The report below is only evidence of anything if coverage.cjs is what collected the
-// coverage that went into it. Nothing sets NODE_V8_COVERAGE before node starts any more, so
-// a missing session here means an empty report rather than one collected some other way.
-// This target also runs under plain `bazel test`, where there is no coverage to collect.
 if (process.env.COVERAGE_DIR) {
     assert.strictEqual(
         typeof globalThis[Symbol.for('aspect_rules_js.v8_coverage')],

--- a/js/private/test/coverage/child_lib.js
+++ b/js/private/test/coverage/child_lib.js
@@ -12,6 +12,18 @@ assert.ok(
     `expected a nested bootstrap, got depth '${process.env.JS_BINARY__NODE_PATCHES_DEPTH}'`
 )
 
+// Nothing sets NODE_V8_COVERAGE before node starts any more; the root process's
+// coverage.cjs puts it in the environment so that node collects this child's coverage the
+// way it always did. child_merger asserts the profile that produces reaches the report.
+// Under plain `bazel test` there is no coverage and neither variable is set.
+if (process.env.COVERAGE_DIR) {
+    assert.match(
+        process.env.NODE_V8_COVERAGE || '',
+        /^\//,
+        `expected an absolute NODE_V8_COVERAGE, got '${process.env.NODE_V8_COVERAGE}'`
+    )
+}
+
 if (true) {
     childCovered()
 } else {

--- a/js/private/test/coverage/child_lib.js
+++ b/js/private/test/coverage/child_lib.js
@@ -12,10 +12,7 @@ assert.ok(
     `expected a nested bootstrap, got depth '${process.env.JS_BINARY__NODE_PATCHES_DEPTH}'`
 )
 
-// Nothing sets NODE_V8_COVERAGE before node starts any more; the root process's
-// coverage.cjs puts it in the environment so that node collects this child's coverage the
-// way it always did. child_merger asserts the profile that produces reaches the report.
-// Under plain `bazel test` there is no coverage and neither variable is set.
+// If this is a coverage-enabled run, then the root process should have set NODE_V8_COVERAGE.
 if (process.env.COVERAGE_DIR) {
     assert.match(
         process.env.NODE_V8_COVERAGE || '',

--- a/js/private/test/coverage/test.bzl
+++ b/js/private/test/coverage/test.bzl
@@ -27,4 +27,5 @@ def _coverage_test(merger, coverage_report = True):
 coverage_preexisting_test = _coverage_test("preexisting_merger")
 coverage_pass_test = _coverage_test("pass_merger")
 coverage_child_test = _coverage_test("child_merger")
+coverage_transpiled_test = _coverage_test("transpiled_merger")
 coverage_no_report_test = _coverage_test("no_report_merger", coverage_report = False)

--- a/js/private/test/coverage/transpiled.js
+++ b/js/private/test/coverage/transpiled.js
@@ -1,0 +1,36 @@
+// Stands in for a runtime transpiler such as ts-node: compiles transpiled_lib.js from
+// memory with a banner line prepended, so every V8 offset in it is one line further down
+// than the file on disk. Nothing on disk holds the generated code or a
+// //# sourceMappingURL for the reporter to find, so node's own record of the mapping,
+// which coverage.cjs writes into the profile, is the only way back to the real lines.
+// transpiled_merger asserts them.
+const fs = require('node:fs')
+const path = require('node:path')
+const Module = require('node:module')
+
+const filename = path.resolve(__dirname, 'transpiled_lib.js')
+const source = fs.readFileSync(filename, 'utf8')
+
+// Generated line n is original line n - 1. A mapping segment is (generated column, source
+// index, source line, source column), each a delta from the previous segment, so 'AAAA' is
+// four zeroes and 'AACA' is the same one source line further on. The leading ';' ends the
+// banner's line, which maps to nothing.
+const map = {
+    version: 3,
+    sources: [filename],
+    names: [],
+    mappings: ';AAAA' + ';AACA'.repeat(source.split('\n').length - 1),
+}
+const generated =
+    '// prepended by transpiled.js\n' +
+    source +
+    '\n//# sourceMappingURL=data:application/json;base64,' +
+    Buffer.from(JSON.stringify(map)).toString('base64') +
+    '\n'
+
+const lib = new Module(filename, module)
+lib.filename = filename
+lib.paths = Module._nodeModulePaths(path.dirname(filename))
+lib._compile(generated, filename)
+
+lib.exports.transpiledCovered()

--- a/js/private/test/coverage/transpiled.js
+++ b/js/private/test/coverage/transpiled.js
@@ -29,8 +29,6 @@ const generated =
     '\n'
 
 const lib = new Module(filename, module)
-lib.filename = filename
-lib.paths = Module._nodeModulePaths(path.dirname(filename))
 lib._compile(generated, filename)
 
 lib.exports.transpiledCovered()

--- a/js/private/test/coverage/transpiled_lib.js
+++ b/js/private/test/coverage/transpiled_lib.js
@@ -1,0 +1,9 @@
+function transpiledCovered() {
+    console.log('transpiled covered')
+}
+
+function transpiledUncovered() {
+    console.log('transpiled uncovered')
+}
+
+module.exports = { transpiledCovered, transpiledUncovered }

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-5a5a86b440816d6f54451fb61d6d87e8adc008628ff8129e3fd4e81f6c8bd80f  js/private/test/image/cksum_node.tar
+21f4fa975d9f7a6822d45530e132db19d9aa27f84bbcd177c409fd28f65b37a7  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 2cb6f678d6eb0b2e9d5e2637f41ae3f192233752f1ea2a55cede2531deec2a64  js/private/test/image/cksum_package_store_1p.tar
 79afa99006aff19460354e72cf2634db693670d09ccc7531fbf27f1f20fe0a5f  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-21f4fa975d9f7a6822d45530e132db19d9aa27f84bbcd177c409fd28f65b37a7  js/private/test/image/cksum_node.tar
+0f7398d8d2fb575ee72775ddc412a8689f0335b76d4c2692b3fb0729e3376fb3  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 2cb6f678d6eb0b2e9d5e2637f41ae3f192233752f1ea2a55cede2531deec2a64  js/private/test/image/cksum_package_store_1p.tar
 79afa99006aff19460354e72cf2634db693670d09ccc7531fbf27f1f20fe0a5f  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-296041ddc116956ef3ad57ec178b0e14e12c06972c331c0921cda1df292092a0  js/private/test/image/cksum_node.tar
+5a5a86b440816d6f54451fb61d6d87e8adc008628ff8129e3fd4e81f6c8bd80f  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 2cb6f678d6eb0b2e9d5e2637f41ae3f192233752f1ea2a55cede2531deec2a64  js/private/test/image/cksum_package_store_1p.tar
 79afa99006aff19460354e72cf2634db693670d09ccc7531fbf27f1f20fe0a5f  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3356 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3090 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 100    0        3423 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 100    0        3356 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 100    0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 100    0        3401 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 100    0        3423 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 100    0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 100    0        3090 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 100    0        3401 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 100    0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3090 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3356 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3090 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/nodejs/

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3356 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/nodejs/

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/nodejs/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3356 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3090 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3356 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3090 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3401 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3423 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -506,12 +506,6 @@ if [ -z "${JS_BINARY__FS_PATCH_ROOTS:-}" ]; then
 fi
 export JS_BINARY__FS_PATCH_ROOTS
 
-# Enable coverage if requested
-if [ "${COVERAGE_DIR:-}" ]; then
-    logf_debug "enabling v8 coverage support ${COVERAGE_DIR}"
-    export NODE_V8_COVERAGE=${COVERAGE_DIR}
-fi
-
 # Disable Node's module compile cache by default (aspect-build/rules_js#2937).
 # We will re-enable it at runtime if NODE_COMPILE_CACHE is set.
 export NODE_DISABLE_COMPILE_CACHE=1


### PR DESCRIPTION
The bash launcher currently exports the `NODE_V8_COVERAGE` environment variable and points it at `$COVERAGE_DIR`. When we switch over to hermetic_launcher we will no longer be able to do this before Node starts, so this change works around that problem by enabling coverage from within Node, without the need to set that environment variable in advance.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases