### PR TITLE
chore: remove Linux hermetic sandbox CI job for now

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -266,28 +266,6 @@ jobs:
                     echo "No test.sh in ${PWD}; skipping"
                   fi
 
-    # Bazel's hermetic Linux sandbox mounts only an action's declared inputs, so it catches
-    # host leakage that the ordinary sandbox hides. This run needs its own job so that it does
-    # not share an action cache with other test runs. Otherwise we could end up reusing cached
-    # results from there instead of exercising the hermetic sandbox. We also set the necessary
-    # flags to ensure we do not use the local disk cache or the remote cache.
-    hermetic-sandbox:
-        # More recent versions of Ubuntu set kernel.apparmor_restrict_unprivileged_userns=1,
-        # which prevents linux-sandbox from working.
-        runs-on: ubuntu-22.04
-        permissions:
-            contents: read
-            id-token: write
-        env:
-            USE_BAZEL_VERSION: 8.x
-        steps:
-            - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
-              with:
-                  aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
-            - name: Test
-              run: aspect test --task-key=hermetic-sandbox --bazel-flag=--test_tag_filters=-skip-on-bazel8 --bazel-flag=--config=hermetic-sandbox --bazel-flag=--noremote_accept_cached --bazel-flag=--noremote_upload_local_results --bazel-flag=--disk_cache= --bazel-flag=--nocache_test_results -- //...
-
     # Mac/Windows smoke tests for the root workspace and e2e/bzlmod.
     # Only run on main branch (not PRs) to minimize minutes (billed at 10X and 2X respectively)
     # unless the branch name contains 'macos' or 'windows'.
@@ -331,7 +309,7 @@ jobs:
     # For branch protection settings, this job provides a "stable" name that can be used to gate PR merges
     # on "all matrix jobs were successful".
     conclusion:
-        needs: [format, buildifier, test, hermetic-sandbox, smoke]
+        needs: [format, buildifier, test, smoke]
         runs-on: ubuntu-latest
         if: always()
         steps:
@@ -339,7 +317,6 @@ jobs:
                   if [[ "${{ needs.format.result }}" == "success" \
                      && "${{ needs.buildifier.result }}" == "success" \
                      && "${{ needs.test.result }}" == "success" \
-                     && "${{ needs.hermetic-sandbox.result }}" == "success" \
                      && ("${{ needs.smoke.result }}" == "success" || "${{ needs.smoke.result }}" == "skipped") ]]; then
                     exit 0
                   else


### PR DESCRIPTION
This build occasionally hangs during a Rollup action and it is not yet clear why. Let's remove it for now to prevent CI from being flaky.

---

### Changes are visible to end-users: no

### Test plan
