### PR TITLE
refactor: apply chdir from the node bootstrap, not the launcher

### DIFF
--- a/js/private/devserver/js_run_devserver.mjs
+++ b/js/private/devserver/js_run_devserver.mjs
@@ -685,19 +685,14 @@ function isWindowsScript(tool) {
     return isScriptFile && os.platform() === 'win32'
 }
 
-async function main(args, sandbox) {
+async function main(args, sandbox, config) {
     console.error(
         `\n\nStarting js_run_devserver ${process.env.JS_BINARY__TARGET}`
     );
 
-    const configPath = path.join(RUNFILES_ROOT, args[0]);
     const entriesPath = path.join(RUNFILES_ROOT, args[1]);
 
-    const config = JSON.parse(await fs.promises.readFile(configPath));
-
-    const cwd = process.env.JS_BINARY__CHDIR
-        ? path.join(sandbox, process.env.JS_BINARY__CHDIR)
-        : sandbox;
+    const cwd = config.chdir ? path.join(sandbox, config.chdir) : sandbox;
 
     const tool = config.tool
         ? path.join(RUNFILES_ROOT, config.tool)
@@ -710,7 +705,6 @@ async function main(args, sandbox) {
     const env = {
         ...process.env,
         BAZEL_BINDIR: '.', // no load bearing but it may be depended on by users
-        JS_BINARY__CHDIR: '',
         JS_BINARY__NO_CD_BINDIR: '1',
     };
 
@@ -1002,9 +996,15 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
         );
         const sandboxMain = path.join(sandbox, JS_BINARY__WORKSPACE);
 
+        // Read before the first mkdirp below, which needs config.chdir.
+        const args = process.argv.slice(2);
+        const config = JSON.parse(
+            await fs.promises.readFile(path.join(RUNFILES_ROOT, args[0]))
+        );
+
         // Intentionally synchronous; see comment on mkdirpSync
-        mkdirpSync(path.join(sandboxMain, process.env.JS_BINARY__CHDIR || ''));
-        await main(process.argv.slice(2), sandboxMain);
+        mkdirpSync(path.join(sandboxMain, config.chdir || ''));
+        await main(args, sandboxMain, config);
     } catch (e) {
         console.error(e);
         process.exit(1);

--- a/js/private/devserver/src/js_run_devserver.mjs
+++ b/js/private/devserver/src/js_run_devserver.mjs
@@ -437,19 +437,14 @@ function isWindowsScript(tool) {
     return isScriptFile && os.platform() === 'win32'
 }
 
-async function main(args, sandbox) {
+async function main(args, sandbox, config) {
     console.error(
         `\n\nStarting js_run_devserver ${process.env.JS_BINARY__TARGET}`
     )
 
-    const configPath = path.join(RUNFILES_ROOT, args[0])
     const entriesPath = path.join(RUNFILES_ROOT, args[1])
 
-    const config = JSON.parse(await fs.promises.readFile(configPath))
-
-    const cwd = process.env.JS_BINARY__CHDIR
-        ? path.join(sandbox, process.env.JS_BINARY__CHDIR)
-        : sandbox
+    const cwd = config.chdir ? path.join(sandbox, config.chdir) : sandbox
 
     const tool = config.tool
         ? path.join(RUNFILES_ROOT, config.tool)
@@ -462,7 +457,6 @@ async function main(args, sandbox) {
     const env = {
         ...process.env,
         BAZEL_BINDIR: '.', // no load bearing but it may be depended on by users
-        JS_BINARY__CHDIR: '',
         JS_BINARY__NO_CD_BINDIR: '1',
     }
 
@@ -755,9 +749,15 @@ async function cycleSyncRecurse(cycle, file, isDirectory, sandbox, writePerm) {
         )
         const sandboxMain = path.join(sandbox, JS_BINARY__WORKSPACE)
 
+        // Read before the first mkdirp below, which needs config.chdir.
+        const args = process.argv.slice(2)
+        const config = JSON.parse(
+            await fs.promises.readFile(path.join(RUNFILES_ROOT, args[0]))
+        )
+
         // Intentionally synchronous; see comment on mkdirpSync
-        mkdirpSync(path.join(sandboxMain, process.env.JS_BINARY__CHDIR || ''))
-        await main(process.argv.slice(2), sandboxMain)
+        mkdirpSync(path.join(sandboxMain, config.chdir || ''))
+        await main(args, sandboxMain, config)
     } catch (e) {
         console.error(e)
         process.exit(1)

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -362,9 +362,6 @@ def _bash_launcher(ctx, nodeinfo, entry_point_path, log_prefix_rule_set, log_pre
         # Set an environment variable to flag that we have copied js_binary data to bin
         envs.append(_ENV_SET.format(var = "JS_BINARY__COPY_DATA_TO_BIN", quoted_value = _bash_quote("1")))
 
-    # The working directory the program runs in, as bootstrap.cjs receives it. Returned to the
-    # caller so that a rule such as js_run_devserver, which has to mirror it elsewhere, does not
-    # have to recompute the normalization below.
     normalized_chdir = ""
 
     if ctx.attr.chdir:

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -362,6 +362,11 @@ def _bash_launcher(ctx, nodeinfo, entry_point_path, log_prefix_rule_set, log_pre
         # Set an environment variable to flag that we have copied js_binary data to bin
         envs.append(_ENV_SET.format(var = "JS_BINARY__COPY_DATA_TO_BIN", quoted_value = _bash_quote("1")))
 
+    # The working directory the program runs in, as bootstrap.cjs receives it. Returned to the
+    # caller so that a rule such as js_run_devserver, which has to mirror it elsewhere, does not
+    # have to recompute the normalization below.
+    normalized_chdir = ""
+
     if ctx.attr.chdir:
         # Set chdir env if not already set to allow js_run_binary to override
         chdir_value = _expand_env_if_needed(ctx, ctx.attr.chdir)
@@ -444,7 +449,7 @@ def _bash_launcher(ctx, nodeinfo, entry_point_path, log_prefix_rule_set, log_pre
         is_executable = True,
     )
 
-    return launcher, toolchain_files
+    return launcher, toolchain_files, normalized_chdir
 
 def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [], fixed_env = {}):
     is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
@@ -466,7 +471,7 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
         entry_point = ctx.files.entry_point[0]
         entry_point_path = entry_point.short_path
 
-    bash_launcher, toolchain_files = _bash_launcher(ctx, nodeinfo, entry_point_path, log_prefix_rule_set, log_prefix_rule, fixed_args, fixed_env, is_windows)
+    bash_launcher, toolchain_files, chdir = _bash_launcher(ctx, nodeinfo, entry_point_path, log_prefix_rule_set, log_prefix_rule, fixed_args, fixed_env, is_windows)
     launcher = create_windows_native_launcher_script(ctx, bash_launcher) if is_windows else bash_launcher
 
     launcher_files = [bash_launcher]
@@ -507,6 +512,7 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
         executable = launcher,
         runfiles = runfiles,
         data_runfiles = data_runfiles,
+        chdir = chdir,
     )
 
 def _js_binary_impl(ctx):

--- a/js/private/js_binary.sh.tpl
+++ b/js/private/js_binary.sh.tpl
@@ -363,15 +363,6 @@ if [ ! -f "$JS_BINARY__NODE_PATCHES" ]; then
     exit 1
 fi
 
-# Change directory to user specified package if set
-if [ "${JS_BINARY__CHDIR:-}" ]; then
-    logf_debug "changing directory to user specified package %s" "$JS_BINARY__CHDIR"
-    case "$JS_BINARY__CHDIR" in
-    external/*) cd "$(resolve_execroot_bin_path "$JS_BINARY__CHDIR")" ;;
-    *) cd "$JS_BINARY__CHDIR" ;;
-    esac
-fi
-
 # Gather node options
 JS_BINARY__NODE_OPTIONS=()
 {{node_options}}

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -91,9 +91,6 @@ def _js_run_devserver_impl(ctx):
     if ctx.attr.grant_sandbox_write_permissions:
         config["grant_sandbox_write_permissions"] = "1"
     if launcher.chdir:
-        # The devserver runs the tool in a sandbox that mirrors the runfiles tree, so it has to
-        # reproduce the working directory there itself. It cannot read JS_BINARY__CHDIR at
-        # runtime: bootstrap.cjs consumes that variable when it applies the chdir.
         config["chdir"] = launcher.chdir
 
     ctx.actions.write(config_file, json.encode(config))

--- a/js/private/js_run_devserver.bzl
+++ b/js/private/js_run_devserver.bzl
@@ -90,6 +90,11 @@ def _js_run_devserver_impl(ctx):
         config["command"] = ctx.attr.command
     if ctx.attr.grant_sandbox_write_permissions:
         config["grant_sandbox_write_permissions"] = "1"
+    if launcher.chdir:
+        # The devserver runs the tool in a sandbox that mirrors the runfiles tree, so it has to
+        # reproduce the working directory there itself. It cannot read JS_BINARY__CHDIR at
+        # runtime: bootstrap.cjs consumes that variable when it applies the chdir.
+        config["chdir"] = launcher.chdir
 
     ctx.actions.write(config_file, json.encode(config))
 

--- a/js/private/node-bootstrap/bootstrap.cjs
+++ b/js/private/node-bootstrap/bootstrap.cjs
@@ -29,11 +29,6 @@ if (JS_BINARY__CHDIR) {
               JS_BINARY__CHDIR
           )
         : JS_BINARY__CHDIR
-    if (JS_BINARY__LOG_DEBUG) {
-        console.error(
-            `DEBUG: ${JS_BINARY__LOG_PREFIX}: changing directory to user specified package ${dir}`
-        )
-    }
     try {
         process.chdir(dir)
     } catch (e) {

--- a/js/private/node-bootstrap/bootstrap.cjs
+++ b/js/private/node-bootstrap/bootstrap.cjs
@@ -18,18 +18,10 @@ const {
     JS_BINARY__PATCH_NODE_FS,
 } = process.env
 
-// working directory
-//
-// js_binary(chdir) / js_run_binary(chdir). The launcher leaves us in the root of the output
-// tree (or in the runfiles tree for a js_test) and hands the requested directory over in
-// JS_BINARY__CHDIR; the move itself happens here so that it does not depend on the launcher
-// being a shell script.
-//
-// Nothing in this process may observe the old cwd, so this runs before the fs patches and
-// before coverage.cjs, which snapshots process.cwd() for the reporter it later spawns.
+// Change directory as indicated by the chdir option on js_binary or js_run_binary.
 if (JS_BINARY__CHDIR) {
     // An "external/<repo>" chdir names a path in the bin directory rather than one relative to
-    // the cwd we were given, which for a js_test is the runfiles tree. See #2827.
+    // the cwd we were given, which for a js_test is the runfiles tree.
     const dir = JS_BINARY__CHDIR.startsWith('external/')
         ? require('node:path').join(
               JS_BINARY__EXECROOT,
@@ -50,13 +42,9 @@ if (JS_BINARY__CHDIR) {
         )
         process.exit(1)
     }
-    // process.chdir() does not maintain PWD, which bash cd did and which some tools read.
+    // process.chdir() does not maintain PWD, so let's update it here.
     process.env.PWD = process.cwd()
-    // The variable is an instruction to this process, and it has now been carried out, so
-    // consume it. A child node process re-enters this bootstrap through the node wrapper's
-    // --require, and a worker thread gets a copy of this environment; both already start in
-    // the directory we just moved to, and applying a relative chdir on top of it would
-    // compound (in a worker, process.chdir() throws outright).
+    // Prevent child processes and worker threads from attempting to cd a second time.
     delete process.env.JS_BINARY__CHDIR
 }
 

--- a/js/private/node-bootstrap/bootstrap.cjs
+++ b/js/private/node-bootstrap/bootstrap.cjs
@@ -7,12 +7,58 @@ if (process.env.NODE_COMPILE_CACHE) {
 
 const patchfs = require('./fs.cjs').patcher
 const {
+    BAZEL_BINDIR,
+    JS_BINARY__BINDIR,
+    JS_BINARY__CHDIR,
+    JS_BINARY__EXECROOT,
     JS_BINARY__FS_PATCH_ROOTS,
     JS_BINARY__LOG_DEBUG,
     JS_BINARY__LOG_PREFIX,
     JS_BINARY__NODE_WRAPPER,
     JS_BINARY__PATCH_NODE_FS,
 } = process.env
+
+// working directory
+//
+// js_binary(chdir) / js_run_binary(chdir). The launcher leaves us in the root of the output
+// tree (or in the runfiles tree for a js_test) and hands the requested directory over in
+// JS_BINARY__CHDIR; the move itself happens here so that it does not depend on the launcher
+// being a shell script.
+//
+// Nothing in this process may observe the old cwd, so this runs before the fs patches and
+// before coverage.cjs, which snapshots process.cwd() for the reporter it later spawns.
+if (JS_BINARY__CHDIR) {
+    // An "external/<repo>" chdir names a path in the bin directory rather than one relative to
+    // the cwd we were given, which for a js_test is the runfiles tree. See #2827.
+    const dir = JS_BINARY__CHDIR.startsWith('external/')
+        ? require('node:path').join(
+              JS_BINARY__EXECROOT,
+              BAZEL_BINDIR || JS_BINARY__BINDIR,
+              JS_BINARY__CHDIR
+          )
+        : JS_BINARY__CHDIR
+    if (JS_BINARY__LOG_DEBUG) {
+        console.error(
+            `DEBUG: ${JS_BINARY__LOG_PREFIX}: changing directory to user specified package ${dir}`
+        )
+    }
+    try {
+        process.chdir(dir)
+    } catch (e) {
+        console.error(
+            `FATAL: ${JS_BINARY__LOG_PREFIX}: could not change directory to '${dir}': ${e.message}`
+        )
+        process.exit(1)
+    }
+    // process.chdir() does not maintain PWD, which bash cd did and which some tools read.
+    process.env.PWD = process.cwd()
+    // The variable is an instruction to this process, and it has now been carried out, so
+    // consume it. A child node process re-enters this bootstrap through the node wrapper's
+    // --require, and a worker thread gets a copy of this environment; both already start in
+    // the directory we just moved to, and applying a relative chdir on top of it would
+    // compound (in a worker, process.chdir() throws outright).
+    delete process.env.JS_BINARY__CHDIR
+}
 
 // Keep a count of how many times these patches are applied; this should reflect the depth
 // of child processes in the default case where a child process inherits process.env since

--- a/js/private/test/chdir/BUILD.bazel
+++ b/js/private/test/chdir/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@bazel_lib//lib:testing.bzl", "assert_contains")
+load("//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
+
+# The chdir is applied by bootstrap.cjs rather than the launcher, so it has to hold for
+# every process that preloads it. cwd.mjs checks the cwd itself, a spawned node child and a
+# worker thread; the two rules below cover the two directories a chdir can be relative to:
+# the runfiles tree for a js_test and the bin directory for a build action.
+
+js_test(
+    name = "cwd_test",
+    chdir = package_name(),
+    entry_point = "cwd.mjs",
+)
+
+js_binary(
+    name = "cwd_bin",
+    chdir = package_name(),
+    entry_point = "cwd.mjs",
+)
+
+js_run_binary(
+    name = "cwd_run",
+    chdir = package_name(),
+    silent_on_success = False,
+    stdout = "cwd-stdout",
+    tool = ":cwd_bin",
+)
+
+assert_contains(
+    name = "cwd_run_test",
+    actual = ":cwd-stdout",
+    expected = "cwd: ",
+)
+
+assert_contains(
+    name = "cwd_run_package_test",
+    actual = ":cwd-stdout",
+    expected = "/bin/js/private/test/chdir",
+)
+
+# The debug line moved from the launcher to bootstrap.cjs along with the chdir itself.
+js_run_binary(
+    name = "cwd_debug",
+    chdir = package_name(),
+    log_level = "debug",
+    silent_on_success = False,
+    stderr = "cwd-stderr",
+    tool = ":cwd_bin",
+)
+
+assert_contains(
+    name = "cwd_debug_test",
+    actual = ":cwd-stderr",
+    expected = "DEBUG: aspect_rules_js[js_binary]: changing directory to user specified package js/private/test/chdir",
+)

--- a/js/private/test/chdir/BUILD.bazel
+++ b/js/private/test/chdir/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@bazel_lib//lib:testing.bzl", "assert_contains")
 load("//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
 
-# The chdir is applied by bootstrap.cjs rather than the launcher, so it has to hold for
-# every process that preloads it. cwd.mjs checks the cwd itself, a spawned node child and a
-# worker thread; the two rules below cover the two directories a chdir can be relative to:
-# the runfiles tree for a js_test and the bin directory for a build action.
+# The chdir is applied by bootstrap.cjs, so it has to hold for every process that preloads it.
+# cwd.mjs checks the cwd itself, a spawned node child and a worker thread; the two rules below
+# cover the two directories a chdir can be relative to: the runfiles tree for a js_test and the
+# bin directory for a build action.
 
 js_test(
     name = "cwd_test",
@@ -27,18 +27,11 @@ js_run_binary(
 )
 
 assert_contains(
-    name = "cwd_run_test",
-    actual = ":cwd-stdout",
-    expected = "cwd: ",
-)
-
-assert_contains(
     name = "cwd_run_package_test",
     actual = ":cwd-stdout",
     expected = "/bin/js/private/test/chdir",
 )
 
-# The debug line moved from the launcher to bootstrap.cjs along with the chdir itself.
 js_run_binary(
     name = "cwd_debug",
     chdir = package_name(),

--- a/js/private/test/chdir/BUILD.bazel
+++ b/js/private/test/chdir/BUILD.bazel
@@ -2,13 +2,31 @@ load("@bazel_lib//lib:testing.bzl", "assert_contains")
 load("//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
 
 # The chdir is applied by bootstrap.cjs, so it has to hold for every process that preloads it.
-# cwd.mjs checks the cwd itself, a spawned node child and a worker thread; the two rules below
-# cover the two directories a chdir can be relative to: the runfiles tree for a js_test and the
-# bin directory for a build action.
+# cwd.mjs checks the cwd itself, a spawned node child and a worker thread; the rules below cover
+# the two directories a chdir can be relative to -- the runfiles tree for a js_test and the bin
+# directory for a build action -- and the shapes a chdir value can take.
 
 js_test(
     name = "cwd_test",
+    args = [package_name()],
     chdir = package_name(),
+    entry_point = "cwd.mjs",
+)
+
+# A "." chdir does not move us, but it must still leave PWD and the JS_BINARY__CHDIR handoff in
+# the same state as any other chdir.
+js_test(
+    name = "cwd_dot_test",
+    chdir = ".",
+    entry_point = "cwd.mjs",
+)
+
+# ".." segments are resolved by the OS like in any other path, so a chdir may round-trip through
+# a parent directory.
+js_test(
+    name = "cwd_parent_test",
+    args = [package_name()],
+    chdir = package_name() + "/../chdir",
     entry_point = "cwd.mjs",
 )
 
@@ -20,6 +38,7 @@ js_binary(
 
 js_run_binary(
     name = "cwd_run",
+    args = [package_name()],
     chdir = package_name(),
     silent_on_success = False,
     stdout = "cwd-stdout",
@@ -30,4 +49,42 @@ assert_contains(
     name = "cwd_run_package_test",
     actual = ":cwd-stdout",
     expected = "/bin/js/private/test/chdir",
+)
+
+js_run_binary(
+    name = "cwd_parent_run",
+    args = [package_name()],
+    chdir = package_name() + "/../chdir",
+    silent_on_success = False,
+    stdout = "cwd-parent-stdout",
+    tool = ":cwd_bin",
+)
+
+assert_contains(
+    name = "cwd_parent_run_package_test",
+    actual = ":cwd-parent-stdout",
+    expected = "/bin/js/private/test/chdir",
+)
+
+# A chdir naming a directory that does not exist must fail loudly rather than silently leaving the
+# program in the wrong place. exit_code_out keeps the action itself successful so that the exit
+# code and message can be asserted on.
+js_run_binary(
+    name = "cwd_missing",
+    chdir = "does-not-exist",
+    exit_code_out = "cwd-missing-exit-code",
+    stderr = "cwd-missing-stderr",
+    tool = ":cwd_bin",
+)
+
+assert_contains(
+    name = "cwd_missing_exit_code_test",
+    actual = ":cwd-missing-exit-code",
+    expected = "1",
+)
+
+assert_contains(
+    name = "cwd_missing_stderr_test",
+    actual = ":cwd-missing-stderr",
+    expected = "could not change directory to 'does-not-exist'",
 )

--- a/js/private/test/chdir/BUILD.bazel
+++ b/js/private/test/chdir/BUILD.bazel
@@ -31,18 +31,3 @@ assert_contains(
     actual = ":cwd-stdout",
     expected = "/bin/js/private/test/chdir",
 )
-
-js_run_binary(
-    name = "cwd_debug",
-    chdir = package_name(),
-    log_level = "debug",
-    silent_on_success = False,
-    stderr = "cwd-stderr",
-    tool = ":cwd_bin",
-)
-
-assert_contains(
-    name = "cwd_debug_test",
-    actual = ":cwd-stderr",
-    expected = "DEBUG: aspect_rules_js[js_binary]: changing directory to user specified package js/private/test/chdir",
-)

--- a/js/private/test/chdir/cwd.mjs
+++ b/js/private/test/chdir/cwd.mjs
@@ -21,12 +21,9 @@ if (!cwd.endsWith(expectedSuffix)) {
     process.exitCode = 1
 }
 
-// The launcher used to `cd`, which keeps the exported PWD in step with the working
-// directory. process.chdir() does not, so bootstrap.cjs has to.
 check('process.env.PWD', process.env.PWD, cwd)
 
-// bootstrap.cjs consumes JS_BINARY__CHDIR when it applies it. That is what keeps the child
-// process and the worker thread below from moving a second time, so assert it directly.
+// bootstrap.cjs consumes JS_BINARY__CHDIR when it applies it.
 check('process.env.JS_BINARY__CHDIR', process.env.JS_BINARY__CHDIR, undefined)
 
 // A child node process re-enters bootstrap.cjs through the node wrapper's --require. It

--- a/js/private/test/chdir/cwd.mjs
+++ b/js/private/test/chdir/cwd.mjs
@@ -15,8 +15,10 @@ function check(what, actual, expected) {
     }
 }
 
-const expectedSuffix = path.join('js', 'private', 'test', 'chdir')
-if (!cwd.endsWith(expectedSuffix)) {
+// argv[2], when given, is a slash-separated path that the cwd must end with. It is omitted
+// when the chdir does not move us anywhere in particular, such as chdir = ".".
+const expectedSuffix = process.argv[2]?.split('/').join(path.sep)
+if (expectedSuffix && !cwd.endsWith(expectedSuffix)) {
     console.error(`FAIL: cwd '${cwd}' does not end with '${expectedSuffix}'`)
     process.exitCode = 1
 }

--- a/js/private/test/chdir/cwd.mjs
+++ b/js/private/test/chdir/cwd.mjs
@@ -1,0 +1,57 @@
+// Asserts that js_binary(chdir) lands the process in the right directory and that nothing
+// downstream of the process re-applies it. The move is done by bootstrap.cjs, which every
+// node process in the tree preloads, so a child node process and a worker thread are the
+// two places a second, compounding chdir could creep in.
+import { spawnSync } from 'node:child_process'
+import * as path from 'node:path'
+import { Worker } from 'node:worker_threads'
+
+const cwd = process.cwd()
+
+function check(what, actual, expected) {
+    if (actual !== expected) {
+        console.error(`FAIL: ${what}: expected '${expected}', got '${actual}'`)
+        process.exitCode = 1
+    }
+}
+
+const expectedSuffix = path.join('js', 'private', 'test', 'chdir')
+if (!cwd.endsWith(expectedSuffix)) {
+    console.error(`FAIL: cwd '${cwd}' does not end with '${expectedSuffix}'`)
+    process.exitCode = 1
+}
+
+// The launcher used to `cd`, which keeps the exported PWD in step with the working
+// directory. process.chdir() does not, so bootstrap.cjs has to.
+check('process.env.PWD', process.env.PWD, cwd)
+
+// bootstrap.cjs consumes JS_BINARY__CHDIR when it applies it. That is what keeps the child
+// process and the worker thread below from moving a second time, so assert it directly.
+check('process.env.JS_BINARY__CHDIR', process.env.JS_BINARY__CHDIR, undefined)
+
+// A child node process re-enters bootstrap.cjs through the node wrapper's --require. It
+// already inherits this cwd, so a relative chdir must not be applied a second time.
+const child = spawnSync('node', ['-e', 'console.log(process.cwd())'], {
+    encoding: 'utf8',
+})
+if (child.status !== 0) {
+    console.error(`FAIL: child exited ${child.status}: ${child.stderr}`)
+    process.exitCode = 1
+}
+check('child cwd', child.stdout.trim(), cwd)
+
+// Preloads run in worker threads too, where process.chdir() throws outright.
+const workerCwd = await new Promise((resolve, reject) => {
+    const worker = new Worker(
+        "require('node:worker_threads').parentPort.postMessage(process.cwd())",
+        { eval: true }
+    )
+    worker.on('message', resolve)
+    worker.on('error', reject)
+    worker.on('exit', () =>
+        reject(new Error('worker exited without a message'))
+    )
+})
+check('worker cwd', workerCwd, cwd)
+
+console.log(`cwd: ${cwd}`)

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-c9b05fddea6816e517b5d166300f5350975d43a2ede54b30ca25db59b7ad3dde  js/private/test/image/cksum_node.tar
+5d2fa8fccc429bb952c091f1403dcffda2ed785370d1c1fcda8e5e5008b131b8  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 2cb6f678d6eb0b2e9d5e2637f41ae3f192233752f1ea2a55cede2531deec2a64  js/private/test/image/cksum_package_store_1p.tar
 79afa99006aff19460354e72cf2634db693670d09ccc7531fbf27f1f20fe0a5f  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-5d2fa8fccc429bb952c091f1403dcffda2ed785370d1c1fcda8e5e5008b131b8  js/private/test/image/cksum_node.tar
+7f7aaeb89a22f2238c907f7434c3e07ad397700011691214266b09f18114079e  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 2cb6f678d6eb0b2e9d5e2637f41ae3f192233752f1ea2a55cede2531deec2a64  js/private/test/image/cksum_package_store_1p.tar
 79afa99006aff19460354e72cf2634db693670d09ccc7531fbf27f1f20fe0a5f  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/checksum_test.expected
+++ b/js/private/test/image/checksum_test.expected
@@ -1,4 +1,4 @@
-7f7aaeb89a22f2238c907f7434c3e07ad397700011691214266b09f18114079e  js/private/test/image/cksum_node.tar
+97511535490d677b58431c2c3074b9ec2eeb34b54254443c0a9e9c669e3705d5  js/private/test/image/cksum_node.tar
 70b10220a2c05d87da4271c17c38ded8febc725e20e06f1c3809d2bb02ba4ae7  js/private/test/image/cksum_package_store_3p.tar
 2cb6f678d6eb0b2e9d5e2637f41ae3f192233752f1ea2a55cede2531deec2a64  js/private/test/image/cksum_package_store_1p.tar
 79afa99006aff19460354e72cf2634db693670d09ccc7531fbf27f1f20fe0a5f  js/private/test/image/cksum_node_modules.tar

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_layers_nomatch_test_node.listing
+++ b/js/private/test/image/custom_layers_nomatch_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        2899 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 100    0        1832 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 100    0        3864 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 100    0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 100    0        3069 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 100    0        2899 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 100    0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/custom_owner_test_node.listing
+++ b/js/private/test/image/custom_owner_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 100    0        3864 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 100    0        3069 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 100    0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 100    0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        2899 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/default_test_node.listing
+++ b/js/private/test/image/default_test_node.listing
@@ -7,7 +7,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runf
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        2899 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/nodejs/

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/nodejs/

--- a/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
+++ b/js/private/test/image/non_ascii/custom_layer_groups_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/non_ascii/bin2.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/nodejs/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        2899 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
+++ b/js/private/test/image/platform_deps/rspack_linux_arm64_test_node.listing
@@ -9,7 +9,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/plat
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/platform_deps/bin.runfiles/rules_nodejs++node+nodejs_linux_arm64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        1832 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        3864 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/image/regex_edge_cases_test_node.listing
+++ b/js/private/test/image/regex_edge_cases_test_node.listing
@@ -8,7 +8,7 @@ drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/
--r-xr-xr-x  0 0      0        3069 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
+-r-xr-xr-x  0 0      0        2899 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/bootstrap.cjs
 -r-xr-xr-x  0 0      0       37120 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/_main/js/private/node-bootstrap/fs.cjs
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/
 drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/js/private/test/image/bin.runfiles/rules_nodejs++node+nodejs_linux_amd64/bin/

--- a/js/private/test/snapshots/launcher.sh
+++ b/js/private/test/snapshots/launcher.sh
@@ -483,15 +483,6 @@ if [ ! -f "$JS_BINARY__NODE_PATCHES" ]; then
     exit 1
 fi
 
-# Change directory to user specified package if set
-if [ "${JS_BINARY__CHDIR:-}" ]; then
-    logf_debug "changing directory to user specified package %s" "$JS_BINARY__CHDIR"
-    case "$JS_BINARY__CHDIR" in
-    external/*) cd "$(resolve_execroot_bin_path "$JS_BINARY__CHDIR")" ;;
-    *) cd "$JS_BINARY__CHDIR" ;;
-    esac
-fi
-
 # Gather node options
 JS_BINARY__NODE_OPTIONS=()
 JS_BINARY__NODE_OPTIONS+=("--preserve-symlinks-main")


### PR DESCRIPTION
This is one of the more complex behaviors remaining in the bash launcher, so let's move it into the node bootstrap in preparation for adopting hermetic_launcher.

bootstrap.cjs now cds into `JS_BINARY__CHDIR` before deleting that variable. Deleting it prevents child processes or worker threads from attempting to cd to that same directory a second time.

This necessitated updating `js_run_devserver` to pass the normalized chdir value via the devserver's JSON config instead of through `JS_BINARY__CHDIR`.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
