### PR TITLE
perf: drive the coverage report from the manifest, not a runfiles glob

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -253,54 +253,6 @@ For the same reason the report is produced by the target's own `node_toolchain`,
 not by the one used for build actions. A test pinned to an old Node version runs
 the coverage reporter under that version too.
 
-To see where a slow report spends its time, run the test with
-`--test_env=JS_BINARY__LOG_DEBUG=1 --test_output=all`. The reporter logs the
-manifest size and its own phase timings.
-
-### Why `bazel coverage` is slower than `bazel test`
-
-Coverage mode does not invalidate build artifacts: with a warm action cache the
-build graph is byte-identical, and build tools are never instrumented because
-`js_run_binary` runs them in the exec configuration, where coverage is off. What
-`bazel coverage` adds is work per test, plus some fixed setup. Four costs are
-worth knowing about, and three of them are yours to control.
-
-**Runfiles trees are materialized.** rules_js recommends
-`--nobuild_runfile_links`, and `tools/preset.bazelrc` sets it — but it also sets
-`coverage --build_runfile_links`, because the reporter maps coverage data back
-onto sources through the runfiles tree
-([bazelbuild/bazel#20577](https://github.com/bazelbuild/bazel/issues/20577)).
-Coverage therefore materializes a runfiles tree for every `js_binary` and
-`js_test` in the build, which `bazel test` skips entirely. For rules_js those
-trees are node_modules-sized, so scope coverage runs to the targets you actually
-want a report for rather than `//...`.
-
-**Toggling coverage discards the analysis cache.** `--collect_code_coverage` is
-part of the build configuration, so alternating `bazel test` and `bazel coverage`
-in one output base re-analyses the graph each time. Coverage mode also pulls in
-the Java, C++ and Python coverage tooling — `@remote_coverage_tools//:Main` and
-its toolchains — which a JS-only repo otherwise never builds or fetches, and
-which rules_js does not use since it supplies its own `_lcov_merger`. Give
-coverage its own output base:
-
-```sh
-bazel --output_base=$(bazel info output_base)-coverage coverage //...
-```
-
-`--output_base` is a startup flag, so it cannot be scoped with a `coverage:` line
-in `.bazelrc`; use a wrapper script or a shell alias.
-
-**Instrumentation is broader than you probably want.** The default
-`--instrumentation_filter` covers essentially everything, which grows every
-test's `COVERAGE_MANIFEST` and adds a `BaselineCoverage` action per instrumented
-target. Narrow it to the packages you want reported:
-
-```sh
-bazel coverage --instrumentation_filter='^//src[/:]' //...
-```
-
-**Report generation is proportional to the manifest.** See the section above.
-
 ### Code run from the program's own `exit` listeners is not covered
 
 The reporter is registered by a `--require` preload, so it necessarily runs

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -253,6 +253,54 @@ For the same reason the report is produced by the target's own `node_toolchain`,
 not by the one used for build actions. A test pinned to an old Node version runs
 the coverage reporter under that version too.
 
+To see where a slow report spends its time, run the test with
+`--test_env=JS_BINARY__LOG_DEBUG=1 --test_output=all`. The reporter logs the
+manifest size and its own phase timings.
+
+### Why `bazel coverage` is slower than `bazel test`
+
+Coverage mode does not invalidate build artifacts: with a warm action cache the
+build graph is byte-identical, and build tools are never instrumented because
+`js_run_binary` runs them in the exec configuration, where coverage is off. What
+`bazel coverage` adds is work per test, plus some fixed setup. Four costs are
+worth knowing about, and three of them are yours to control.
+
+**Runfiles trees are materialized.** rules_js recommends
+`--nobuild_runfile_links`, and `tools/preset.bazelrc` sets it — but it also sets
+`coverage --build_runfile_links`, because the reporter maps coverage data back
+onto sources through the runfiles tree
+([bazelbuild/bazel#20577](https://github.com/bazelbuild/bazel/issues/20577)).
+Coverage therefore materializes a runfiles tree for every `js_binary` and
+`js_test` in the build, which `bazel test` skips entirely. For rules_js those
+trees are node_modules-sized, so scope coverage runs to the targets you actually
+want a report for rather than `//...`.
+
+**Toggling coverage discards the analysis cache.** `--collect_code_coverage` is
+part of the build configuration, so alternating `bazel test` and `bazel coverage`
+in one output base re-analyses the graph each time. Coverage mode also pulls in
+the Java, C++ and Python coverage tooling — `@remote_coverage_tools//:Main` and
+its toolchains — which a JS-only repo otherwise never builds or fetches, and
+which rules_js does not use since it supplies its own `_lcov_merger`. Give
+coverage its own output base:
+
+```sh
+bazel --output_base=$(bazel info output_base)-coverage coverage //...
+```
+
+`--output_base` is a startup flag, so it cannot be scoped with a `coverage:` line
+in `.bazelrc`; use a wrapper script or a shell alias.
+
+**Instrumentation is broader than you probably want.** The default
+`--instrumentation_filter` covers essentially everything, which grows every
+test's `COVERAGE_MANIFEST` and adds a `BaselineCoverage` action per instrumented
+target. Narrow it to the packages you want reported:
+
+```sh
+bazel coverage --instrumentation_filter='^//src[/:]' //...
+```
+
+**Report generation is proportional to the manifest.** See the section above.
+
 ### Code run from the program's own `exit` listeners is not covered
 
 The reporter is registered by a `--require` preload, so it necessarily runs

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -41,9 +41,15 @@ const pwd = path.join(
 )
 process.chdir(pwd)
 
+// Same list as COVERAGE_EXTENSIONS in js/private/coverage/extensions.bzl, which is what
+// decides the contents of COVERAGE_MANIFEST. c8 drops a manifest entry whose extension is
+// not listed here, so the two must agree; c8's own default list has neither .mts nor .cts.
+const extensions = new Set(['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx', '.tsx'])
+
 const report = new Report({
     include: include,
     exclude: include.length === 0 ? ['**'] : [],
+    extension: [...extensions],
     reportsDirectory: process.env.COVERAGE_DIR,
     tempDirectory: process.env.COVERAGE_DIR,
     resolve: '',
@@ -51,15 +57,6 @@ const report = new Report({
     all: true,
     reporter: ['lcovonly'],
 })
-
-// js_binary's instrumentation lists .mts and .cts, so they reach COVERAGE_MANIFEST, but
-// c8's default extension list has neither and would drop them from the report.
-for (const ext of ['.mts', '.cts']) {
-    if (!report.exclude.extension.includes(ext)) {
-        report.exclude.extension.push(ext)
-    }
-}
-const extensions = new Set(report.exclude.extension)
 
 // Bazel already computed the exact set of instrumented files and handed it to us in
 // COVERAGE_MANIFEST, so membership is a lookup. c8 otherwise answers the same question by

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -2,9 +2,30 @@ import { Report } from 'c8'
 import fs from 'fs'
 import path from 'path'
 
-// Runs in the test action, the only place the V8 data and instrumented sources are
+// Runs in the test action, the only place the V8 data and the instrumented sources are
 // both present. coverage.sh.tpl reads back this exact filename; keep them in sync.
 const stash = path.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov')
+
+const debug = !!process.env.JS_BINARY__LOG_DEBUG
+const timings = []
+
+// Report generation is charged against the test's own timeout, so when something is slow
+// this is the only place that says which part. See docs/troubleshooting.md.
+function logDebug(message) {
+    if (debug) {
+        console.error(`DEBUG: ${process.env.JS_BINARY__LOG_PREFIX}: ${message}`)
+    }
+}
+
+function timed(label, fn) {
+    if (!debug) return fn()
+    const start = process.hrtime.bigint()
+    const value = fn()
+    timings.push(`${label}=${(Number(process.hrtime.bigint() - start) / 1e6).toFixed(0)}ms`)
+    return value
+}
+
+const started = process.hrtime.bigint()
 
 const include = fs
     .readFileSync(process.env.COVERAGE_MANIFEST)
@@ -20,7 +41,7 @@ const pwd = path.join(
 )
 process.chdir(pwd)
 
-new Report({
+const report = new Report({
     include: include,
     exclude: include.length === 0 ? ['**'] : [],
     reportsDirectory: process.env.COVERAGE_DIR,
@@ -30,9 +51,52 @@ new Report({
     all: true,
     reporter: ['lcovonly'],
 })
+
+// js_binary's instrumentation lists .mts and .cts, so they reach COVERAGE_MANIFEST, but
+// c8's default extension list has neither and would drop them from the report.
+for (const ext of ['.mts', '.cts']) {
+    if (!report.exclude.extension.includes(ext)) {
+        report.exclude.extension.push(ext)
+    }
+}
+const extensions = new Set(report.exclude.extension)
+
+// Bazel already computed the exact set of instrumented files and handed it to us in
+// COVERAGE_MANIFEST, so membership is a lookup. c8 otherwise answers the same question by
+// globbing the whole runfiles tree under `src` and minimatching every hit against every
+// manifest entry -- and TestExclude expands each entry into two patterns -- which is
+// O(files in runfiles x manifest entries) in each test action. Both hooks below replace
+// that with the set Bazel already knows.
+const instrumented = new Set(include.map((f) => path.resolve(pwd, f)))
+
+report.exclude.shouldInstrument = function shouldInstrument(filename) {
+    const resolved = path.resolve(pwd, filename)
+    return extensions.has(path.extname(resolved)) && instrumented.has(resolved)
+}
+
+// `all: true` reports files no test executed. Those are exactly the manifest entries no
+// V8 profile mentioned, so the directory walk this replaces could only ever have found a
+// subset of them. Non-existent entries must be filtered out here rather than left to
+// c8: it stats each returned path without guarding, where the glob simply never yielded
+// a path that was not on disk.
+report.exclude.globSync = function globSync() {
+    return timed('uncovered_scan', () =>
+        include.filter((f) => fs.existsSync(path.resolve(pwd, f)))
+    )
+}
+
+logDebug(
+    `coverage manifest ${process.env.COVERAGE_MANIFEST}: ${include.length} entries`
+)
+
+report
     .run()
     .then(() => {
         fs.renameSync(path.join(process.env.COVERAGE_DIR, 'lcov.info'), stash)
+        const total = (Number(process.hrtime.bigint() - started) / 1e6).toFixed(0)
+        logDebug(
+            `coverage report generated in ${total}ms${timings.length ? ` (${timings.join(' ')})` : ''}`
+        )
     })
     .catch((err) => {
         console.error(err)

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -8,8 +8,6 @@ const stash = path.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov')
 
 const LOG_DEBUG = !!process.env.JS_BINARY__LOG_DEBUG
 
-// Report generation is charged against the test's own timeout, so when something is slow
-// this is the only place that says so.
 function logDebug(message) {
     if (LOG_DEBUG) {
         console.error(`DEBUG: ${process.env.JS_BINARY__LOG_PREFIX}: ${message}`)
@@ -37,20 +35,16 @@ process.chdir(pwd)
 // not listed here, so the two must agree; c8's own default list has neither .mts nor .cts.
 const extensions = new Set(['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx', '.tsx'])
 
-// c8's Report asks its `exclude` object three questions: which executed scripts belong
-// in the report, which unexecuted files belong in it, and which extensions are
-// instrumentable at all. Bazel already answered all three in COVERAGE_MANIFEST.
-//
-// test-exclude answers them by globbing the whole runfiles tree and minimatching every
-// hit against every manifest entry -- and prepGlobPatterns expands each entry into
-// several patterns -- which is O(files in runfiles x manifest entries) in each test
-// action, charged against the test's own timeout. This replaces it with lookups against
-// the set Bazel handed us.
-//
-// It replaces the object rather than patching methods on it, so a method c8 starts
-// calling that we have not implemented fails loudly instead of silently falling back to
-// the tree walk. Standing in for, pinned to the version c8 10.1.3 resolves:
+// We provide our own implementation of the TestExclude class from here:
 // https://github.com/istanbuljs/test-exclude/blob/3a37faa17cc4f0f602a7c1ec23ef0b0fcf44ab37/index.js
+// The upstream TestExclude is inefficient for our use case, because it globs the whole
+// runfiles tree and matches every result individually against every entry in the coverage
+// manifest. This is O(number of runfiles * number of coverage manifest entries), or quadratic
+// in the number of runfiles if you assume that those two quantities are proportional to each
+// other. Our implementation is careful to avoid this quadratic scaling.
+//
+// We do not implement every method from the original class, only the ones that Report calls.
+// If Report changes then this may break, but it should fail in a loud way that we can address.
 class ManifestExclude {
     constructor(root, files, extensions) {
         this.root = root
@@ -62,40 +56,20 @@ class ManifestExclude {
         this.extension = [...extensions]
     }
 
-    // index.js#L76. c8 asks this of every executed script, so the original costs manifest
-    // size times scripts loaded. extname does not care whether a path is resolved, so
-    // reject on extension first and skip the resolve for anything uninstrumentable.
     shouldInstrument(filename) {
         if (!this.extensions.has(path.extname(filename))) return false
         return this.instrumented.has(path.resolve(this.root, filename))
     }
 
-    // index.js#L105. c8 calls this from _includeUncoveredFiles, the `all: true` pass that
-    // reports files no test executed. Those are exactly the manifest entries no V8 profile
-    // mentioned, so the walk it replaces could only ever have found a subset of them.
-    //
-    // Entries not on disk must be dropped here rather than left to c8: it stats each
-    // returned path without guarding, where a real glob never yields a path that is not
-    // there. A manifest entry need not be in this test's runfiles -- a first-party library
-    // repackaged by npm_package reaches the manifest at its source path but reaches
-    // runfiles only as a copy inside the node_modules store.
     globSync(cwd = this.root) {
-        // c8 passes an entry of `src`, and we give it exactly one. Manifest entries are
-        // relative to that directory, so another root cannot be answered from the manifest
-        // and silently reporting the wrong paths would be worse than failing.
+        // The only directory we know about is this.root, so if we are asked about a different
+        // one then we should return an error rather than a wrong answer.
         if (cwd !== this.root) {
             throw new Error(
                 `coverage report requested for ${cwd}, but the manifest describes ${this.root}`
             )
         }
         return this.files.filter((f) => fs.existsSync(path.resolve(this.root, f)))
-    }
-
-    // index.js#L119. test-exclude pairs glob with globSync the way fs does. Report only
-    // calls the sync one today, but implementing one and not the other would leave a
-    // silent path back to the tree walk if that changed. Nothing here is async.
-    async glob(cwd = this.root) {
-        return this.globSync(cwd)
     }
 }
 

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -10,7 +10,7 @@ const debug = !!process.env.JS_BINARY__LOG_DEBUG
 const timings = []
 
 // Report generation is charged against the test's own timeout, so when something is slow
-// this is the only place that says which part. See docs/troubleshooting.md.
+// this is the only place that says which part.
 function logDebug(message) {
     if (debug) {
         console.error(`DEBUG: ${process.env.JS_BINARY__LOG_PREFIX}: ${message}`)

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -37,10 +37,72 @@ process.chdir(pwd)
 // not listed here, so the two must agree; c8's own default list has neither .mts nor .cts.
 const extensions = new Set(['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx', '.tsx'])
 
+// c8's Report asks its `exclude` object three questions: which executed scripts belong
+// in the report, which unexecuted files belong in it, and which extensions are
+// instrumentable at all. Bazel already answered all three in COVERAGE_MANIFEST.
+//
+// test-exclude answers them by globbing the whole runfiles tree and minimatching every
+// hit against every manifest entry -- and prepGlobPatterns expands each entry into
+// several patterns -- which is O(files in runfiles x manifest entries) in each test
+// action, charged against the test's own timeout. This replaces it with lookups against
+// the set Bazel handed us.
+//
+// It replaces the object rather than patching methods on it, so a method c8 starts
+// calling that we have not implemented fails loudly instead of silently falling back to
+// the tree walk. Standing in for, pinned to the version c8 10.1.3 resolves:
+// https://github.com/istanbuljs/test-exclude/blob/3a37faa17cc4f0f602a7c1ec23ef0b0fcf44ab37/index.js
+class ManifestExclude {
+    constructor(root, files, extensions) {
+        this.root = root
+        this.files = files
+        this.extensions = extensions
+        this.instrumented = new Set(files.map((f) => path.resolve(root, f)))
+        // _includeUncoveredFiles reads this directly and drops any path whose extension
+        // is not in it before stat'ing the rest.
+        this.extension = [...extensions]
+    }
+
+    // index.js#L76. c8 asks this of every executed script, so the original costs manifest
+    // size times scripts loaded. extname does not care whether a path is resolved, so
+    // reject on extension first and skip the resolve for anything uninstrumentable.
+    shouldInstrument(filename) {
+        if (!this.extensions.has(path.extname(filename))) return false
+        return this.instrumented.has(path.resolve(this.root, filename))
+    }
+
+    // index.js#L105. c8 calls this from _includeUncoveredFiles, the `all: true` pass that
+    // reports files no test executed. Those are exactly the manifest entries no V8 profile
+    // mentioned, so the walk it replaces could only ever have found a subset of them.
+    //
+    // Entries not on disk must be dropped here rather than left to c8: it stats each
+    // returned path without guarding, where a real glob never yields a path that is not
+    // there. A manifest entry need not be in this test's runfiles -- a first-party library
+    // repackaged by npm_package reaches the manifest at its source path but reaches
+    // runfiles only as a copy inside the node_modules store.
+    globSync(cwd = this.root) {
+        // c8 passes an entry of `src`, and we give it exactly one. Manifest entries are
+        // relative to that directory, so another root cannot be answered from the manifest
+        // and silently reporting the wrong paths would be worse than failing.
+        if (cwd !== this.root) {
+            throw new Error(
+                `coverage report requested for ${cwd}, but the manifest describes ${this.root}`
+            )
+        }
+        return this.files.filter((f) => fs.existsSync(path.resolve(this.root, f)))
+    }
+
+    // index.js#L119. test-exclude pairs glob with globSync the way fs does. Report only
+    // calls the sync one today, but implementing one and not the other would leave a
+    // silent path back to the tree walk if that changed. Nothing here is async.
+    async glob(cwd = this.root) {
+        return this.globSync(cwd)
+    }
+}
+
+// `include`, `exclude`, `extension`, `excludeNodeModules` and `allowExternal` are omitted:
+// Report forwards them to the test-exclude instance it builds in its constructor, and we
+// replace that instance outright.
 const report = new Report({
-    include: include,
-    exclude: include.length === 0 ? ['**'] : [],
-    extension: [...extensions],
     reportsDirectory: process.env.COVERAGE_DIR,
     tempDirectory: process.env.COVERAGE_DIR,
     resolve: '',
@@ -49,55 +111,7 @@ const report = new Report({
     reporter: ['lcovonly'],
 })
 
-// Bazel already computed the exact set of instrumented files and handed it to us in
-// COVERAGE_MANIFEST, so membership is a lookup. c8 would otherwise answer the same
-// question by globbing the whole runfiles tree and matching every hit against every
-// manifest entry, which is O(files in runfiles x manifest entries) in each test action.
-// The three hooks below replace that with the set Bazel already knows.
-//
-// They are methods of TestExclude, which c8 constructs from the Report options above:
-// https://github.com/istanbuljs/test-exclude/blob/3a37faa17cc4f0f602a7c1ec23ef0b0fcf44ab37/index.js
-const instrumented = new Set(include.map((f) => path.resolve(pwd, f)))
-
-// Replaces shouldInstrument (index.js#L76), which minimatches the filename against
-// every include pattern -- and prepGlobPatterns expands each manifest entry into
-// several. c8 asks this of every executed script, so the cost is manifest size times
-// scripts loaded, in every test action.
-report.exclude.shouldInstrument = function shouldInstrument(filename) {
-    if (!extensions.has(path.extname(filename))) return false
-    return instrumented.has(path.resolve(pwd, filename))
-}
-
-// Replaces globSync (index.js#L105), which walks cwd for files matching the extension
-// pattern and filters them through shouldInstrument. c8 calls it from
-// _includeUncoveredFiles, the `all: true` pass that reports files no test executed.
-// Those files are exactly the manifest entries no V8 profile mentioned, so the walk
-// could only ever have found a subset of them.
-//
-// Non-existent entries must be filtered out here rather than left to c8: it stats each
-// returned path without guarding, where the real glob simply never yielded a path that
-// was not on disk. A manifest entry need not be in this test's runfiles -- a first-party
-// library repackaged by npm_package reaches the manifest at its source path but reaches
-// runfiles only as a copy inside the node_modules store.
-report.exclude.globSync = function globSync(cwd = pwd) {
-    // c8 passes an entry of `src`, and we give it exactly one. Manifest entries are
-    // relative to that directory, so another cwd cannot be answered from the manifest
-    // and silently reporting the wrong paths would be worse than failing.
-    if (cwd !== pwd) {
-        throw new Error(
-            `coverage report requested for ${cwd}, but the manifest describes ${pwd}`
-        )
-    }
-    return include.filter((f) => fs.existsSync(path.resolve(pwd, f)))
-}
-
-// TestExclude pairs glob (index.js#L119) with globSync the way fs does. Report only
-// calls the sync one today, so this override is unreachable -- but overriding one and
-// not the other would leave a silent path back to the tree walk if that ever changed.
-// Nothing here is async, so it just defers to the sync implementation.
-report.exclude.glob = async function glob(cwd = pwd) {
-    return report.exclude.globSync(cwd)
-}
+report.exclude = new ManifestExclude(pwd, include, extensions)
 
 logDebug(
     `coverage manifest ${process.env.COVERAGE_MANIFEST}: ${include.length} entries`

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -6,23 +6,14 @@ import path from 'path'
 // both present. coverage.sh.tpl reads back this exact filename; keep them in sync.
 const stash = path.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov')
 
-const debug = !!process.env.JS_BINARY__LOG_DEBUG
-const timings = []
+const LOG_DEBUG = !!process.env.JS_BINARY__LOG_DEBUG
 
 // Report generation is charged against the test's own timeout, so when something is slow
-// this is the only place that says which part.
+// this is the only place that says so.
 function logDebug(message) {
-    if (debug) {
+    if (LOG_DEBUG) {
         console.error(`DEBUG: ${process.env.JS_BINARY__LOG_PREFIX}: ${message}`)
     }
-}
-
-function timed(label, fn) {
-    if (!debug) return fn()
-    const start = process.hrtime.bigint()
-    const value = fn()
-    timings.push(`${label}=${(Number(process.hrtime.bigint() - start) / 1e6).toFixed(0)}ms`)
-    return value
 }
 
 const started = process.hrtime.bigint()
@@ -48,7 +39,6 @@ const extensions = new Set(['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx'
 
 const report = new Report({
     include: include,
-    extension: extensions,
     exclude: include.length === 0 ? ['**'] : [],
     extension: [...extensions],
     reportsDirectory: process.env.COVERAGE_DIR,
@@ -63,18 +53,50 @@ const report = new Report({
 // COVERAGE_MANIFEST, so membership is a lookup. c8 would otherwise answer the same
 // question by globbing the whole runfiles tree and matching every hit against every
 // manifest entry, which is O(files in runfiles x manifest entries) in each test action.
-// Both hooks below replace that with the set Bazel already knows.
+// The three hooks below replace that with the set Bazel already knows.
+//
+// They are methods of TestExclude, which c8 constructs from the Report options above:
+// https://github.com/istanbuljs/test-exclude/blob/3a37faa17cc4f0f602a7c1ec23ef0b0fcf44ab37/index.js
 const instrumented = new Set(include.map((f) => path.resolve(pwd, f)))
 
+// Replaces shouldInstrument (index.js#L76), which minimatches the filename against
+// every include pattern -- and prepGlobPatterns expands each manifest entry into
+// several. c8 asks this of every executed script, so the cost is manifest size times
+// scripts loaded, in every test action.
 report.exclude.shouldInstrument = function shouldInstrument(filename) {
-    const resolved = path.resolve(pwd, filename)
-    return extensions.has(path.extname(resolved)) && instrumented.has(resolved)
+    if (!extensions.has(path.extname(filename))) return false
+    return instrumented.has(path.resolve(pwd, filename))
 }
 
-report.exclude.globSync = function globSync() {
-    return timed('uncovered_scan', () =>
-        include.filter((f) => fs.existsSync(path.resolve(pwd, f)))
-    )
+// Replaces globSync (index.js#L105), which walks cwd for files matching the extension
+// pattern and filters them through shouldInstrument. c8 calls it from
+// _includeUncoveredFiles, the `all: true` pass that reports files no test executed.
+// Those files are exactly the manifest entries no V8 profile mentioned, so the walk
+// could only ever have found a subset of them.
+//
+// Non-existent entries must be filtered out here rather than left to c8: it stats each
+// returned path without guarding, where the real glob simply never yielded a path that
+// was not on disk. A manifest entry need not be in this test's runfiles -- a first-party
+// library repackaged by npm_package reaches the manifest at its source path but reaches
+// runfiles only as a copy inside the node_modules store.
+report.exclude.globSync = function globSync(cwd = pwd) {
+    // c8 passes an entry of `src`, and we give it exactly one. Manifest entries are
+    // relative to that directory, so another cwd cannot be answered from the manifest
+    // and silently reporting the wrong paths would be worse than failing.
+    if (cwd !== pwd) {
+        throw new Error(
+            `coverage report requested for ${cwd}, but the manifest describes ${pwd}`
+        )
+    }
+    return include.filter((f) => fs.existsSync(path.resolve(pwd, f)))
+}
+
+// TestExclude pairs glob (index.js#L119) with globSync the way fs does. Report only
+// calls the sync one today, so this override is unreachable -- but overriding one and
+// not the other would leave a silent path back to the tree walk if that ever changed.
+// Nothing here is async, so it just defers to the sync implementation.
+report.exclude.glob = async function glob(cwd = pwd) {
+    return report.exclude.globSync(cwd)
 }
 
 logDebug(
@@ -86,9 +108,7 @@ report
     .then(() => {
         fs.renameSync(path.join(process.env.COVERAGE_DIR, 'lcov.info'), stash)
         const total = (Number(process.hrtime.bigint() - started) / 1e6).toFixed(0)
-        logDebug(
-            `coverage report generated in ${total}ms${timings.length ? ` (${timings.join(' ')})` : ''}`
-        )
+        logDebug(`coverage report generated in ${total}ms`)
     })
     .catch((err) => {
         console.error(err)

--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -60,11 +60,10 @@ const report = new Report({
 })
 
 // Bazel already computed the exact set of instrumented files and handed it to us in
-// COVERAGE_MANIFEST, so membership is a lookup. c8 otherwise answers the same question by
-// globbing the whole runfiles tree under `src` and minimatching every hit against every
-// manifest entry -- and TestExclude expands each entry into two patterns -- which is
-// O(files in runfiles x manifest entries) in each test action. Both hooks below replace
-// that with the set Bazel already knows.
+// COVERAGE_MANIFEST, so membership is a lookup. c8 would otherwise answer the same
+// question by globbing the whole runfiles tree and matching every hit against every
+// manifest entry, which is O(files in runfiles x manifest entries) in each test action.
+// Both hooks below replace that with the set Bazel already knows.
 const instrumented = new Set(include.map((f) => path.resolve(pwd, f)))
 
 report.exclude.shouldInstrument = function shouldInstrument(filename) {
@@ -72,11 +71,6 @@ report.exclude.shouldInstrument = function shouldInstrument(filename) {
     return extensions.has(path.extname(resolved)) && instrumented.has(resolved)
 }
 
-// `all: true` reports files no test executed. Those are exactly the manifest entries no
-// V8 profile mentioned, so the directory walk this replaces could only ever have found a
-// subset of them. Non-existent entries must be filtered out here rather than left to
-// c8: it stats each returned path without guarding, where the glob simply never yielded
-// a path that was not on disk.
 report.exclude.globSync = function globSync() {
     return timed('uncovered_scan', () =>
         include.filter((f) => fs.existsSync(path.resolve(pwd, f)))

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16106,9 +16106,15 @@ const pwd = path.join(
 );
 process.chdir(pwd);
 
+// Same list as COVERAGE_EXTENSIONS in js/private/coverage/extensions.bzl, which is what
+// decides the contents of COVERAGE_MANIFEST. c8 drops a manifest entry whose extension is
+// not listed here, so the two must agree; c8's own default list has neither .mts nor .cts.
+const extensions = new Set(['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx', '.tsx']);
+
 const report = new c8Exports.Report({
     include: include,
     exclude: include.length === 0 ? ['**'] : [],
+    extension: [...extensions],
     reportsDirectory: process.env.COVERAGE_DIR,
     tempDirectory: process.env.COVERAGE_DIR,
     resolve: '',
@@ -16116,15 +16122,6 @@ const report = new c8Exports.Report({
     all: true,
     reporter: ['lcovonly'],
 });
-
-// js_binary's instrumentation lists .mts and .cts, so they reach COVERAGE_MANIFEST, but
-// c8's default extension list has neither and would drop them from the report.
-for (const ext of ['.mts', '.cts']) {
-    if (!report.exclude.extension.includes(ext)) {
-        report.exclude.extension.push(ext);
-    }
-}
-const extensions = new Set(report.exclude.extension);
 
 // Bazel already computed the exact set of instrumented files and handed it to us in
 // COVERAGE_MANIFEST, so membership is a lookup. c8 otherwise answers the same question by

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var require$$0$2 = require('path');
+var path = require('path');
 var require$$2$1 = require('node:url');
 var require$$1$1 = require('node:path');
 var require$$0$1 = require('fs');
@@ -10,10 +10,10 @@ var require$$0 = require('node:events');
 var require$$1 = require('node:stream');
 var require$$2 = require('node:string_decoder');
 var require$$2$2 = require('util');
-var require$$0$3 = require('os');
+var require$$0$2 = require('os');
 var require$$1$2 = require('tty');
 var require$$1$3 = require('url');
-var require$$0$4 = require('assert');
+var require$$0$3 = require('assert');
 var require$$12 = require('module');
 
 var c8 = {};
@@ -8756,13 +8756,13 @@ function requireIsOutsideDirWin32 () {
 	if (hasRequiredIsOutsideDirWin32) return isOutsideDirWin32;
 	hasRequiredIsOutsideDirWin32 = 1;
 
-	const path = require$$0$2;
+	const path$1 = path;
 	const { minimatch } = requireCommonjs$4();
 
 	const dot = { dot: true, windowsPathsNoEscape: true };
 
 	isOutsideDirWin32 = function(dir, filename) {
-	    return !minimatch(path.resolve(dir, filename), path.join(dir, '**'), dot);
+	    return !minimatch(path$1.resolve(dir, filename), path$1.join(dir, '**'), dot);
 	};
 	return isOutsideDirWin32;
 }
@@ -8774,10 +8774,10 @@ function requireIsOutsideDirPosix () {
 	if (hasRequiredIsOutsideDirPosix) return isOutsideDirPosix;
 	hasRequiredIsOutsideDirPosix = 1;
 
-	const path = require$$0$2;
+	const path$1 = path;
 
 	isOutsideDirPosix = function(dir, filename) {
-	    return /^\.\./.test(path.relative(dir, filename));
+	    return /^\.\./.test(path$1.relative(dir, filename));
 	};
 	return isOutsideDirPosix;
 }
@@ -8803,7 +8803,7 @@ function requireTestExclude () {
 	if (hasRequiredTestExclude) return testExclude;
 	hasRequiredTestExclude = 1;
 
-	const path = require$$0$2;
+	const path$1 = path;
 	const { glob } = requireCommonjs();
 	const { minimatch } = requireCommonjs$4();
 	const { defaults } = requireSchema();
@@ -8887,7 +8887,7 @@ function requireTestExclude () {
 	        let pathToCheck = filename;
 
 	        if (this.relativePath) {
-	            relFile = relFile || path.relative(this.cwd, filename);
+	            relFile = relFile || path$1.relative(this.cwd, filename);
 
 	            // Don't instrument files that are outside of the current working directory.
 	            if (isOutsideDir(this.cwd, filename)) {
@@ -8916,7 +8916,7 @@ function requireTestExclude () {
 
 	        return glob
 	            .sync(globPatterns, globOptions)
-	            .filter(file => this.shouldInstrument(path.resolve(cwd, file)));
+	            .filter(file => this.shouldInstrument(path$1.resolve(cwd, file)));
 	    }
 
 	    async glob(cwd = this.cwd) {
@@ -8929,7 +8929,7 @@ function requireTestExclude () {
 	        }
 
 	        const list = await glob(globPatterns, globOptions);
-	        return list.filter(file => this.shouldInstrument(path.resolve(cwd, file)));
+	        return list.filter(file => this.shouldInstrument(path$1.resolve(cwd, file)));
 	    }
 	}
 
@@ -10536,7 +10536,7 @@ function requireMakeDir () {
 	if (hasRequiredMakeDir) return makeDir.exports;
 	hasRequiredMakeDir = 1;
 	const fs = require$$0$1;
-	const path = require$$0$2;
+	const path$1 = path;
 	const {promisify} = require$$2$2;
 	const semverGte = requireGte();
 
@@ -10546,7 +10546,7 @@ function requireMakeDir () {
 	// https://github.com/libuv/libuv/pull/1088
 	const checkPath = pth => {
 		if (process.platform === 'win32') {
-			const pathHasInvalidWinCharacters = /[<>:"|?*]/.test(pth.replace(path.parse(pth).root, ''));
+			const pathHasInvalidWinCharacters = /[<>:"|?*]/.test(pth.replace(path$1.parse(pth).root, ''));
 
 			if (pathHasInvalidWinCharacters) {
 				const error = new Error(`Path contains invalid characters: ${pth}`);
@@ -10587,7 +10587,7 @@ function requireMakeDir () {
 		const stat = promisify(options.fs.stat);
 
 		if (useNativeRecursiveOption && options.fs.mkdir === fs.mkdir) {
-			const pth = path.resolve(input);
+			const pth = path$1.resolve(input);
 
 			await mkdir(pth, {
 				mode: options.mode,
@@ -10608,7 +10608,7 @@ function requireMakeDir () {
 				}
 
 				if (error.code === 'ENOENT') {
-					if (path.dirname(pth) === pth) {
+					if (path$1.dirname(pth) === pth) {
 						throw permissionError(pth);
 					}
 
@@ -10616,7 +10616,7 @@ function requireMakeDir () {
 						throw error;
 					}
 
-					await make(path.dirname(pth));
+					await make(path$1.dirname(pth));
 
 					return make(pth);
 				}
@@ -10634,7 +10634,7 @@ function requireMakeDir () {
 			}
 		};
 
-		return make(path.resolve(input));
+		return make(path$1.resolve(input));
 	};
 
 	makeDir.exports = makeDir$1;
@@ -10644,7 +10644,7 @@ function requireMakeDir () {
 		options = processOptions(options);
 
 		if (useNativeRecursiveOption && options.fs.mkdirSync === fs.mkdirSync) {
-			const pth = path.resolve(input);
+			const pth = path$1.resolve(input);
 
 			fs.mkdirSync(pth, {
 				mode: options.mode,
@@ -10663,7 +10663,7 @@ function requireMakeDir () {
 				}
 
 				if (error.code === 'ENOENT') {
-					if (path.dirname(pth) === pth) {
+					if (path$1.dirname(pth) === pth) {
 						throw permissionError(pth);
 					}
 
@@ -10671,7 +10671,7 @@ function requireMakeDir () {
 						throw error;
 					}
 
-					make(path.dirname(pth));
+					make(path$1.dirname(pth));
 					return make(pth);
 				}
 
@@ -10687,7 +10687,7 @@ function requireMakeDir () {
 			return pth;
 		};
 
-		return make(path.resolve(input));
+		return make(path$1.resolve(input));
 	};
 	return makeDir.exports;
 }
@@ -10714,7 +10714,7 @@ var hasRequiredSupportsColor;
 function requireSupportsColor () {
 	if (hasRequiredSupportsColor) return supportsColor_1;
 	hasRequiredSupportsColor = 1;
-	const os = require$$0$3;
+	const os = require$$0$2;
 	const tty = require$$1$2;
 	const hasFlag = requireHasFlag();
 
@@ -10861,7 +10861,7 @@ function requireFileWriter () {
 	 Copyright 2012-2015, Yahoo Inc.
 	 Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
 	 */
-	const path = require$$0$2;
+	const path$1 = path;
 	const fs = require$$0$1;
 	const mkdirp = requireMakeDir();
 	const supportsColor = requireSupportsColor();
@@ -10995,7 +10995,7 @@ function requireFileWriter () {
 	     * @returns {FileWriter}
 	     */
 	    writerForDir(subdir) {
-	        if (path.isAbsolute(subdir)) {
+	        if (path$1.isAbsolute(subdir)) {
 	            throw new Error(
 	                `Cannot create subdir writer for absolute path: ${subdir}`
 	            );
@@ -11011,11 +11011,11 @@ function requireFileWriter () {
 	     *  (e.g., an "this file is autogenerated" comment, copyright notice, etc.)
 	     */
 	    copyFile(source, dest, header) {
-	        if (path.isAbsolute(dest)) {
+	        if (path$1.isAbsolute(dest)) {
 	            throw new Error(`Cannot write to absolute path: ${dest}`);
 	        }
-	        dest = path.resolve(this.baseDir, dest);
-	        mkdirp.sync(path.dirname(dest));
+	        dest = path$1.resolve(this.baseDir, dest);
+	        mkdirp.sync(path$1.dirname(dest));
 	        let contents;
 	        if (header) {
 	            contents = header + fs.readFileSync(source, 'utf8');
@@ -11035,11 +11035,11 @@ function requireFileWriter () {
 	        if (file === null || file === '-') {
 	            return new ConsoleWriter();
 	        }
-	        if (path.isAbsolute(file)) {
+	        if (path$1.isAbsolute(file)) {
 	            throw new Error(`Cannot write to absolute path: ${file}`);
 	        }
-	        file = path.resolve(this.baseDir, file);
-	        mkdirp.sync(path.dirname(file));
+	        file = path$1.resolve(this.baseDir, file);
+	        mkdirp.sync(path$1.dirname(file));
 	        return new FileContentWriter(fs.openSync(file, 'w'));
 	    }
 	}
@@ -11327,9 +11327,9 @@ function requirePath () {
 	if (hasRequiredPath) return path_1;
 	hasRequiredPath = 1;
 
-	const path = require$$0$2;
-	let parsePath = path.parse;
-	let SEP = path.sep;
+	const path$1 = path;
+	let parsePath = path$1.parse;
+	let SEP = path$1.sep;
 	const origParser = parsePath;
 	const origSep = SEP;
 
@@ -12038,10 +12038,10 @@ function requireLcovonly () {
 	        const branches = fc.b;
 	        const branchMap = fc.branchMap;
 	        const summary = node.getCoverageSummary();
-	        const path = require$$0$2;
+	        const path$1 = path;
 
 	        writer.println('TN:');
-	        const fileName = path.relative(this.projectRoot, fc.path);
+	        const fileName = path$1.relative(this.projectRoot, fc.path);
 	        writer.println('SF:' + fileName);
 
 	        Object.values(functionMap).forEach(meta => {
@@ -14189,11 +14189,11 @@ var hasRequiredV8ToIstanbul$1;
 function requireV8ToIstanbul$1 () {
 	if (hasRequiredV8ToIstanbul$1) return v8ToIstanbul$1;
 	hasRequiredV8ToIstanbul$1 = 1;
-	const assert = require$$0$4;
+	const assert = require$$0$3;
 	const convertSourceMap = requireConvertSourceMap();
 	const util = require$$2$2;
 	const debuglog = util.debuglog('c8');
-	const { dirname, isAbsolute, join, resolve } = require$$0$2;
+	const { dirname, isAbsolute, join, resolve } = path;
 	const { fileURLToPath } = require$$1$3;
 	const CovBranch = requireBranch();
 	const CovFunction = require_function();
@@ -15505,11 +15505,11 @@ function requireLib () {
 	return lib;
 }
 
-var report;
+var report$1;
 var hasRequiredReport;
 
 function requireReport () {
-	if (hasRequiredReport) return report;
+	if (hasRequiredReport) return report$1;
 	hasRequiredReport = 1;
 	const Exclude = requireTestExclude();
 	const libCoverage = requireIstanbulLibCoverage();
@@ -15522,7 +15522,7 @@ function requireReport () {
 ({ readFile } = require$$0$1.promises);
 	}
 	const { readdirSync, readFileSync, statSync } = require$$0$1;
-	const { isAbsolute, resolve, extname } = require$$0$2;
+	const { isAbsolute, resolve, extname } = path;
 	const { pathToFileURL, fileURLToPath } = require$$1$3;
 	const getSourceMapFromFile = requireSourceMapFromFile();
 	// TODO: switch back to @c88/v8-coverage once patch is landed.
@@ -16050,10 +16050,10 @@ function requireReport () {
 	  }
 	}
 
-	report = function (opts) {
+	report$1 = function (opts) {
 	  return new Report(opts)
 	};
-	return report;
+	return report$1;
 }
 
 var hasRequiredC8;
@@ -16067,9 +16067,30 @@ function requireC8 () {
 
 var c8Exports = requireC8();
 
-// Runs in the test action, the only place the V8 data and instrumented sources are
+// Runs in the test action, the only place the V8 data and the instrumented sources are
 // both present. coverage.sh.tpl reads back this exact filename; keep them in sync.
-const stash = require$$0$2.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov');
+const stash = path.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov');
+
+const debug = !!process.env.JS_BINARY__LOG_DEBUG;
+const timings = [];
+
+// Report generation is charged against the test's own timeout, so when something is slow
+// this is the only place that says which part. See docs/troubleshooting.md.
+function logDebug(message) {
+    if (debug) {
+        console.error(`DEBUG: ${process.env.JS_BINARY__LOG_PREFIX}: ${message}`);
+    }
+}
+
+function timed(label, fn) {
+    if (!debug) return fn()
+    const start = process.hrtime.bigint();
+    const value = fn();
+    timings.push(`${label}=${(Number(process.hrtime.bigint() - start) / 1e6).toFixed(0)}ms`);
+    return value
+}
+
+const started = process.hrtime.bigint();
 
 const include = require$$0$1
     .readFileSync(process.env.COVERAGE_MANIFEST)
@@ -16079,13 +16100,13 @@ const include = require$$0$1
 
 // TODO: can or should we instrument files from other repositories as well?
 // if so then the path.join call below will yield invalid paths since files will have external/wksp as their prefix.
-const pwd = require$$0$2.join(
+const pwd = path.join(
     process.env.JS_COVERAGE__RUNFILES,
     process.env.TEST_WORKSPACE
 );
 process.chdir(pwd);
 
-new c8Exports.Report({
+const report = new c8Exports.Report({
     include: include,
     exclude: include.length === 0 ? ['**'] : [],
     reportsDirectory: process.env.COVERAGE_DIR,
@@ -16094,10 +16115,53 @@ new c8Exports.Report({
     src: pwd,
     all: true,
     reporter: ['lcovonly'],
-})
+});
+
+// js_binary's instrumentation lists .mts and .cts, so they reach COVERAGE_MANIFEST, but
+// c8's default extension list has neither and would drop them from the report.
+for (const ext of ['.mts', '.cts']) {
+    if (!report.exclude.extension.includes(ext)) {
+        report.exclude.extension.push(ext);
+    }
+}
+const extensions = new Set(report.exclude.extension);
+
+// Bazel already computed the exact set of instrumented files and handed it to us in
+// COVERAGE_MANIFEST, so membership is a lookup. c8 otherwise answers the same question by
+// globbing the whole runfiles tree under `src` and minimatching every hit against every
+// manifest entry -- and TestExclude expands each entry into two patterns -- which is
+// O(files in runfiles x manifest entries) in each test action. Both hooks below replace
+// that with the set Bazel already knows.
+const instrumented = new Set(include.map((f) => path.resolve(pwd, f)));
+
+report.exclude.shouldInstrument = function shouldInstrument(filename) {
+    const resolved = path.resolve(pwd, filename);
+    return extensions.has(path.extname(resolved)) && instrumented.has(resolved)
+};
+
+// `all: true` reports files no test executed. Those are exactly the manifest entries no
+// V8 profile mentioned, so the directory walk this replaces could only ever have found a
+// subset of them. Non-existent entries must be filtered out here rather than left to
+// c8: it stats each returned path without guarding, where the glob simply never yielded
+// a path that was not on disk.
+report.exclude.globSync = function globSync() {
+    return timed('uncovered_scan', () =>
+        include.filter((f) => require$$0$1.existsSync(path.resolve(pwd, f)))
+    )
+};
+
+logDebug(
+    `coverage manifest ${process.env.COVERAGE_MANIFEST}: ${include.length} entries`
+);
+
+report
     .run()
     .then(() => {
-        require$$0$1.renameSync(require$$0$2.join(process.env.COVERAGE_DIR, 'lcov.info'), stash);
+        require$$0$1.renameSync(path.join(process.env.COVERAGE_DIR, 'lcov.info'), stash);
+        const total = (Number(process.hrtime.bigint() - started) / 1e6).toFixed(0);
+        logDebug(
+            `coverage report generated in ${total}ms${timings.length ? ` (${timings.join(' ')})` : ''}`
+        );
     })
     .catch((err) => {
         console.error(err);

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16102,10 +16102,72 @@ process.chdir(pwd);
 // not listed here, so the two must agree; c8's own default list has neither .mts nor .cts.
 const extensions = new Set(['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx', '.tsx']);
 
+// c8's Report asks its `exclude` object three questions: which executed scripts belong
+// in the report, which unexecuted files belong in it, and which extensions are
+// instrumentable at all. Bazel already answered all three in COVERAGE_MANIFEST.
+//
+// test-exclude answers them by globbing the whole runfiles tree and minimatching every
+// hit against every manifest entry -- and prepGlobPatterns expands each entry into
+// several patterns -- which is O(files in runfiles x manifest entries) in each test
+// action, charged against the test's own timeout. This replaces it with lookups against
+// the set Bazel handed us.
+//
+// It replaces the object rather than patching methods on it, so a method c8 starts
+// calling that we have not implemented fails loudly instead of silently falling back to
+// the tree walk. Standing in for, pinned to the version c8 10.1.3 resolves:
+// https://github.com/istanbuljs/test-exclude/blob/3a37faa17cc4f0f602a7c1ec23ef0b0fcf44ab37/index.js
+class ManifestExclude {
+    constructor(root, files, extensions) {
+        this.root = root;
+        this.files = files;
+        this.extensions = extensions;
+        this.instrumented = new Set(files.map((f) => path.resolve(root, f)));
+        // _includeUncoveredFiles reads this directly and drops any path whose extension
+        // is not in it before stat'ing the rest.
+        this.extension = [...extensions];
+    }
+
+    // index.js#L76. c8 asks this of every executed script, so the original costs manifest
+    // size times scripts loaded. extname does not care whether a path is resolved, so
+    // reject on extension first and skip the resolve for anything uninstrumentable.
+    shouldInstrument(filename) {
+        if (!this.extensions.has(path.extname(filename))) return false
+        return this.instrumented.has(path.resolve(this.root, filename))
+    }
+
+    // index.js#L105. c8 calls this from _includeUncoveredFiles, the `all: true` pass that
+    // reports files no test executed. Those are exactly the manifest entries no V8 profile
+    // mentioned, so the walk it replaces could only ever have found a subset of them.
+    //
+    // Entries not on disk must be dropped here rather than left to c8: it stats each
+    // returned path without guarding, where a real glob never yields a path that is not
+    // there. A manifest entry need not be in this test's runfiles -- a first-party library
+    // repackaged by npm_package reaches the manifest at its source path but reaches
+    // runfiles only as a copy inside the node_modules store.
+    globSync(cwd = this.root) {
+        // c8 passes an entry of `src`, and we give it exactly one. Manifest entries are
+        // relative to that directory, so another root cannot be answered from the manifest
+        // and silently reporting the wrong paths would be worse than failing.
+        if (cwd !== this.root) {
+            throw new Error(
+                `coverage report requested for ${cwd}, but the manifest describes ${this.root}`
+            )
+        }
+        return this.files.filter((f) => require$$0$1.existsSync(path.resolve(this.root, f)))
+    }
+
+    // index.js#L119. test-exclude pairs glob with globSync the way fs does. Report only
+    // calls the sync one today, but implementing one and not the other would leave a
+    // silent path back to the tree walk if that changed. Nothing here is async.
+    async glob(cwd = this.root) {
+        return this.globSync(cwd)
+    }
+}
+
+// `include`, `exclude`, `extension`, `excludeNodeModules` and `allowExternal` are omitted:
+// Report forwards them to the test-exclude instance it builds in its constructor, and we
+// replace that instance outright.
 const report = new c8Exports.Report({
-    include: include,
-    exclude: include.length === 0 ? ['**'] : [],
-    extension: [...extensions],
     reportsDirectory: process.env.COVERAGE_DIR,
     tempDirectory: process.env.COVERAGE_DIR,
     resolve: '',
@@ -16114,55 +16176,7 @@ const report = new c8Exports.Report({
     reporter: ['lcovonly'],
 });
 
-// Bazel already computed the exact set of instrumented files and handed it to us in
-// COVERAGE_MANIFEST, so membership is a lookup. c8 would otherwise answer the same
-// question by globbing the whole runfiles tree and matching every hit against every
-// manifest entry, which is O(files in runfiles x manifest entries) in each test action.
-// The three hooks below replace that with the set Bazel already knows.
-//
-// They are methods of TestExclude, which c8 constructs from the Report options above:
-// https://github.com/istanbuljs/test-exclude/blob/3a37faa17cc4f0f602a7c1ec23ef0b0fcf44ab37/index.js
-const instrumented = new Set(include.map((f) => path.resolve(pwd, f)));
-
-// Replaces shouldInstrument (index.js#L76), which minimatches the filename against
-// every include pattern -- and prepGlobPatterns expands each manifest entry into
-// several. c8 asks this of every executed script, so the cost is manifest size times
-// scripts loaded, in every test action.
-report.exclude.shouldInstrument = function shouldInstrument(filename) {
-    if (!extensions.has(path.extname(filename))) return false
-    return instrumented.has(path.resolve(pwd, filename))
-};
-
-// Replaces globSync (index.js#L105), which walks cwd for files matching the extension
-// pattern and filters them through shouldInstrument. c8 calls it from
-// _includeUncoveredFiles, the `all: true` pass that reports files no test executed.
-// Those files are exactly the manifest entries no V8 profile mentioned, so the walk
-// could only ever have found a subset of them.
-//
-// Non-existent entries must be filtered out here rather than left to c8: it stats each
-// returned path without guarding, where the real glob simply never yielded a path that
-// was not on disk. A manifest entry need not be in this test's runfiles -- a first-party
-// library repackaged by npm_package reaches the manifest at its source path but reaches
-// runfiles only as a copy inside the node_modules store.
-report.exclude.globSync = function globSync(cwd = pwd) {
-    // c8 passes an entry of `src`, and we give it exactly one. Manifest entries are
-    // relative to that directory, so another cwd cannot be answered from the manifest
-    // and silently reporting the wrong paths would be worse than failing.
-    if (cwd !== pwd) {
-        throw new Error(
-            `coverage report requested for ${cwd}, but the manifest describes ${pwd}`
-        )
-    }
-    return include.filter((f) => require$$0$1.existsSync(path.resolve(pwd, f)))
-};
-
-// TestExclude pairs glob (index.js#L119) with globSync the way fs does. Report only
-// calls the sync one today, so this override is unreachable -- but overriding one and
-// not the other would leave a silent path back to the tree walk if that ever changed.
-// Nothing here is async, so it just defers to the sync implementation.
-report.exclude.glob = async function glob(cwd = pwd) {
-    return report.exclude.globSync(cwd)
-};
+report.exclude = new ManifestExclude(pwd, include, extensions);
 
 logDebug(
     `coverage manifest ${process.env.COVERAGE_MANIFEST}: ${include.length} entries`

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16071,23 +16071,14 @@ var c8Exports = requireC8();
 // both present. coverage.sh.tpl reads back this exact filename; keep them in sync.
 const stash = path.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov');
 
-const debug = !!process.env.JS_BINARY__LOG_DEBUG;
-const timings = [];
+const LOG_DEBUG = !!process.env.JS_BINARY__LOG_DEBUG;
 
 // Report generation is charged against the test's own timeout, so when something is slow
-// this is the only place that says which part.
+// this is the only place that says so.
 function logDebug(message) {
-    if (debug) {
+    if (LOG_DEBUG) {
         console.error(`DEBUG: ${process.env.JS_BINARY__LOG_PREFIX}: ${message}`);
     }
-}
-
-function timed(label, fn) {
-    if (!debug) return fn()
-    const start = process.hrtime.bigint();
-    const value = fn();
-    timings.push(`${label}=${(Number(process.hrtime.bigint() - start) / 1e6).toFixed(0)}ms`);
-    return value
 }
 
 const started = process.hrtime.bigint();
@@ -16113,7 +16104,6 @@ const extensions = new Set(['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx'
 
 const report = new c8Exports.Report({
     include: include,
-    extension: extensions,
     exclude: include.length === 0 ? ['**'] : [],
     extension: [...extensions],
     reportsDirectory: process.env.COVERAGE_DIR,
@@ -16128,18 +16118,50 @@ const report = new c8Exports.Report({
 // COVERAGE_MANIFEST, so membership is a lookup. c8 would otherwise answer the same
 // question by globbing the whole runfiles tree and matching every hit against every
 // manifest entry, which is O(files in runfiles x manifest entries) in each test action.
-// Both hooks below replace that with the set Bazel already knows.
+// The three hooks below replace that with the set Bazel already knows.
+//
+// They are methods of TestExclude, which c8 constructs from the Report options above:
+// https://github.com/istanbuljs/test-exclude/blob/3a37faa17cc4f0f602a7c1ec23ef0b0fcf44ab37/index.js
 const instrumented = new Set(include.map((f) => path.resolve(pwd, f)));
 
+// Replaces shouldInstrument (index.js#L76), which minimatches the filename against
+// every include pattern -- and prepGlobPatterns expands each manifest entry into
+// several. c8 asks this of every executed script, so the cost is manifest size times
+// scripts loaded, in every test action.
 report.exclude.shouldInstrument = function shouldInstrument(filename) {
-    const resolved = path.resolve(pwd, filename);
-    return extensions.has(path.extname(resolved)) && instrumented.has(resolved)
+    if (!extensions.has(path.extname(filename))) return false
+    return instrumented.has(path.resolve(pwd, filename))
 };
 
-report.exclude.globSync = function globSync() {
-    return timed('uncovered_scan', () =>
-        include.filter((f) => require$$0$1.existsSync(path.resolve(pwd, f)))
-    )
+// Replaces globSync (index.js#L105), which walks cwd for files matching the extension
+// pattern and filters them through shouldInstrument. c8 calls it from
+// _includeUncoveredFiles, the `all: true` pass that reports files no test executed.
+// Those files are exactly the manifest entries no V8 profile mentioned, so the walk
+// could only ever have found a subset of them.
+//
+// Non-existent entries must be filtered out here rather than left to c8: it stats each
+// returned path without guarding, where the real glob simply never yielded a path that
+// was not on disk. A manifest entry need not be in this test's runfiles -- a first-party
+// library repackaged by npm_package reaches the manifest at its source path but reaches
+// runfiles only as a copy inside the node_modules store.
+report.exclude.globSync = function globSync(cwd = pwd) {
+    // c8 passes an entry of `src`, and we give it exactly one. Manifest entries are
+    // relative to that directory, so another cwd cannot be answered from the manifest
+    // and silently reporting the wrong paths would be worse than failing.
+    if (cwd !== pwd) {
+        throw new Error(
+            `coverage report requested for ${cwd}, but the manifest describes ${pwd}`
+        )
+    }
+    return include.filter((f) => require$$0$1.existsSync(path.resolve(pwd, f)))
+};
+
+// TestExclude pairs glob (index.js#L119) with globSync the way fs does. Report only
+// calls the sync one today, so this override is unreachable -- but overriding one and
+// not the other would leave a silent path back to the tree walk if that ever changed.
+// Nothing here is async, so it just defers to the sync implementation.
+report.exclude.glob = async function glob(cwd = pwd) {
+    return report.exclude.globSync(cwd)
 };
 
 logDebug(
@@ -16151,9 +16173,7 @@ report
     .then(() => {
         require$$0$1.renameSync(path.join(process.env.COVERAGE_DIR, 'lcov.info'), stash);
         const total = (Number(process.hrtime.bigint() - started) / 1e6).toFixed(0);
-        logDebug(
-            `coverage report generated in ${total}ms${timings.length ? ` (${timings.join(' ')})` : ''}`
-        );
+        logDebug(`coverage report generated in ${total}ms`);
     })
     .catch((err) => {
         console.error(err);

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16075,7 +16075,7 @@ const debug = !!process.env.JS_BINARY__LOG_DEBUG;
 const timings = [];
 
 // Report generation is charged against the test's own timeout, so when something is slow
-// this is the only place that says which part. See docs/troubleshooting.md.
+// this is the only place that says which part.
 function logDebug(message) {
     if (debug) {
         console.error(`DEBUG: ${process.env.JS_BINARY__LOG_PREFIX}: ${message}`);

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16073,8 +16073,6 @@ const stash = path.join(process.env.COVERAGE_DIR, '_rules_js_report.lcov');
 
 const LOG_DEBUG = !!process.env.JS_BINARY__LOG_DEBUG;
 
-// Report generation is charged against the test's own timeout, so when something is slow
-// this is the only place that says so.
 function logDebug(message) {
     if (LOG_DEBUG) {
         console.error(`DEBUG: ${process.env.JS_BINARY__LOG_PREFIX}: ${message}`);
@@ -16102,20 +16100,16 @@ process.chdir(pwd);
 // not listed here, so the two must agree; c8's own default list has neither .mts nor .cts.
 const extensions = new Set(['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx', '.tsx']);
 
-// c8's Report asks its `exclude` object three questions: which executed scripts belong
-// in the report, which unexecuted files belong in it, and which extensions are
-// instrumentable at all. Bazel already answered all three in COVERAGE_MANIFEST.
-//
-// test-exclude answers them by globbing the whole runfiles tree and minimatching every
-// hit against every manifest entry -- and prepGlobPatterns expands each entry into
-// several patterns -- which is O(files in runfiles x manifest entries) in each test
-// action, charged against the test's own timeout. This replaces it with lookups against
-// the set Bazel handed us.
-//
-// It replaces the object rather than patching methods on it, so a method c8 starts
-// calling that we have not implemented fails loudly instead of silently falling back to
-// the tree walk. Standing in for, pinned to the version c8 10.1.3 resolves:
+// We provide our own implementation of the TestExclude class from here:
 // https://github.com/istanbuljs/test-exclude/blob/3a37faa17cc4f0f602a7c1ec23ef0b0fcf44ab37/index.js
+// The upstream TestExclude is inefficient for our use case, because it globs the whole
+// runfiles tree and matches every result individually against every entry in the coverage
+// manifest. This is O(number of runfiles * number of coverage manifest entries), or quadratic
+// in the number of runfiles if you assume that those two quantities are proportional to each
+// other. Our implementation is careful to avoid this quadratic scaling.
+//
+// We do not implement every method from the original class, only the ones that Report calls.
+// If Report changes then this may break, but it should fail in a loud way that we can address.
 class ManifestExclude {
     constructor(root, files, extensions) {
         this.root = root;
@@ -16127,40 +16121,20 @@ class ManifestExclude {
         this.extension = [...extensions];
     }
 
-    // index.js#L76. c8 asks this of every executed script, so the original costs manifest
-    // size times scripts loaded. extname does not care whether a path is resolved, so
-    // reject on extension first and skip the resolve for anything uninstrumentable.
     shouldInstrument(filename) {
         if (!this.extensions.has(path.extname(filename))) return false
         return this.instrumented.has(path.resolve(this.root, filename))
     }
 
-    // index.js#L105. c8 calls this from _includeUncoveredFiles, the `all: true` pass that
-    // reports files no test executed. Those are exactly the manifest entries no V8 profile
-    // mentioned, so the walk it replaces could only ever have found a subset of them.
-    //
-    // Entries not on disk must be dropped here rather than left to c8: it stats each
-    // returned path without guarding, where a real glob never yields a path that is not
-    // there. A manifest entry need not be in this test's runfiles -- a first-party library
-    // repackaged by npm_package reaches the manifest at its source path but reaches
-    // runfiles only as a copy inside the node_modules store.
     globSync(cwd = this.root) {
-        // c8 passes an entry of `src`, and we give it exactly one. Manifest entries are
-        // relative to that directory, so another root cannot be answered from the manifest
-        // and silently reporting the wrong paths would be worse than failing.
+        // The only directory we know about is this.root, so if we are asked about a different
+        // one then we should return an error rather than a wrong answer.
         if (cwd !== this.root) {
             throw new Error(
                 `coverage report requested for ${cwd}, but the manifest describes ${this.root}`
             )
         }
         return this.files.filter((f) => require$$0$1.existsSync(path.resolve(this.root, f)))
-    }
-
-    // index.js#L119. test-exclude pairs glob with globSync the way fs does. Report only
-    // calls the sync one today, but implementing one and not the other would leave a
-    // silent path back to the tree walk if that changed. Nothing here is async.
-    async glob(cwd = this.root) {
-        return this.globSync(cwd)
     }
 }
 

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16125,11 +16125,10 @@ const report = new c8Exports.Report({
 });
 
 // Bazel already computed the exact set of instrumented files and handed it to us in
-// COVERAGE_MANIFEST, so membership is a lookup. c8 otherwise answers the same question by
-// globbing the whole runfiles tree under `src` and minimatching every hit against every
-// manifest entry -- and TestExclude expands each entry into two patterns -- which is
-// O(files in runfiles x manifest entries) in each test action. Both hooks below replace
-// that with the set Bazel already knows.
+// COVERAGE_MANIFEST, so membership is a lookup. c8 would otherwise answer the same
+// question by globbing the whole runfiles tree and matching every hit against every
+// manifest entry, which is O(files in runfiles x manifest entries) in each test action.
+// Both hooks below replace that with the set Bazel already knows.
 const instrumented = new Set(include.map((f) => path.resolve(pwd, f)));
 
 report.exclude.shouldInstrument = function shouldInstrument(filename) {
@@ -16137,11 +16136,6 @@ report.exclude.shouldInstrument = function shouldInstrument(filename) {
     return extensions.has(path.extname(resolved)) && instrumented.has(resolved)
 };
 
-// `all: true` reports files no test executed. Those are exactly the manifest entries no
-// V8 profile mentioned, so the directory walk this replaces could only ever have found a
-// subset of them. Non-existent entries must be filtered out here rather than left to
-// c8: it stats each returned path without guarding, where the glob simply never yielded
-// a path that was not on disk.
 report.exclude.globSync = function globSync() {
     return timed('uncovered_scan', () =>
         include.filter((f) => require$$0$1.existsSync(path.resolve(pwd, f)))


### PR DESCRIPTION
As of today, we effectively glob the whole runfiles directory and then match each entry against the coverage manifest. This is slow because it ends up being O(number of runfiles * length of coverage manifest).

This change speeds up the coverage reporting by using the coverage manifest instead of globbing.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added