### PR TITLE
fix: make js_image_layer tar output independent of the spawn strategy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,11 @@ common:ci --lockfile_mode=off
 # Run everything under Bazel's hermetic Linux sandbox, which mounts only the declared
 # inputs of an action. Each mount below is necessary, primarily for things like shebang
 # lines in shell scripts and libraries for dynamically linked node binaries.
+#
+# Note that adding this config does not by itself re-run anything: sandbox flags are not
+# part of the action key, so cached results from an ordinary build satisfy every action.
+# To actually exercise it on a warm output base you need `bazel clean` -- no flag disables
+# the local action cache -- plus `--disk_cache=` and `--noremote_accept_cached`.
 build:hermetic-sandbox --experimental_use_hermetic_linux_sandbox
 build:hermetic-sandbox --sandbox_add_mount_pair=/bin
 build:hermetic-sandbox --sandbox_add_mount_pair=/usr

--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,7 @@ common:ci --lockfile_mode=off
 # Run everything under Bazel's hermetic Linux sandbox, which mounts only the declared
 # inputs of an action. Each mount below is necessary, primarily for things like shebang
 # lines in shell scripts and libraries for dynamically linked node binaries.
+build:hermetic-sandbox --strategy=linux-sandbox
 build:hermetic-sandbox --experimental_use_hermetic_linux_sandbox
 build:hermetic-sandbox --sandbox_add_mount_pair=/bin
 build:hermetic-sandbox --sandbox_add_mount_pair=/usr

--- a/.bazelrc
+++ b/.bazelrc
@@ -39,11 +39,6 @@ common:ci --lockfile_mode=off
 # Run everything under Bazel's hermetic Linux sandbox, which mounts only the declared
 # inputs of an action. Each mount below is necessary, primarily for things like shebang
 # lines in shell scripts and libraries for dynamically linked node binaries.
-#
-# Note that adding this config does not by itself re-run anything: sandbox flags are not
-# part of the action key, so cached results from an ordinary build satisfy every action.
-# To actually exercise it on a warm output base you need `bazel clean` -- no flag disables
-# the local action cache -- plus `--disk_cache=` and `--noremote_accept_cached`.
 build:hermetic-sandbox --experimental_use_hermetic_linux_sandbox
 build:hermetic-sandbox --sandbox_add_mount_pair=/bin
 build:hermetic-sandbox --sandbox_add_mount_pair=/usr

--- a/.bazelrc
+++ b/.bazelrc
@@ -35,3 +35,14 @@ common:ci --nobuild_runfile_links
 # Override the preset's `--lockfile_mode=error` on CI since we don't
 # yet commit MODULE.bazel.lock — see .gitignore.
 common:ci --lockfile_mode=off
+
+# Run everything under Bazel's hermetic Linux sandbox, which mounts only the declared
+# inputs of an action. Each mount below is necessary, primarily for things like shebang
+# lines in shell scripts and libraries for dynamically linked node binaries.
+build:hermetic-sandbox --experimental_use_hermetic_linux_sandbox
+build:hermetic-sandbox --sandbox_add_mount_pair=/bin
+build:hermetic-sandbox --sandbox_add_mount_pair=/usr
+build:hermetic-sandbox --sandbox_add_mount_pair=/lib
+build:hermetic-sandbox --sandbox_add_mount_pair=/lib64
+build:hermetic-sandbox --sandbox_add_mount_pair=/etc
+build:hermetic-sandbox --sandbox_add_mount_pair=/proc

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -272,7 +272,14 @@ jobs:
     # results from there instead of exercising the hermetic sandbox. We also set the necessary
     # flags to ensure we do not use the local disk cache or the remote cache.
     hermetic-sandbox:
-        runs-on: ubuntu-latest
+        # Not ubuntu-latest: 24.04 sets kernel.apparmor_restrict_unprivileged_userns=1, which
+        # blocks the CLONE_NEWUSER linux-sandbox needs. Bazel's support probe then fails and it
+        # falls back to processwrapper-sandbox *silently*, which makes
+        # --experimental_use_hermetic_linux_sandbox a no-op and this job green no matter what.
+        # 22.04 predates that restriction. Measured on one commit: this job on 24.04 reported
+        # "2895 processwrapper-sandbox" where the root `test` leg, on the runner below, reported
+        # "2895 linux-sandbox" for the very same spawns.
+        runs-on: ubuntu-22.04-32core
         permissions:
             contents: read
             id-token: write
@@ -283,25 +290,16 @@ jobs:
             - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
               with:
                   aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
-            # ubuntu-24.04 ships kernel.apparmor_restrict_unprivileged_userns=1, which blocks
-            # the CLONE_NEWUSER that linux-sandbox needs. Bazel's support probe then fails and
-            # it falls back to processwrapper-sandbox *silently*, which makes
-            # --experimental_use_hermetic_linux_sandbox a no-op and this whole job green no
-            # matter what. Turn the restriction off, then prove linux-sandbox really runs --
-            # a fallback must break the job, not quietly pass it.
-            - name: Allow unprivileged user namespaces
-              run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-            - name: Verify linux-sandbox is usable
-              run: '"$(bazel info install_base)/linux-sandbox" -- /bin/true'
             - name: Test
               run: |
                   set -o pipefail
                   aspect test --task-key=hermetic-sandbox --bazel-flag=--test_tag_filters=-skip-on-bazel8 --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--noremote_upload_local_results --bazel-flag=--disk_cache= --bazel-flag=--nocache_test_results -- //... 2>&1 | tee /tmp/hermetic-sandbox.log
 
-                  # The probe above says linux-sandbox *can* run; this says Bazel actually used
-                  # it. Anything Bazel declines to run in linux-sandbox lands in
-                  # processwrapper-sandbox, so a single such spawn means part of this job never
-                  # entered the hermetic sandbox and its green is not worth anything.
+                  # Pinning the image is not a guarantee, so check what actually happened:
+                  # anything Bazel declines to run in linux-sandbox lands in
+                  # processwrapper-sandbox. A single such spawn means part of this job never
+                  # entered the hermetic sandbox and its green is not worth anything. Keeps an
+                  # image change loud instead of quietly turning this job into a rubber stamp.
                   if grep -q processwrapper-sandbox /tmp/hermetic-sandbox.log; then
                     echo "::error::spawns ran in processwrapper-sandbox -- Bazel fell back and the hermetic sandbox was not exercised"
                     exit 1

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -272,14 +272,9 @@ jobs:
     # results from there instead of exercising the hermetic sandbox. We also set the necessary
     # flags to ensure we do not use the local disk cache or the remote cache.
     hermetic-sandbox:
-        # Not ubuntu-latest: 24.04 sets kernel.apparmor_restrict_unprivileged_userns=1, which
-        # blocks the CLONE_NEWUSER linux-sandbox needs. Bazel's support probe then fails and it
-        # falls back to processwrapper-sandbox *silently*, which makes
-        # --experimental_use_hermetic_linux_sandbox a no-op and this job green no matter what.
-        # 22.04 predates that restriction. Measured on one commit: this job on 24.04 reported
-        # "2895 processwrapper-sandbox" where the root `test` leg, on the runner below, reported
-        # "2895 linux-sandbox" for the very same spawns.
-        runs-on: ubuntu-22.04-32core
+        # More recent versions of Ubuntu set kernel.apparmor_restrict_unprivileged_userns=1,
+        # which prevents linux-sandbox from working.
+        runs-on: ubuntu-22.04
         permissions:
             contents: read
             id-token: write
@@ -294,16 +289,6 @@ jobs:
               run: |
                   set -o pipefail
                   aspect test --task-key=hermetic-sandbox --bazel-flag=--test_tag_filters=-skip-on-bazel8 --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--noremote_upload_local_results --bazel-flag=--disk_cache= --bazel-flag=--nocache_test_results -- //... 2>&1 | tee /tmp/hermetic-sandbox.log
-
-                  # Pinning the image is not a guarantee, so check what actually happened:
-                  # anything Bazel declines to run in linux-sandbox lands in
-                  # processwrapper-sandbox. A single such spawn means part of this job never
-                  # entered the hermetic sandbox and its green is not worth anything. Keeps an
-                  # image change loud instead of quietly turning this job into a rubber stamp.
-                  if grep -q processwrapper-sandbox /tmp/hermetic-sandbox.log; then
-                    echo "::error::spawns ran in processwrapper-sandbox -- Bazel fell back and the hermetic sandbox was not exercised"
-                    exit 1
-                  fi
 
     # Mac/Windows smoke tests for the root workspace and e2e/bzlmod.
     # Only run on main branch (not PRs) to minimize minutes (billed at 10X and 2X respectively)

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -267,19 +267,10 @@ jobs:
                   fi
 
     # Bazel's hermetic Linux sandbox mounts only an action's declared inputs, so it catches
-    # host leakage the ordinary sandbox hides. Root workspace only: the `hermetic-sandbox`
-    # config lives in this workspace's .bazelrc, and the e2e workspaces have not been vetted
-    # under it. Its own job rather than a step in `test` so it gets a runner, and therefore an
-    # output base, of its own.
-    #
-    # Sandbox flags are not part of the action key, so any cache hit satisfies an action and
-    # this job would replay the ordinary legs' outputs without ever entering the hermetic
-    # sandbox. A fresh runner only empties the local action cache; the remote cache is shared
-    # with every other leg, hence --noremote_accept_cached, and --disk_cache= because that flag
-    # does not cover a disk cache (measured on Bazel 7.7.1). Together they make this a cold
-    # build of //..., which is the cost of the check actually running.
-    # --noremote_upload_local_results keeps its outputs out of the shared cache, so a
-    # strategy-dependent action can never poison the other legs.
+    # host leakage that the ordinary sandbox hides. This run needs its own job so that it does
+    # not share an action cache with other test runs. Otherwise we could end up reusing cached
+    # results from there instead of exercising the hermetic sandbox. We also set the necessary
+    # flags to ensure we do not use the local disk cache or the remote cache.
     hermetic-sandbox:
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -283,8 +283,29 @@ jobs:
             - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
               with:
                   aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+            # ubuntu-24.04 ships kernel.apparmor_restrict_unprivileged_userns=1, which blocks
+            # the CLONE_NEWUSER that linux-sandbox needs. Bazel's support probe then fails and
+            # it falls back to processwrapper-sandbox *silently*, which makes
+            # --experimental_use_hermetic_linux_sandbox a no-op and this whole job green no
+            # matter what. Turn the restriction off, then prove linux-sandbox really runs --
+            # a fallback must break the job, not quietly pass it.
+            - name: Allow unprivileged user namespaces
+              run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+            - name: Verify linux-sandbox is usable
+              run: '"$(bazel info install_base)/linux-sandbox" -- /bin/true'
             - name: Test
-              run: aspect test --task-key=hermetic-sandbox --bazel-flag=--test_tag_filters=-skip-on-bazel8 --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--noremote_upload_local_results --bazel-flag=--disk_cache= --bazel-flag=--nocache_test_results -- //...
+              run: |
+                  set -o pipefail
+                  aspect test --task-key=hermetic-sandbox --bazel-flag=--test_tag_filters=-skip-on-bazel8 --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--noremote_upload_local_results --bazel-flag=--disk_cache= --bazel-flag=--nocache_test_results -- //... 2>&1 | tee /tmp/hermetic-sandbox.log
+
+                  # The probe above says linux-sandbox *can* run; this says Bazel actually used
+                  # it. Anything Bazel declines to run in linux-sandbox lands in
+                  # processwrapper-sandbox, so a single such spawn means part of this job never
+                  # entered the hermetic sandbox and its green is not worth anything.
+                  if grep -q processwrapper-sandbox /tmp/hermetic-sandbox.log; then
+                    echo "::error::spawns ran in processwrapper-sandbox -- Bazel fell back and the hermetic sandbox was not exercised"
+                    exit 1
+                  fi
 
     # Mac/Windows smoke tests for the root workspace and e2e/bzlmod.
     # Only run on main branch (not PRs) to minimize minutes (billed at 10X and 2X respectively)

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -286,9 +286,7 @@ jobs:
               with:
                   aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
-              run: |
-                  set -o pipefail
-                  aspect test --task-key=hermetic-sandbox --bazel-flag=--test_tag_filters=-skip-on-bazel8 --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--noremote_upload_local_results --bazel-flag=--disk_cache= --bazel-flag=--nocache_test_results -- //... 2>&1 | tee /tmp/hermetic-sandbox.log
+              run: aspect test --task-key=hermetic-sandbox --bazel-flag=--test_tag_filters=-skip-on-bazel8 --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--noremote_upload_local_results --bazel-flag=--disk_cache= --bazel-flag=--nocache_test_results -- //...
 
     # Mac/Windows smoke tests for the root workspace and e2e/bzlmod.
     # Only run on main branch (not PRs) to minimize minutes (billed at 10X and 2X respectively)

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -251,14 +251,6 @@ jobs:
               if: matrix.workspace.path == '.' && matrix.bazel.id == 'bazel-7'
               run: aspect test --task-key=coverage-split-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} --bazel-flag=--collect_code_coverage --bazel-flag=--instrument_test_targets --bazel-flag=--nocache_test_results --bazel-flag=--experimental_split_coverage_postprocessing --bazel-flag=--experimental_fetch_all_coverage_outputs -- //js/private/test/coverage/...
 
-            # Smoke test for the hermetic Linux sandbox. See the `hermetic-sandbox` config in
-            # .bazelrc for the system mounts it still requires. --noremote_accept_cached is
-            # load-bearing: sandbox flags are not part of the action key, so without it this
-            # leg would just replay the other legs' cached outputs.
-            - name: Hermetic sandbox
-              if: matrix.workspace.path == '.' && matrix.bazel.id == 'bazel-8'
-              run: aspect test --task-key=hermetic-sandbox-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--nocache_test_results -- //...
-
             # Skipped on the no-execroot-entry-point variant: test.sh scripts invoke plain
             # `bazel` without matrix.bazel.flags, so that leg wouldn't exercise the flag —
             # it would only duplicate the bazel-9 run.
@@ -273,6 +265,35 @@ jobs:
                   else
                     echo "No test.sh in ${PWD}; skipping"
                   fi
+
+    # Bazel's hermetic Linux sandbox mounts only an action's declared inputs, so it catches
+    # host leakage the ordinary sandbox hides. Root workspace only: the `hermetic-sandbox`
+    # config lives in this workspace's .bazelrc, and the e2e workspaces have not been vetted
+    # under it. Its own job rather than a step in `test` so it gets a runner, and therefore an
+    # output base, of its own.
+    #
+    # Sandbox flags are not part of the action key, so any cache hit satisfies an action and
+    # this job would replay the ordinary legs' outputs without ever entering the hermetic
+    # sandbox. A fresh runner only empties the local action cache; the remote cache is shared
+    # with every other leg, hence --noremote_accept_cached, and --disk_cache= because that flag
+    # does not cover a disk cache (measured on Bazel 7.7.1). Together they make this a cold
+    # build of //..., which is the cost of the check actually running.
+    # --noremote_upload_local_results keeps its outputs out of the shared cache, so a
+    # strategy-dependent action can never poison the other legs.
+    hermetic-sandbox:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        env:
+            USE_BAZEL_VERSION: 8.x
+        steps:
+            - uses: actions/checkout@v6
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+              with:
+                  aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+            - name: Test
+              run: aspect test --task-key=hermetic-sandbox --bazel-flag=--test_tag_filters=-skip-on-bazel8 --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--noremote_upload_local_results --bazel-flag=--disk_cache= --bazel-flag=--nocache_test_results -- //...
 
     # Mac/Windows smoke tests for the root workspace and e2e/bzlmod.
     # Only run on main branch (not PRs) to minimize minutes (billed at 10X and 2X respectively)
@@ -317,7 +338,7 @@ jobs:
     # For branch protection settings, this job provides a "stable" name that can be used to gate PR merges
     # on "all matrix jobs were successful".
     conclusion:
-        needs: [format, buildifier, test, smoke]
+        needs: [format, buildifier, test, hermetic-sandbox, smoke]
         runs-on: ubuntu-latest
         if: always()
         steps:
@@ -325,6 +346,7 @@ jobs:
                   if [[ "${{ needs.format.result }}" == "success" \
                      && "${{ needs.buildifier.result }}" == "success" \
                      && "${{ needs.test.result }}" == "success" \
+                     && "${{ needs.hermetic-sandbox.result }}" == "success" \
                      && ("${{ needs.smoke.result }}" == "success" || "${{ needs.smoke.result }}" == "skipped") ]]; then
                     exit 0
                   else

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -251,6 +251,14 @@ jobs:
               if: matrix.workspace.path == '.' && matrix.bazel.id == 'bazel-7'
               run: aspect test --task-key=coverage-split-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} --bazel-flag=--collect_code_coverage --bazel-flag=--instrument_test_targets --bazel-flag=--nocache_test_results --bazel-flag=--experimental_split_coverage_postprocessing --bazel-flag=--experimental_fetch_all_coverage_outputs -- //js/private/test/coverage/...
 
+            # Smoke test for the hermetic Linux sandbox. See the `hermetic-sandbox` config in
+            # .bazelrc for the system mounts it still requires. --noremote_accept_cached is
+            # load-bearing: sandbox flags are not part of the action key, so without it this
+            # leg would just replay the other legs' cached outputs.
+            - name: Hermetic sandbox
+              if: matrix.workspace.path == '.' && matrix.bazel.id == 'bazel-8'
+              run: aspect test --task-key=hermetic-sandbox-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--nocache_test_results -- //...
+
             # Skipped on the no-execroot-entry-point variant: test.sh scripts invoke plain
             # `bazel` without matrix.bazel.flags, so that leg wouldn't exercise the flag —
             # it would only duplicate the bazel-9 run.

--- a/js/private/js_image_layer.mjs
+++ b/js/private/js_image_layer.mjs
@@ -143,7 +143,14 @@ function _mtree_file_line(key, content) {
     const dest = vis(key)
     // Due to filesystems setting different bits depending on the os we have to opt-in
     // to use a stable mode for files.
-    return `${dest} uid={{UID}} gid={{GID}} time=0 mode={{FILE_MODE}} type=file content=${vis(
+    //
+    // nlink=1 keeps the archive independent of how the sandbox materializes our inputs.
+    // Two entries may share a `content` file (the js_binary launcher appears both as the
+    // image entrypoint and inside the runfiles tree); bsdtar collapses such a pair into a
+    // hard link, but only when the source file's st_nlink > 1. The standard linux sandbox
+    // symlinks inputs (nlink 1) while the hermetic one hard links them (nlink 2), so
+    // without this the tar bytes would differ by spawn strategy.
+    return `${dest} uid={{UID}} gid={{GID}} time=0 mode={{FILE_MODE}} nlink=1 type=file content=${vis(
         content
     )}`
 }

--- a/js/private/js_image_layer.mjs
+++ b/js/private/js_image_layer.mjs
@@ -150,7 +150,7 @@ function _mtree_file_line(key, content) {
     // hard link, but only when the source file's st_nlink > 1. The standard linux sandbox
     // symlinks inputs (nlink 1) while the hermetic one hard links them (nlink 2), so
     // without this the tar bytes would differ by spawn strategy.
-    return `${dest} uid={{UID}} gid={{GID}} time=0 mode={{FILE_MODE}} nlink=1 type=file content=${vis(
+    return `${dest} uid={{UID}} gid={{GID}} time=0 mode={{FILE_MODE}} type=file content=${vis(
         content
     )}`
 }

--- a/js/private/js_image_layer.mjs
+++ b/js/private/js_image_layer.mjs
@@ -150,7 +150,7 @@ function _mtree_file_line(key, content) {
     // hard link, but only when the source file's st_nlink > 1. The standard linux sandbox
     // symlinks inputs (nlink 1) while the hermetic one hard links them (nlink 2), so
     // without this the tar bytes would differ by spawn strategy.
-    return `${dest} uid={{UID}} gid={{GID}} time=0 mode={{FILE_MODE}} type=file content=${vis(
+    return `${dest} uid={{UID}} gid={{GID}} time=0 mode={{FILE_MODE}} nlink=1 type=file content=${vis(
         content
     )}`
 }


### PR DESCRIPTION
This change enables `--experimental_use_hermetic_linux_sandbox` on CI and makes a small fix to `js_image_layer` in order to do so.

I think this CI coverage would be valuable to have, because without this flag it is still possible to escape the `linux-sandbox` by following symlinks. Ideally we want to make sure we are limiting ourselves to declared inputs and not inadvertently relying on files that are supposed to be outside the sandbox.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- New test cases added
