### PR TITLE
refactor: avoid assuming that js_binary is always a bash script

### DIFF
--- a/e2e/js_image_oci/src/BUILD.bazel
+++ b/e2e/js_image_oci/src/BUILD.bazel
@@ -65,13 +65,12 @@ oci_image(
     # Since js_binary depends on bash we have to bring in a base image that has bash
     base = "@debian",
     # This is `/[js_image_layer 'root']/[package name of js_image_layer 'binary' target]/[name of js_image_layer 'binary' target]`
-    cmd = ["/app/src/bin"],
-    entrypoint = ["/usr/bin/bash"],
+    entrypoint = ["/app/src/bin"],
     tars = [
         ":layers",
     ],
     visibility = ["//visibility:public"],
-    # This is `cmd` + `.runfiles/[workspace name]`
+    # This is `entrypoint` + `.runfiles/[workspace name]`
     workdir = "/app/src/bin.runfiles/_main",
 )
 

--- a/e2e/js_image_oci/src/BUILD.bazel
+++ b/e2e/js_image_oci/src/BUILD.bazel
@@ -64,7 +64,6 @@ oci_image(
     name = "image",
     # Since js_binary depends on bash we have to bring in a base image that has bash
     base = "@debian",
-    cmd = [],
     # This is `/[js_image_layer 'root']/[package name of js_image_layer 'binary' target]/[name of js_image_layer 'binary' target]`
     entrypoint = ["/app/src/bin"],
     tars = [

--- a/e2e/js_image_oci/src/BUILD.bazel
+++ b/e2e/js_image_oci/src/BUILD.bazel
@@ -64,6 +64,7 @@ oci_image(
     name = "image",
     # Since js_binary depends on bash we have to bring in a base image that has bash
     base = "@debian",
+    cmd = [],
     # This is `/[js_image_layer 'root']/[package name of js_image_layer 'binary' target]/[name of js_image_layer 'binary' target]`
     entrypoint = ["/app/src/bin"],
     tars = [

--- a/e2e/js_image_oci/src/test.yaml
+++ b/e2e/js_image_oci/src/test.yaml
@@ -2,8 +2,7 @@ schemaVersion: 2.0.0
 
 commandTests:
     - name: 'smoke'
-      command: '/usr/bin/bash'
-      args: ['/app/src/bin']
+      command: '/app/src/bin'
       expectedOutput:
           [
               'OS',
@@ -23,8 +22,7 @@ commandTests:
               ' REPO NPM CHECK    true',
           ]
     - name: 'smoke2'
-      command: '/usr/bin/bash'
-      args: ['/app/src/bin']
+      command: '/app/src/bin'
       expectedOutput:
           [
               'OS',

--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -29,12 +29,12 @@ _DOC = """Create container image layers from js_binary targets.
 By design, js_image_layer doesn't have any preference over which rule assembles the container image.
 This means the downstream rule (`oci_image` from [rules_oci](https://github.com/bazel-contrib/rules_oci)
 or `container_image` from [rules_docker](https://github.com/bazelbuild/rules_docker)) must
-set a proper `workdir` and `cmd` to for the container work.
+set a proper `workdir` and `entrypoint` to for the container work.
 
-A proper `cmd` usually looks like /`[ js_image_layer 'root' ]`/`[ package name of js_image_layer 'binary' target ]/[ name of js_image_layer 'binary' target ]`,
+A proper `entrypoint` usually looks like /`[ js_image_layer 'root' ]`/`[ package name of js_image_layer 'binary' target ]/[ name of js_image_layer 'binary' target ]`,
 unless you have a custom launcher script that invokes the entry_point of the `js_binary` in a different path.
 
-On the other hand, `workdir` has to be set to the "runfiles tree root" which would be exactly `cmd` **but with `.runfiles/[ name of the workspace ]` suffix**.
+On the other hand, `workdir` has to be set to the "runfiles tree root" which would be exactly `entrypoint` **but with `.runfiles/[ name of the workspace ]` suffix**.
 When using bzlmod then name of the local workspace is always `_main`. If `workdir` is not set correctly, some attributes such as `chdir` might not work properly.
 
 js_image_layer creates up to 5 layers depending on what files are included in the runfiles of the provided
@@ -102,8 +102,7 @@ js_image_layer(
 
 oci_image(
     name = "image",
-    cmd = ["/app/bin"],
-    entrypoint = ["bash"],
+    entrypoint = ["/app/bin"],
     tars = [
         ":layers"
     ],
@@ -140,8 +139,7 @@ js_binary(
 
     oci_image(
         name = "{}_image".format(arch),
-        cmd = ["/app/bin"],
-        entrypoint = ["bash"],
+        entrypoint = ["/app/bin"],
         tars = [
             ":{}_layers".format(arch)
         ],

--- a/js/private/js_image_layer.bzl
+++ b/js/private/js_image_layer.bzl
@@ -29,7 +29,7 @@ _DOC = """Create container image layers from js_binary targets.
 By design, js_image_layer doesn't have any preference over which rule assembles the container image.
 This means the downstream rule (`oci_image` from [rules_oci](https://github.com/bazel-contrib/rules_oci)
 or `container_image` from [rules_docker](https://github.com/bazelbuild/rules_docker)) must
-set a proper `workdir` and `entrypoint` to for the container work.
+set a proper `workdir` and `entrypoint` for the container to work.
 
 A proper `entrypoint` usually looks like /`[ js_image_layer 'root' ]`/`[ package name of js_image_layer 'binary' target ]/[ name of js_image_layer 'binary' target ]`,
 unless you have a custom launcher script that invokes the entry_point of the `js_binary` in a different path.


### PR DESCRIPTION
Today js_binary always has a bash launcher, but that will probably not be true in the near future. This change fixes a couple places that assume that a js_binary executable can be run with bash.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases