### PR TITLE
test: add tests of quoting in js_binary entry points and fixed_args

### DIFF
--- a/js/private/test/entry_point_quoting/BUILD.bazel
+++ b/js/private/test/entry_point_quoting/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@bazel_lib//lib:testing.bzl", "assert_contains")
+load("//js:defs.bzl", "js_binary", "js_run_binary")
+
+package(default_testonly = True)
+
+js_binary(
+    name = "quoted_bin",
+    entry_point = "it's ok.mjs",
+)
+
+js_run_binary(
+    name = "run_quoted",
+    silent_on_success = False,
+    stdout = "quoted_out",
+    tool = ":quoted_bin",
+)
+
+assert_contains(
+    name = "quoted_test",
+    actual = "quoted_out",
+    expected = "entry point with an apostrophe ran",
+)

--- a/js/private/test/entry_point_quoting/it's ok.mjs
+++ b/js/private/test/entry_point_quoting/it's ok.mjs
@@ -1,0 +1,1 @@
+console.log('entry point with an apostrophe ran')

--- a/js/private/test/fixed_args/BUILD.bazel
+++ b/js/private/test/fixed_args/BUILD.bazel
@@ -89,3 +89,50 @@ assert_contains(
     actual = "locations_out_no_expand",
     expected = "$(rootpaths :test.txt)",
 )
+
+# Quote removal happens at analysis time, but the presence of single quotes should still
+# prevent $VAR expansion from happening at run time.
+js_binary(
+    name = "single_quoted_var_bin",
+    entry_point = "fixed_args.mjs",
+    expand_args = False,
+    fixed_args = [
+        "'$JS_BINARY__WORKSPACE/x'",
+    ],
+)
+
+js_run_binary(
+    name = "run_single_quoted_var",
+    silent_on_success = False,
+    stdout = "single_quoted_var_out",
+    tool = ":single_quoted_var_bin",
+)
+
+assert_contains(
+    name = "single_quoted_var_test",
+    actual = "single_quoted_var_out",
+    expected = "$JS_BINARY__WORKSPACE/x",
+)
+
+# Without single quotes, the $VAR expansion does happen.
+js_binary(
+    name = "unquoted_var_bin",
+    entry_point = "fixed_args.mjs",
+    expand_args = False,
+    fixed_args = [
+        "$JS_BINARY__WORKSPACE/x",
+    ],
+)
+
+js_run_binary(
+    name = "run_unquoted_var",
+    silent_on_success = False,
+    stdout = "unquoted_var_out",
+    tool = ":unquoted_var_bin",
+)
+
+assert_contains(
+    name = "unquoted_var_test",
+    actual = "unquoted_var_out",
+    expected = "_main/x",
+)

--- a/js/private/test/fixed_args/BUILD.bazel
+++ b/js/private/test/fixed_args/BUILD.bazel
@@ -90,8 +90,7 @@ assert_contains(
     expected = "$(rootpaths :test.txt)",
 )
 
-# Quote removal happens at analysis time, but the presence of single quotes should still
-# prevent $VAR expansion from happening at run time.
+# The presence of single quotes should prevent $VAR expansion from happening at run time.
 js_binary(
     name = "single_quoted_var_bin",
     entry_point = "fixed_args.mjs",


### PR DESCRIPTION
Both values reach node through the launcher, so how the launcher quotes them is observable behavior, and neither of these cases was covered:

- an entry point whose path contains an apostrophe;
- a $VAR in a single-quoted fixed_arg, which must not be expanded at run time, and the same $VAR unquoted, which must be.

Nothing is broken today. These record the behavior so that a change to how the launcher spells either value cannot break it silently.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
