### PR TITLE
fix: report coverage for .mts and .cts sources

### DIFF
--- a/js/private/coverage/bundle/c8.js
+++ b/js/private/coverage/bundle/c8.js
@@ -20,8 +20,14 @@ const pwd = path.join(
 )
 process.chdir(pwd)
 
+// Same list as COVERAGE_EXTENSIONS in js/private/coverage/extensions.bzl, which is what
+// decides the contents of COVERAGE_MANIFEST. c8 drops a manifest entry whose extension is
+// not listed here, so the two must agree; c8's own default list has neither .mts nor .cts.
+const extensions = ['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx', '.tsx']
+
 new Report({
     include: include,
+    extension: extensions,
     exclude: include.length === 0 ? ['**'] : [],
     reportsDirectory: process.env.COVERAGE_DIR,
     tempDirectory: process.env.COVERAGE_DIR,

--- a/js/private/coverage/coverage.js
+++ b/js/private/coverage/coverage.js
@@ -16085,8 +16085,14 @@ const pwd = require$$0$2.join(
 );
 process.chdir(pwd);
 
+// Same list as COVERAGE_EXTENSIONS in js/private/coverage/extensions.bzl, which is what
+// decides the contents of COVERAGE_MANIFEST. c8 drops a manifest entry whose extension is
+// not listed here, so the two must agree; c8's own default list has neither .mts nor .cts.
+const extensions = ['.mjs', '.mts', '.cjs', '.cts', '.ts', '.js', '.jsx', '.tsx'];
+
 new c8Exports.Report({
     include: include,
+    extension: extensions,
     exclude: include.length === 0 ? ['**'] : [],
     reportsDirectory: process.env.COVERAGE_DIR,
     tempDirectory: process.env.COVERAGE_DIR,

--- a/js/private/test/coverage/BUILD.bazel
+++ b/js/private/test/coverage/BUILD.bazel
@@ -190,6 +190,11 @@ grep -q '^SF:js/private/test/coverage/extensions/lib.js$' "$COVERAGE_OUTPUT_FILE
 }
 grep -q '^FNDA:1,extCovered$' "$COVERAGE_OUTPUT_FILE" || { echo "expected an executed function" >&2; exit 1; }
 grep -q '^FNDA:0,extUncovered$' "$COVERAGE_OUTPUT_FILE" || { echo "expected an unexecuted function" >&2; exit 1; }
+grep -q '^SF:js/private/test/coverage/extensions/lib.mts$' "$COVERAGE_OUTPUT_FILE" || {
+    echo "expected a record for the .mts source; c8's default extension list omits .mts" >&2
+    cat "$COVERAGE_OUTPUT_FILE" >&2
+    exit 1
+}
 ! grep -q 'asset.json' "$COVERAGE_OUTPUT_FILE" || {
     echo "a non-instrumentable src was reported:" >&2
     grep 'asset.json' "$COVERAGE_OUTPUT_FILE" >&2

--- a/js/private/test/coverage/extensions/BUILD.bazel
+++ b/js/private/test/coverage/extensions/BUILD.bazel
@@ -2,14 +2,17 @@ load("//js:defs.bzl", "js_library")
 
 package(default_testonly = True)
 
-# A library whose srcs mix an instrumentable source with one that is not. js_library
-# filters srcs by COVERAGE_EXTENSIONS, so only lib.js should reach a dependent test's
-# COVERAGE_MANIFEST.
+# A library whose srcs mix instrumentable sources with one source that is not. js_library
+# filters srcs by COVERAGE_EXTENSIONS, so asset.json must not reach a dependent test's
+# COVERAGE_MANIFEST. lib.mts is never executed: it is here so the report's `all` pass has
+# to emit a record for it, pinning that the reporter's extension list covers .mts. c8's
+# own default list does not, so without an explicit list it is silently dropped.
 js_library(
     name = "lib",
     srcs = [
         "asset.json",
         "lib.js",
+        "lib.mts",
     ],
     visibility = ["//js/private/test/coverage:__pkg__"],
 )

--- a/js/private/test/coverage/extensions/lib.mts
+++ b/js/private/test/coverage/extensions/lib.mts
@@ -1,0 +1,3 @@
+export function mtsUncovered(): string {
+    return 'never called'
+}


### PR DESCRIPTION
js_library instruments .mts and .cts files, so they reach COVERAGE_MANIFEST. c8's default extension list has neither, and it drops a manifest entry whose extension it does not recognize, so those sources were silently absent from the report.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- New test cases added
