### PR TITLE
fix: resolve npmrc credentials before running pnpm install for update_pnpm_lock

### DIFF
--- a/e2e/npm_translate_lock_auth_token_helper/MODULE.bazel
+++ b/e2e/npm_translate_lock_auth_token_helper/MODULE.bazel
@@ -19,8 +19,10 @@ npm = use_extension(
 )
 npm.npm_translate_lock(
     name = "npm",
+    data = ["//:package.json"],
     npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
+    update_pnpm_lock = True,
     verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "npm")

--- a/e2e/npm_translate_lock_auth_token_helper/README.md
+++ b/e2e/npm_translate_lock_auth_token_helper/README.md
@@ -6,3 +6,7 @@ covers a [`tokenHelper`](https://pnpm.io/npmrc#urltokenhelper) declared in the `
 `token-helper.sh` prints the token from `ASPECT_GH_PACKAGES_AUTH_TOKEN`, and
 `ASPECT_NPM_AUTH_TOKEN` must have permission to pull the `@aspect-priv-npm` scope, same as
 the sibling test.
+
+`update_pnpm_lock` is enabled and `test.sh` changes `package.json` so that `pnpm install`
+runs with the private registry, which pnpm can only authenticate with because rules_js
+resolves the `tokenHelper` into the `.npmrc` copy it hands to pnpm.

--- a/e2e/npm_translate_lock_auth_token_helper/test.sh
+++ b/e2e/npm_translate_lock_auth_token_helper/test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+# Integration test for update_pnpm_lock with a tokenHelper in the project .npmrc
+
+# sedi makes `sed -i` work on both OSX & Linux
+# See https://stackoverflow.com/questions/2320564/i-need-my-sed-i-command-for-in-place-editing-to-work-with-both-gnu-sed-and-bsd
+_sedi() {
+    case $(uname) in
+    Darwin*) sedi=('-i' '') ;;
+    *) sedi=('-i') ;;
+    esac
+
+    sed "${sedi[@]}" "$@"
+}
+
+# Change package.json to invalidate the repository rule
+_sedi 's#"@types/node": "22.18.13"#"@types/node": "22"#' package.json
+
+# Allow updating the lockfile for this test
+unset ASPECT_RULES_JS_FROZEN_PNPM_LOCK
+
+# Trigger the update of the pnpm lockfile which should exit non-zero
+if bazel run @npm//:sync; then
+    echo "ERROR: expected 'update_pnpm_lock' to exit with non-zero exit code on update"
+    exit 1
+fi
+
+if ! git status --porcelain | grep -q "\.aspect/rules/external_repository_action_cache/npm_translate_lock_"; then
+    echo "ERROR: expected .aspect/rules/external_repository_action_cache/npm_translate_lock_* to be updated by sync"
+    exit 1
+fi
+if ! git status --porcelain | grep -q "pnpm-lock.yaml"; then
+    echo "ERROR: expected pnpm-lock.yaml to be updated by sync"
+    exit 1
+fi
+
+# The lockfile has been updated and sync should now exit 0
+if ! bazel run @npm//:sync; then
+    echo "ERROR: expected 'update_pnpm_lock' to exit zero once the lockfile is up to date"
+    exit 1
+fi
+
+export ASPECT_RULES_JS_FROZEN_PNPM_LOCK=1
+
+bazel test //...

--- a/npm/private/npm_translate_lock.bzl
+++ b/npm/private/npm_translate_lock.bzl
@@ -196,9 +196,15 @@ For more about how to use npm_translate_lock, read [pnpm and rules_js](/docs/pnp
             specified in the file are passed to the Bazel downloader for authentication with private npm registries.
 
             A [`tokenHelper`](https://pnpm.io/npmrc#urltokenhelper) is also honored: rules_js runs the executable it
-            names and uses the token it prints on stdout. The helper path may be absolute or relative to this
+            names and uses what it prints on stdout as the token, with a leading `Bearer ` stripped or a leading
+            `Basic ` selecting basic authentication. The helper path may be absolute or relative to this
             `.npmrc` file, and may reference environment variables. A helper runs during repository setup,
             only for a registry a package in the lockfile resolves to, and at most once per registry.
+
+            When `update_pnpm_lock` is enabled, the copy of this file that `pnpm install` reads has each
+            `tokenHelper` and environment variable credential replaced with its resolved value, since pnpm only
+            honors those from the user-level `.npmrc`. The copy lives in the external repository; the source
+            file is not modified.
 
             SECURITY: unlike pnpm, which only runs a `tokenHelper` from user-level config, rules_js runs one declared
             in this `.npmrc` even when it is checked into the repository. A `tokenHelper` names an executable that
@@ -462,7 +468,19 @@ STDERR:
             fail(msg)
 
 ################################################################################
+def _resolve_npmrc_credentials(rctx, attr):
+    if not attr.npmrc:
+        return
+
+    npmrc = paths.join(attr.npmrc.package, attr.npmrc.name)
+    content = rctx.read(npmrc)
+    resolved = helpers.resolve_npmrc_credentials(content, rctx.path(attr.npmrc), rctx)
+    if resolved != content:
+        rctx.file(npmrc, resolved)
+
+################################################################################
 def _update_pnpm_lock(rctx, attr, state):
+    _resolve_npmrc_credentials(rctx, attr)
     _execute_preupdate_scripts(rctx, attr, state)
 
     pnpm_lock_label = state.pnpm_lock_label()

--- a/npm/private/npm_translate_lock_helpers.bzl
+++ b/npm/private/npm_translate_lock_helpers.bzl
@@ -140,7 +140,44 @@ def _run_token_helper(helper, npmrc_path, rctx):
             npmrc = npmrc_path,
         ))
 
-    return token
+    # pnpm uses the output as the Authorization header value, so a helper written for it
+    # prefixes the scheme; a bare token is taken as a bearer token.
+    if token.startswith("Basic "):
+        return ("basic", token[len("Basic "):].strip())
+    return ("bearer", token.removeprefix("Bearer ").strip())
+
+def _npmrc_setting_is(key, name):
+    return key == name or key.endswith(":" + name)
+
+def _resolve_npmrc_credentials(content, npmrc_path, rctx):
+    """Rewrites a project `.npmrc` so its credentials survive being read by pnpm.
+
+    pnpm only honors a `tokenHelper` from the user-level `.npmrc`, and does not expand environment
+    variables in credentials that come from a project-level one. Replace both with the values
+    rules_js resolves for its own downloads, so `pnpm install` authenticates the same way.
+
+    Args:
+        content: The `.npmrc` content.
+        npmrc_path: The path of the `.npmrc` the content was read from, used to resolve a relative
+            `tokenHelper` and in diagnostics.
+        rctx: The repository_ctx or module_ctx.
+
+    Returns:
+        The rewritten content.
+    """
+    lines = []
+    for line in content.splitlines():
+        key, _, value = line.split(";", 1)[0].split("#", 1)[0].partition("=")
+        key = key.strip()
+        value = value.strip()
+        if _npmrc_setting_is(key, "tokenHelper"):
+            kind, credential = _run_token_helper(value, npmrc_path, rctx)
+            setting = "_authToken" if kind == "bearer" else "_auth"
+            line = key.removesuffix("tokenHelper") + setting + "=" + credential
+        elif value.startswith("$") and (_npmrc_setting_is(key, "_authToken") or _npmrc_setting_is(key, "_auth")):
+            line = key + "=" + utils.replace_npmrc_token_envvar(value, npmrc_path, rctx)
+        lines.append(line)
+    return "\n".join(lines) + "\n"
 
 ################################################################################
 def _get_npm_auth(npmrc, npmrc_path, rctx):
@@ -284,8 +321,9 @@ def _get_npm_auth(npmrc, npmrc_path, rctx):
         if registry not in auth:
             auth[registry] = {}
 
-        # A helper wins over a static token, and must not shadow its own memoized result
+        # A helper wins over a static credential
         auth[registry].pop("bearer", None)
+        auth[registry].pop("basic", None)
         auth[registry]["token_helper"] = struct(command = helper, npmrc_path = npmrc_path)
 
     return (registries, auth)
@@ -327,9 +365,10 @@ def _select_npm_auth(url, npm_auth, rctx = None):
         return None, None, None, None
 
     # Memoized into the auth entry so a helper runs once per registry, not once per package
-    helper = matched.get("token_helper")
-    if helper and "bearer" not in matched:
-        matched["bearer"] = _run_token_helper(helper.command, helper.npmrc_path, rctx)
+    helper = matched.pop("token_helper", None)
+    if helper:
+        kind, credential = _run_token_helper(helper.command, helper.npmrc_path, rctx)
+        matched[kind] = credential
 
     return (
         matched.get("bearer"),
@@ -772,6 +811,7 @@ helpers = struct(
     get_npm_auth = _get_npm_auth,
     get_npm_imports = _get_npm_imports,
     link_package = _link_package,
+    resolve_npmrc_credentials = _resolve_npmrc_credentials,
     to_apparent_repo_name = _to_apparent_repo_name,
     verify_node_modules_ignored = _verify_node_modules_ignored,
     verify_lifecycle_hooks_specified = _verify_lifecycle_hooks_specified,

--- a/npm/private/test/npm_auth_test.bzl
+++ b/npm/private/test/npm_auth_test.bzl
@@ -331,6 +331,109 @@ def _token_helper_precedence_test_impl(ctx):
 
     return unittest.end(env)
 
+def _token_helper_header_prefix_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # pnpm helpers print the Authorization header value rather than a bare token
+    asserts.equals(
+        env,
+        "HELPER_TOKEN",
+        _bearer_for(
+            {"//registry1/:tokenHelper": "/abs/token-helper"},
+            "https://registry1/pkg/-/pkg-1.0.0.tgz",
+            _fake_auth_rctx(stdout = "Bearer HELPER_TOKEN\n"),
+        ),
+    )
+
+    executed = []
+    rctx = _fake_auth_rctx(stdout = "Basic dXNlcjpwYXNz\n", executed = executed)
+    (_, auth) = helpers.get_npm_auth(
+        {
+            "//registry1/:_authToken": "STATIC",
+            "//registry1/:tokenHelper": "/abs/token-helper",
+        },
+        "/work/.npmrc",
+        rctx,
+    )
+    for _ in range(2):
+        asserts.equals(
+            env,
+            (None, "dXNlcjpwYXNz", None, None),
+            helpers_testonly.select_npm_auth("https://registry1/pkg/-/pkg-1.0.0.tgz", auth, rctx),
+        )
+    asserts.equals(env, 1, len(executed))
+
+    return unittest.end(env)
+
+_NPMRC_FOR_PNPM = """# pnpm settings
+hoist=false
+; //registry1/:tokenHelper=ignored-in-a-comment
+@myorg:registry=https://registry1/
+//registry1/:tokenHelper=token-helper.sh
+_authToken=${NPM_TOKEN}
+//registry2/:_auth=$BASIC
+//registry3/:_authToken=STATIC
+//registry3/:username=someone
+"""
+
+def _resolve_npmrc_credentials_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    executed = []
+    rctx = _fake_auth_rctx(
+        env = {"NPM_TOKEN": "SECRET", "BASIC": "dXNlcjpwYXNz"},
+        executed = executed,
+    )
+
+    asserts.equals(
+        env,
+        """# pnpm settings
+hoist=false
+; //registry1/:tokenHelper=ignored-in-a-comment
+@myorg:registry=https://registry1/
+//registry1/:_authToken=HELPER_TOKEN
+_authToken=SECRET
+//registry2/:_auth=dXNlcjpwYXNz
+//registry3/:_authToken=STATIC
+//registry3/:username=someone
+""",
+        helpers.resolve_npmrc_credentials(_NPMRC_FOR_PNPM, "/work/nested/.npmrc", rctx),
+    )
+
+    # A relative helper resolves against the directory of the declaring `.npmrc`
+    asserts.equals(env, [["/work/nested/token-helper.sh"]], executed)
+
+    return unittest.end(env)
+
+def _resolve_npmrc_credentials_basic_helper_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "//registry1/:_auth=dXNlcjpwYXNz\n",
+        helpers.resolve_npmrc_credentials(
+            "//registry1/:tokenHelper=/abs/token-helper\n",
+            "/work/.npmrc",
+            _fake_auth_rctx(stdout = "Basic dXNlcjpwYXNz\n"),
+        ),
+    )
+
+    return unittest.end(env)
+
+def _resolve_npmrc_credentials_unchanged_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    executed = []
+    static = "hoist=false\n//registry1/:_authToken=STATIC\n"
+    asserts.equals(
+        env,
+        static,
+        helpers.resolve_npmrc_credentials(static, "/work/.npmrc", _fake_auth_rctx(executed = executed)),
+    )
+    asserts.equals(env, [], executed)
+
+    return unittest.end(env)
+
 def _env_var_token_test_impl(ctx):
     env = unittest.begin(ctx)
 
@@ -634,6 +737,10 @@ token_helper_memoized_test = unittest.make(_token_helper_memoized_test_impl)
 token_helper_precedence_test = unittest.make(_token_helper_precedence_test_impl)
 select_npm_auth_longest_prefix_test = unittest.make(_select_npm_auth_longest_prefix_test_impl)
 select_npm_auth_boundary_test = unittest.make(_select_npm_auth_boundary_test_impl)
+token_helper_header_prefix_test = unittest.make(_token_helper_header_prefix_test_impl)
+resolve_npmrc_credentials_test = unittest.make(_resolve_npmrc_credentials_test_impl)
+resolve_npmrc_credentials_basic_helper_test = unittest.make(_resolve_npmrc_credentials_basic_helper_test_impl)
+resolve_npmrc_credentials_unchanged_test = unittest.make(_resolve_npmrc_credentials_unchanged_test_impl)
 
 def npm_auth_test_suite():
     unittest.suite(
@@ -655,6 +762,10 @@ def npm_auth_test_suite():
         partial.make(token_helper_precedence_test, timeout = "short"),
         partial.make(select_npm_auth_longest_prefix_test, timeout = "short"),
         partial.make(select_npm_auth_boundary_test, timeout = "short"),
+        partial.make(token_helper_header_prefix_test, timeout = "short"),
+        partial.make(resolve_npmrc_credentials_test, timeout = "short"),
+        partial.make(resolve_npmrc_credentials_basic_helper_test, timeout = "short"),
+        partial.make(resolve_npmrc_credentials_unchanged_test, timeout = "short"),
     )
 
 # A failing tokenHelper aborts analysis, which unittest.make cannot observe, so these drive the


### PR DESCRIPTION
Rewrite the external repository copy of the .npmrc handed to pnpm: tokenHelper entries become _authToken (or _auth for a Basic header) with the helper output, and `$VAR` credentials become their resolved values. The source file is untouched.

Fix #3004

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
